### PR TITLE
Vscode launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Server",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/packages/server",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": ["workspace", "@ogfcommunity/variants-server", "run", "start"],
+            "outputCapture": "std",
+        },
+        {
+            "name": "Client",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/packages/vue-client",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": ["workspace", "@ogfcommunity/variants-vue-client", "run", "dev"],
+        },
+    ],
+    "compounds": [
+        {
+            "name": "Server+Client",
+            "configurations": ["Server", "Client"],
+            "stopAll": true,
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:check": "yarn workspaces foreach -pti run lint:check",
     "lint": "yarn workspaces foreach -pti run lint",
     "start:server": "yarn workspace @ogfcommunity/variants-server run start",
-    "start:client": "yarn workspace @ogfcommunity/variants-client run start",
+    "start:client": "yarn workspace @ogfcommunity/variants-vue-client run start",
     "start:shared": "yarn workspace @ogfcommunity/variants-shared run start"
   },
   "workspaces": {


### PR DESCRIPTION
The `launch.json` file allows to run client *and* server inside VSCode per mouse click (as long as VSCode can find `yarn`, which it does for me only when I run VS Code via a bash terminal, because of how nvm/yarn is setup on my computer).

I've also updated the `start:client` command, to start the `vue-client` package, instead of the react `client` package, which was removed a while ago.