### PR TITLE
Responsive board

### DIFF
--- a/packages/vue-client/src/assets/main.css
+++ b/packages/vue-client/src/assets/main.css
@@ -8,6 +8,12 @@
   font-weight: normal;
 }
 
+@media (max-width: 540px) {
+  #app {
+    padding: 0.2rem;
+  }
+}
+
 a,
 .green {
   text-decoration: none;

--- a/packages/vue-client/src/components/boards/BadukBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukBoard.vue
@@ -44,8 +44,8 @@ function positionClicked(pos: Coordinate) {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    width="600px"
-    height="600px"
+    width="100%"
+    height="100%"
     v-bind:viewBox="`-1 -1 ${width + 1} ${height + 1}`"
   >
     <rect

--- a/packages/vue-client/src/components/boards/BadukBoardAbstract.vue
+++ b/packages/vue-client/src/components/boards/BadukBoardAbstract.vue
@@ -44,8 +44,8 @@ const viewBox = computed(() => {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    width="600px"
-    height="600px"
+    width="100%"
+    height="100%"
     v-bind:viewBox="viewBox"
   >
     <g

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -45,8 +45,8 @@ function positionHovered(pos: Coordinate) {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    width="600px"
-    height="600px"
+    width="100%"
+    height="100%"
     v-bind:viewBox="`-1 -1 ${width + 1} ${height + 1}`"
   >
     <rect x="-0.5" y="-0.5" :width="width" :height="height" fill="#dcb35c" />

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -167,4 +167,10 @@ watchEffect((onCleanup) => {
 pre {
   text-align: left;
 }
+
+@media (min-width: 664px) {
+  .board {
+    width: 600px;
+  }
+}
 </style>


### PR DESCRIPTION
Fixes #51 

This new CSS should keep the desktop layout more or less the same, but on mobile, the boards will now fit on screen.

## Screenshots

### Before
<img alt="Screen Shot grid board old" src="https://github.com/govariantsteam/govariants/assets/25233703/7ee33472-4431-4d4d-bb97-9db22d5a2560" width=300px />
<img alt="Screen Shot graph board old" src="https://github.com/govariantsteam/govariants/assets/25233703/f3c413b9-c47b-418c-b49e-9e90447b2a00" width=300px/>


### After

<img alt="Screen Shot grid board new" src="https://github.com/govariantsteam/govariants/assets/25233703/a45096f2-4c2e-4da4-aad1-36c8d6a8b019" width=300px/>
<img alt="Screen Shot graph board new" src="https://github.com/govariantsteam/govariants/assets/25233703/356487fe-ca64-4700-8ad5-2c9c05e0694a" width=300px/>

