### PR TITLE
Remove the game response JSON from the UI

### DIFF
--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -153,10 +153,6 @@ watchEffect((onCleanup) => {
     >
       {{ value }}
     </button>
-    <pre>
-      <span>from /games/{{gameResponse.id}}</span>
-      {{JSON.stringify(gameResponse, null, 2)}}
-    </pre>
   </div>
   <div v-if="game.result" style="font-weight: bold; font-size: 24pt">
     Result: {{ game.result }}


### PR DESCRIPTION
If devs are interested in the JSON, it's available in the network tab.  Much cleaner to hide it from the users.

Before/After:

<img alt="before with json" src="https://github.com/govariantsteam/govariants/assets/25233703/dfa69274-e726-4a4e-a30d-252265939ec6" width=200/>

<img alt="after without json" src="https://github.com/govariantsteam/govariants/assets/25233703/9ff08f22-88f4-42a8-9de0-d47017e87b0a" width=200/>
