### PR TITLE
Add visual representation of the game to the game list.

### DIFF
--- a/packages/vue-client/src/components/GameList.vue
+++ b/packages/vue-client/src/components/GameList.vue
@@ -2,6 +2,8 @@
 import { ref, computed } from "vue";
 import { useFetch } from "@vueuse/core";
 import type { GameResponse } from "@ogfcommunity/variants-shared";
+import GameListItem from "@/components/GameListItem.vue";
+
 const countOptions = [10, 15, 25, 50];
 const count = ref(countOptions[0]);
 const offset = ref(0);
@@ -24,11 +26,9 @@ const next = () => {
 
 <template>
   <ul>
-    <li v-for="game in games" :key="game.id">
-      <RouterLink v-bind:to="{ name: 'game', params: { gameId: game.id } }">
-        {{ game.id }}
-      </RouterLink>
-    </li>
+    <template v-for="game in games" :key="game.id">
+      <GameListItem :game="game" />
+    </template>
   </ul>
   <button @click="first()" :disabled="offset === 0">First</button>
   <button @click="previous()" :disabled="offset === 0">Previous</button>
@@ -42,3 +42,9 @@ const next = () => {
     </select>
   </label>
 </template>
+
+<style scoped>
+ul {
+  padding: 0;
+}
+</style>

--- a/packages/vue-client/src/components/GameListItem.vue
+++ b/packages/vue-client/src/components/GameListItem.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import {
+  makeGameObject,
+  type GameResponse,
+} from "@ogfcommunity/variants-shared";
+import { computed } from "vue";
+import { board_map } from "@/board_map";
+
+const props = defineProps<{ game: GameResponse }>();
+
+const game = computed(() => {
+  const game_obj = makeGameObject(props.game.variant, props.game.config);
+  props.game.moves.forEach((move) => {
+    game_obj.playMove(move);
+  });
+  const state = game_obj.exportState();
+  return {
+    state,
+  };
+});
+
+const variantGameView = computed(() => board_map[props.game.variant]);
+</script>
+
+<template>
+  <li class="game-list-item">
+    <RouterLink v-bind:to="{ name: 'game', params: { gameId: props.game.id } }">
+      <component
+        v-if="variantGameView"
+        v-bind:is="variantGameView"
+        v-bind:gamestate="game.state"
+        v-bind:config="props.game.config"
+      />
+      <div class="variant-text">{{ props.game.variant }}</div>
+    </RouterLink>
+  </li>
+</template>
+
+<style scoped>
+li.game-list-item {
+  padding: 10px;
+  width: 50%;
+  list-style-type: none;
+  display: inline-block;
+}
+
+.variant-text {
+  font-variant: small-caps;
+  color: gray;
+  text-align: right;
+  padding: 0;
+  margin-top: -15px;
+}
+
+.board {
+  width: 100%;
+  padding: 0;
+}
+</style>


### PR DESCRIPTION
Fixes #52 

We could probably get more information in here (players, config etc.) but a board representation is an improvement to the current list of Mongo IDs.

<img width="898" alt="Screenshot 2023-06-03 at 4 12 38 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/8e45f223-3872-4f5f-9b87-c756487585d0">
