### PR TITLE
Chess

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint --fix ./src"
   },
   "dependencies": {
+    "chess.js": "^1.0.0-beta.6",
     "typescript": "^4.7.4"
   }
 }

--- a/packages/shared/src/chess/chess.test.ts
+++ b/packages/shared/src/chess/chess.test.ts
@@ -1,48 +1,34 @@
-import { Chess } from "./chess";
+import { ChessGame } from "./chess";
 
 // A 3-letter placeholder helps with board alignment
 const ___ = null;
 
 test("Knight can move", () => {
-  const game = new Chess({});
+  const game = new ChessGame();
 
   game.playMove({ 0: "e4" });
   game.playMove({ 1: "e5" });
   game.playMove({ 0: "Nf3" });
 
-  expect(game.exportState().board).toEqual([
-    ["r", "n", "b", "q", "k", "b", "n", "r"],
-    ["p", "p", "p", "p", ___, "p", "p", "p"],
-    [___, ___, ___, ___, ___, ___, ___, ___],
-    [___, ___, ___, ___, "p", ___, ___, ___],
-    [___, ___, ___, ___, "P", ___, ___, ___],
-    [___, ___, ___, ___, ___, "N", ___, ___],
-    ["P", "P", "P", "P", ___, "P", "P", "P"],
-    ["R", "N", "B", "Q", "K", "B", ___, "R"],
-  ]);
+  expect(game.exportState().fen).toBe(
+    "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2"
+  );
 });
 
 test("Bishop can move", () => {
-  const game = new Chess({});
+  const game = new ChessGame();
 
   game.playMove({ 0: "e4" });
   game.playMove({ 1: "e5" });
   game.playMove({ 0: "Bc4" });
 
-  expect(game.exportState().board).toEqual([
-    ["r", "n", "b", "q", "k", "b", "n", "r"],
-    ["p", "p", "p", "p", ___, "p", "p", "p"],
-    [___, ___, ___, ___, ___, ___, ___, ___],
-    [___, ___, ___, ___, "p", ___, ___, ___],
-    [___, ___, "B", ___, "P", ___, ___, ___],
-    [___, ___, ___, ___, ___, ___, ___, ___],
-    ["P", "P", "P", "P", ___, "P", "P", "P"],
-    ["R", "N", "B", "Q", "K", ___, "N", "R"],
-  ]);
+  expect(game.exportState().fen).toEqual(
+    "rnbqkbnr/pppp1ppp/8/4p3/2B1P3/8/PPPP1PPP/RNBQK1NR b KQkq - 1 2"
+  );
 });
 
 test("King's side castle", () => {
-  const game = new Chess({});
+  const game = new ChessGame();
 
   game.playMove({ 0: "e4" });
   game.playMove({ 1: "e5" });
@@ -50,46 +36,30 @@ test("King's side castle", () => {
   game.playMove({ 1: "Nc6" });
   game.playMove({ 0: "Bc4" });
   game.playMove({ 1: "d6" });
-  game.playMove({ 0: "0-0" });
+  game.playMove({ 0: "O-O" });
 
-  expect(game.exportState().castling_rights).toBe("K");
-
-  // Capture the d5 pawn by en passant
-  game.playMove({ 0: "exd6" });
-
-  expect(game.exportState().board).toEqual([
-    ["r", "n", "b", "q", "k", "b", "n", "r"],
-    ["p", "p", "p", "p", ___, "p", "p", "p"],
-    [___, ___, ___, ___, ___, ___, ___, ___],
-    [___, ___, ___, ___, "p", ___, ___, ___],
-    [___, ___, "B", ___, "P", ___, ___, ___],
-    [___, ___, ___, ___, ___, "N", ___, ___],
-    ["P", "P", "P", "P", ___, "P", "P", "P"],
-    ["R", "N", "B", "Q", ___, "R", "K", ___],
-  ]);
+  expect(game.exportState().fen).toEqual(
+    "r1bqkbnr/ppp2ppp/2np4/4p3/2B1P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 1 4"
+  );
 });
 
 test("En Passant", () => {
-  const game = new Chess({});
+  const game = new ChessGame();
 
   game.playMove({ 0: "e4" });
   game.playMove({ 1: "e6" });
   game.playMove({ 0: "e5" });
   game.playMove({ 1: "d5" });
 
-  expect(game.exportState().en_passant_target).toBe("d6");
+  // en passant target is set to d6
+  expect(game.exportState().fen).toBe(
+    "rnbqkbnr/ppp2ppp/4p3/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 3"
+  );
 
   // Capture the d5 pawn by en passant
   game.playMove({ 0: "exd6" });
 
-  expect(game.exportState().board).toEqual([
-    ["r", "n", "b", "q", "k", "b", "n", "r"],
-    ["p", "p", "p", ___, ___, "p", "p", "p"],
-    [___, ___, ___, "P", "p", ___, ___, ___],
-    [___, ___, ___, ___, ___, ___, ___, ___],
-    [___, ___, ___, ___, ___, ___, ___, ___],
-    [___, ___, ___, ___, ___, ___, ___, ___],
-    ["P", "P", "P", "P", ___, "P", "P", "P"],
-    ["R", "N", "B", "Q", "K", "B", "N", "R"],
-  ]);
+  expect(game.exportState().fen).toEqual(
+    "rnbqkbnr/ppp2ppp/3Pp3/8/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 3"
+  );
 });

--- a/packages/shared/src/chess/chess.test.ts
+++ b/packages/shared/src/chess/chess.test.ts
@@ -1,0 +1,95 @@
+import { Chess } from "./chess";
+
+// A 3-letter placeholder helps with board alignment
+const ___ = null;
+
+test("Knight can move", () => {
+  const game = new Chess({});
+
+  game.playMove({ 0: "e4" });
+  game.playMove({ 1: "e5" });
+  game.playMove({ 0: "Nf3" });
+
+  expect(game.exportState().board).toEqual([
+    ["r", "n", "b", "q", "k", "b", "n", "r"],
+    ["p", "p", "p", "p", ___, "p", "p", "p"],
+    [___, ___, ___, ___, ___, ___, ___, ___],
+    [___, ___, ___, ___, "p", ___, ___, ___],
+    [___, ___, ___, ___, "P", ___, ___, ___],
+    [___, ___, ___, ___, ___, "N", ___, ___],
+    ["P", "P", "P", "P", ___, "P", "P", "P"],
+    ["R", "N", "B", "Q", "K", "B", ___, "R"],
+  ]);
+});
+
+test("Bishop can move", () => {
+  const game = new Chess({});
+
+  game.playMove({ 0: "e4" });
+  game.playMove({ 1: "e5" });
+  game.playMove({ 0: "Bc4" });
+
+  expect(game.exportState().board).toEqual([
+    ["r", "n", "b", "q", "k", "b", "n", "r"],
+    ["p", "p", "p", "p", ___, "p", "p", "p"],
+    [___, ___, ___, ___, ___, ___, ___, ___],
+    [___, ___, ___, ___, "p", ___, ___, ___],
+    [___, ___, "B", ___, "P", ___, ___, ___],
+    [___, ___, ___, ___, ___, ___, ___, ___],
+    ["P", "P", "P", "P", ___, "P", "P", "P"],
+    ["R", "N", "B", "Q", "K", ___, "N", "R"],
+  ]);
+});
+
+test("King's side castle", () => {
+  const game = new Chess({});
+
+  game.playMove({ 0: "e4" });
+  game.playMove({ 1: "e5" });
+  game.playMove({ 0: "Nf3" });
+  game.playMove({ 1: "Nc6" });
+  game.playMove({ 0: "Bc4" });
+  game.playMove({ 1: "d6" });
+  game.playMove({ 0: "0-0" });
+
+  expect(game.exportState().castling_rights).toBe("K");
+
+  // Capture the d5 pawn by en passant
+  game.playMove({ 0: "exd6" });
+
+  expect(game.exportState().board).toEqual([
+    ["r", "n", "b", "q", "k", "b", "n", "r"],
+    ["p", "p", "p", "p", ___, "p", "p", "p"],
+    [___, ___, ___, ___, ___, ___, ___, ___],
+    [___, ___, ___, ___, "p", ___, ___, ___],
+    [___, ___, "B", ___, "P", ___, ___, ___],
+    [___, ___, ___, ___, ___, "N", ___, ___],
+    ["P", "P", "P", "P", ___, "P", "P", "P"],
+    ["R", "N", "B", "Q", ___, "R", "K", ___],
+  ]);
+});
+
+test("En Passant", () => {
+  const game = new Chess({});
+
+  game.playMove({ 0: "e4" });
+  game.playMove({ 1: "e6" });
+  game.playMove({ 0: "e5" });
+  game.playMove({ 1: "d5" });
+
+  expect(game.exportState().en_passant_target).toBe("d6");
+
+  // Capture the d5 pawn by en passant
+  game.playMove({ 0: "exd6" });
+
+  expect(game.exportState().board).toEqual([
+    ["r", "n", "b", "q", "k", "b", "n", "r"],
+    ["p", "p", "p", ___, ___, "p", "p", "p"],
+    [___, ___, ___, "P", "p", ___, ___, ___],
+    [___, ___, ___, ___, ___, ___, ___, ___],
+    [___, ___, ___, ___, ___, ___, ___, ___],
+    [___, ___, ___, ___, ___, ___, ___, ___],
+    ["P", "P", "P", "P", ___, "P", "P", "P"],
+    ["R", "N", "B", "Q", "K", "B", "N", "R"],
+  ]);
+});

--- a/packages/shared/src/chess/chess.ts
+++ b/packages/shared/src/chess/chess.ts
@@ -1,53 +1,48 @@
 import { AbstractGame, MovesType } from "../abstract_game";
-import { Grid } from "../grid";
+import { Chess } from "chess.js";
 
-type WhitePiece = "p" | "r" | "n" | "b" | "q" | "k";
-type BlackPiece = Uppercase<WhitePiece>;
-type Piece = WhitePiece | BlackPiece;
-type Rank = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
-type File = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h";
-type Square = `${File}${Rank}`;
-
-// Not exactly FEN, but concepts and notations borrowed
 export interface ChessState {
-  board: Array<Array<Piece | null>>;
-  en_passant_target: Square | null;
-  castling_rights: { K: boolean; Q: boolean; k: boolean; q: boolean };
+  fen: string;
 }
 
-const EMPTY_ROW = [null, null, null, null, null, null, null, null];
-const STARTING_BOARD: Array<Array<Piece | null>> = [
-  ["r", "n", "b", "q", "k", "b", "n", "r"],
-  ["p", "p", "p", "p", "p", "p", "p", "p"],
-  EMPTY_ROW,
-  EMPTY_ROW,
-  EMPTY_ROW,
-  EMPTY_ROW,
-  ["P", "P", "P", "P", "P", "P", "P", "P"],
-  ["R", "N", "B", "Q", "K", "B", "N", "R"],
-];
+export class ChessGame extends AbstractGame<object, ChessState> {
+  // third-party chess object
+  private chess = new Chess();
 
-export class Chess extends AbstractGame<object, ChessState> {
-  private board = Grid.from2DArray(STARTING_BOARD);
-  private active_color: 0 | 1 = 0;
-  private en_passant_target: Square | null = null;
-  private castling_rights = { K: true, Q: true, k: true, q: true };
-  private halfmove_clock = 0;
-
-  playMove(move: MovesType): void {
-    throw new Error("Method not implemented.");
+  playMove(moves: MovesType): void {
+    const { move, player } = getOnlyMove(moves);
+    if (player === 1 && "b" != this.chess.turn()) {
+      throw Error("Not Black's turn");
+    }
+    if (player === 0 && "w" != this.chess.turn()) {
+      throw Error("Not White's turn");
+    }
+    this.chess.move(move);
   }
 
   exportState(): ChessState {
-    throw new Error("Method not implemented.");
+    return { fen: this.chess.fen() };
   }
   nextToPlay(): number[] {
-    throw new Error("Method not implemented.");
+    return [this.chess.turn() == "b" ? 1 : 0];
   }
   numPlayers(): number {
-    throw new Error("Method not implemented.");
+    return 2;
   }
   defaultConfig(): object {
-    throw new Error("Method not implemented.");
+    return {};
   }
+}
+
+// TODO: dedupe
+function getOnlyMove(moves: MovesType): { player: number; move: string } {
+  const players = Object.keys(moves);
+  if (players.length > 1) {
+    throw Error(`More than one player: ${players}`);
+  }
+  if (players.length === 0) {
+    throw Error("No players specified!");
+  }
+  const player = Number(players[0]);
+  return { player, move: moves[player] };
 }

--- a/packages/shared/src/chess/chess.ts
+++ b/packages/shared/src/chess/chess.ts
@@ -1,0 +1,53 @@
+import { AbstractGame, MovesType } from "../abstract_game";
+import { Grid } from "../grid";
+
+type WhitePiece = "p" | "r" | "n" | "b" | "q" | "k";
+type BlackPiece = Uppercase<WhitePiece>;
+type Piece = WhitePiece | BlackPiece;
+type Rank = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+type File = "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h";
+type Square = `${File}${Rank}`;
+
+// Not exactly FEN, but concepts and notations borrowed
+export interface ChessState {
+  board: Array<Array<Piece | null>>;
+  en_passant_target: Square | null;
+  castling_rights: { K: boolean; Q: boolean; k: boolean; q: boolean };
+}
+
+const EMPTY_ROW = [null, null, null, null, null, null, null, null];
+const STARTING_BOARD: Array<Array<Piece | null>> = [
+  ["r", "n", "b", "q", "k", "b", "n", "r"],
+  ["p", "p", "p", "p", "p", "p", "p", "p"],
+  EMPTY_ROW,
+  EMPTY_ROW,
+  EMPTY_ROW,
+  EMPTY_ROW,
+  ["P", "P", "P", "P", "P", "P", "P", "P"],
+  ["R", "N", "B", "Q", "K", "B", "N", "R"],
+];
+
+export class Chess extends AbstractGame<object, ChessState> {
+  private board = Grid.from2DArray(STARTING_BOARD);
+  private active_color: 0 | 1 = 0;
+  private en_passant_target: Square | null = null;
+  private castling_rights = { K: true, Q: true, k: true, q: true };
+  private halfmove_clock = 0;
+
+  playMove(move: MovesType): void {
+    throw new Error("Method not implemented.");
+  }
+
+  exportState(): ChessState {
+    throw new Error("Method not implemented.");
+  }
+  nextToPlay(): number[] {
+    throw new Error("Method not implemented.");
+  }
+  numPlayers(): number {
+    throw new Error("Method not implemented.");
+  }
+  defaultConfig(): object {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/shared/src/chess/index.ts
+++ b/packages/shared/src/chess/index.ts
@@ -1,0 +1,1 @@
+export { ChessGame } from "./chess";

--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -4,6 +4,7 @@ import { BadukWithAbstractBoard } from "./badukWithAbstractBoard/badukWithAbstra
 import { Phantom } from "./phantom";
 import { ParallelGo } from "./parallel";
 import { Capture } from "./capture";
+import { ChessGame } from "./chess/chess";
 
 export const game_map: {
   [variant: string]: new (config?: any) => AbstractGame;
@@ -13,6 +14,7 @@ export const game_map: {
   phantom: Phantom,
   parallel: ParallelGo,
   capture: Capture,
+  chess: ChessGame,
 };
 
 class ConfigError extends Error {

--- a/packages/vue-client/package.json
+++ b/packages/vue-client/package.json
@@ -18,10 +18,12 @@
   "dependencies": {
     "@ogfcommunity/variants-shared": "1.0.0",
     "@vueuse/core": "^9.13.0",
+    "chessground": "^8.3.10",
     "pinia": "^2.0.14",
     "socket.io-client": "^4.5.2",
-    "vue": "^3.2.37",
-    "vue-router": "^4.1.2"
+    "vue": "3.2.47",
+    "vue-router": "^4.1.2",
+    "vue3-chessboard": "^1.1.8"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.1.0",

--- a/packages/vue-client/src/board_map.ts
+++ b/packages/vue-client/src/board_map.ts
@@ -1,6 +1,7 @@
 import Baduk from "@/components/boards/BadukBoard.vue";
 import BadukBoardAbstract from "@/components/boards/BadukBoardAbstract.vue";
 import ParallelGoBoard from "@/components/boards/ParallelGoBoard.vue";
+import ChessBoard from "@/components/boards/ChessBoard.vue";
 import type { Component } from "vue";
 
 export const board_map: {
@@ -11,4 +12,5 @@ export const board_map: {
   badukWithAbstractBoard: BadukBoardAbstract,
   parallel: ParallelGoBoard,
   capture: Baduk,
+  chess: ChessBoard,
 };

--- a/packages/vue-client/src/components/boards/ChessBoard.vue
+++ b/packages/vue-client/src/components/boards/ChessBoard.vue
@@ -12,28 +12,30 @@ const emit = defineEmits<{
   (e: "move", move: string): void;
 }>();
 
-let ground = null;
+let ground: ReturnType<typeof Chessground> | null = null;
 
 function updateBoard() {
   ground?.set({ fen: props.gamestate.fen });
 }
 
-function onMove(source, target) {
+function onMove(source: string, target: string) {
   // Keep the board in its prior state until the server has verified the move
   updateBoard();
   // send the move to the server
   emit("move", `${source}-${target}`);
 }
 
-const container = ref(null);
+const container = ref<HTMLElement | null>(null);
 onMounted(() => {
+  if (!container.value) {
+    throw new Error("Failed to mount chess board container");
+  }
   ground = Chessground(container.value, {
     fen: props.gamestate.fen,
     events: {
       move: onMove,
     },
   });
-  window.ground = ground;
 });
 
 watch(props, updateBoard);

--- a/packages/vue-client/src/components/boards/ChessBoard.vue
+++ b/packages/vue-client/src/components/boards/ChessBoard.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { Chessground } from "chessground";
+import { ref, onMounted } from "vue";
+import "vue3-chessboard/style.css";
+
+const props = defineProps<{
+  gamestate: { fen: string };
+  config: unknown;
+}>();
+
+const emit = defineEmits<{
+  (e: "move", move: string): void;
+}>();
+
+function onMove(move: MoveEvent) {
+  emit("move", `${move.from}-${move.to}`);
+}
+
+const boardConfig = {
+  fen: props.gamestate.fen,
+};
+
+const container = ref(null);
+let ground = null;
+onMounted(() => {
+  ground = Chessground(container.value, {});
+});
+</script>
+
+<template>
+  <div ref="container" class="chessboard" />
+</template>
+
+<style scoped>
+.chessboard {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  height: unset;
+  position: relative;
+}
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.20.15, @babel/parser@npm:^7.21.3":
+  version: 7.22.5
+  resolution: "@babel/parser@npm:7.22.5"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 470ebba516417ce8683b36e2eddd56dcfecb32c54b9bb507e28eb76b30d1c3e618fd0cfeee1f64d8357c2254514e1a19e32885cfb4e73149f4ae875436a6d59c
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-async-generators@npm:^7.8.4":
   version: 7.8.4
   resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
@@ -1757,7 +1766,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.13":
   version: 1.4.15
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
   checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
@@ -1897,6 +1906,7 @@ __metadata:
     "@vue/test-utils": ^2.0.2
     "@vue/tsconfig": ^0.1.3
     "@vueuse/core": ^9.13.0
+    chessground: ^8.3.10
     cypress: ^10.3.0
     eslint: ^8.5.0
     eslint-plugin-cypress: ^2.12.1
@@ -1910,9 +1920,10 @@ __metadata:
     typescript: ~4.7.4
     vite: ^2.9.14
     vitest: ^0.18.0
-    vue: ^3.2.37
+    vue: 3.2.47
     vue-router: ^4.1.2
     vue-tsc: ^0.38.4
+    vue3-chessboard: ^1.1.8
   languageName: unknown
   linkType: soft
 
@@ -2591,6 +2602,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-core@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/compiler-core@npm:3.3.4"
+  dependencies:
+    "@babel/parser": ^7.21.3
+    "@vue/shared": 3.3.4
+    estree-walker: ^2.0.2
+    source-map-js: ^1.0.2
+  checksum: 5437942ea6575b316c9cd84f4f128a44939713da8b6958060e152c599e6d771d5db056c398d7574ee706ff8092e0d99ac4f14e7eef8712a8dd923d2323201b9e
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-dom@npm:3.2.47, @vue/compiler-dom@npm:^3.0.1, @vue/compiler-dom@npm:^3.2.37":
   version: 3.2.47
   resolution: "@vue/compiler-dom@npm:3.2.47"
@@ -2598,6 +2621,16 @@ __metadata:
     "@vue/compiler-core": 3.2.47
     "@vue/shared": 3.2.47
   checksum: 1eced735f865e6df0c2d7fa041f9f27996ff4c0d4baf5fad0f67e65e623215f4394c49bba337b78427c6e71f2cc2db12b19ec6b865b4c057c0a15ccedeb20752
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-dom@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/compiler-dom@npm:3.3.4"
+  dependencies:
+    "@vue/compiler-core": 3.3.4
+    "@vue/shared": 3.3.4
+  checksum: 1c2ac0c89de8eef7be1c568d57504e6245adaaec40c2c4d9717bc231ca10bf682d918a3b358d24c786eeaf8e0d7eb8a65f57d9044775a304783fde1d069a1896
   languageName: node
   linkType: hard
 
@@ -2619,6 +2652,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-sfc@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/compiler-sfc@npm:3.3.4"
+  dependencies:
+    "@babel/parser": ^7.20.15
+    "@vue/compiler-core": 3.3.4
+    "@vue/compiler-dom": 3.3.4
+    "@vue/compiler-ssr": 3.3.4
+    "@vue/reactivity-transform": 3.3.4
+    "@vue/shared": 3.3.4
+    estree-walker: ^2.0.2
+    magic-string: ^0.30.0
+    postcss: ^8.1.10
+    source-map-js: ^1.0.2
+  checksum: 0a0adfdd3e812f528e25e4b3bbf14b2296b719a8aac609eca42035295527cc253b918a552dc15218e917efef26b7ca94054dc8784a1a18c06c3d4bb4d18ab8b9
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-ssr@npm:3.2.47":
   version: 3.2.47
   resolution: "@vue/compiler-ssr@npm:3.2.47"
@@ -2626,6 +2677,16 @@ __metadata:
     "@vue/compiler-dom": 3.2.47
     "@vue/shared": 3.2.47
   checksum: 91bc6e46744d5405713c08d8e576971aa6d13a0cde84ec592d3221bf6ee228e49ce12233af8c18dc39723455b420df2951f3616ceb99758eb432485475fa7bc2
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-ssr@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/compiler-ssr@npm:3.3.4"
+  dependencies:
+    "@vue/compiler-dom": 3.3.4
+    "@vue/shared": 3.3.4
+  checksum: 5d1875d55ea864080dd90e5d81a29f93308e312faf00163db5b391b38c2fe799fd3eb58955823dc632f2f8bdd271a4534cc0020646b7f82717be1a8d30dc16e7
   languageName: node
   linkType: hard
 
@@ -2680,12 +2741,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/reactivity-transform@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/reactivity-transform@npm:3.3.4"
+  dependencies:
+    "@babel/parser": ^7.20.15
+    "@vue/compiler-core": 3.3.4
+    "@vue/shared": 3.3.4
+    estree-walker: ^2.0.2
+    magic-string: ^0.30.0
+  checksum: b425e78b2084ac7037887fbe012dcad5e5963ac9714ae15a04fda1c6766ec8c53ef231de1cfdc4d3cf46bd5d84bfec8ebdccf48da4ff5ee2f4b5084e54f0a1b1
+  languageName: node
+  linkType: hard
+
 "@vue/reactivity@npm:3.2.47, @vue/reactivity@npm:^3.2.37":
   version: 3.2.47
   resolution: "@vue/reactivity@npm:3.2.47"
   dependencies:
     "@vue/shared": 3.2.47
   checksum: bd61134e4b2f281067e78b23b34d17f1290a0b3fdb0cd7f06424570b4428c899389451a396694144b0af2fc6dbb1459c38e79151119f12c4f818f4c5004b7d16
+  languageName: node
+  linkType: hard
+
+"@vue/reactivity@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/reactivity@npm:3.3.4"
+  dependencies:
+    "@vue/shared": 3.3.4
+  checksum: 81c3d0c587d23656a57a7a31afb51357274f6512b51baffc67cda183b2361a7e65e646029c26a8bc28587f26b65bba808dcd93cdd3bacab48d2b99d11ad0ec97
   languageName: node
   linkType: hard
 
@@ -2699,6 +2782,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/runtime-core@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/runtime-core@npm:3.3.4"
+  dependencies:
+    "@vue/reactivity": 3.3.4
+    "@vue/shared": 3.3.4
+  checksum: d402da51269658cba5d857d65fbe322121160bcb1a6fcf03601d5183705e92505c6e90418f491a331ca3e27628f457a6ca7158b9add25f5b0cf5cf53664b8011
+  languageName: node
+  linkType: hard
+
 "@vue/runtime-dom@npm:3.2.47":
   version: 3.2.47
   resolution: "@vue/runtime-dom@npm:3.2.47"
@@ -2707,6 +2800,17 @@ __metadata:
     "@vue/shared": 3.2.47
     csstype: ^2.6.8
   checksum: 8987d7276174120ed346c456752cdb3633c400432ae89a1a866e342c964b7ed2f9e3e09926f2b4b81fe175b1e4fb3935fe3920c113bcc71464ff39b4e50931f5
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-dom@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/runtime-dom@npm:3.3.4"
+  dependencies:
+    "@vue/runtime-core": 3.3.4
+    "@vue/shared": 3.3.4
+    csstype: ^3.1.1
+  checksum: dac9ada7f6128bcccc031fe5c25d00db94ffb7c011fcb70bada22fa4d889ff842eeb139ab9304bcc52cb5ae9030911a52cb3510b691bb190bbe5fab680b4411a
   languageName: node
   linkType: hard
 
@@ -2722,10 +2826,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/server-renderer@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/server-renderer@npm:3.3.4"
+  dependencies:
+    "@vue/compiler-ssr": 3.3.4
+    "@vue/shared": 3.3.4
+  peerDependencies:
+    vue: 3.3.4
+  checksum: e8598ed1a44df70edaea0ad6786aea6443b9b3d9266249eec5690401859d72d45a1e29ba3eef20e37a95f020abd5e763088b79070ee848af436a4390a253a37a
+  languageName: node
+  linkType: hard
+
 "@vue/shared@npm:3.2.47, @vue/shared@npm:^3.2.37":
   version: 3.2.47
   resolution: "@vue/shared@npm:3.2.47"
   checksum: 0aa711dc9160fa0e476e6e94eea4e019398adf2211352d0e4a672cfb6b65b104bbd5d234807d1c091107bdc0f5d818d0f12378987eb7861d39be3aa9f6cd6e3e
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:3.3.4":
+  version: 3.3.4
+  resolution: "@vue/shared@npm:3.3.4"
+  checksum: 12fe53ff816bfa29ea53f89212067a86512c626b8d30149ff28b36705820f6150e1fb4e4e46897ad9eddb1d1cfc02d8941053939910eed69a905f7a5509baabe
   languageName: node
   linkType: hard
 
@@ -3550,6 +3673,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chessground@npm:^8.3.10, chessground@npm:^8.3.7":
+  version: 8.3.10
+  resolution: "chessground@npm:8.3.10"
+  checksum: 56958eb864a1fb666ba72ceab9a2cd920efc45dc682618bd1d5e915b6419455dd101057dd972a99e3e3bcccbcb2444a511223e3fa795a77dfad59102ba3f8e12
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^3.5.2":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
@@ -3904,6 +4034,13 @@ __metadata:
   version: 2.6.21
   resolution: "csstype@npm:2.6.21"
   checksum: 2ce8bc832375146eccdf6115a1f8565a27015b74cce197c35103b4494955e9516b246140425ad24103864076aa3e1257ac9bab25a06c8d931dd87a6428c9dccf
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "csstype@npm:3.1.2"
+  checksum: e1a52e6c25c1314d6beef5168da704ab29c5186b877c07d822bd0806717d9a265e8493a2e35ca7e68d0f5d472d43fac1cdce70fd79fd0853dff81f3028d857b5
   languageName: node
   linkType: hard
 
@@ -7303,6 +7440,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.0":
+  version: 0.30.0
+  resolution: "magic-string@npm:0.30.0"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.4.13
+  checksum: 7bdf22e27334d8a393858a16f5f840af63a7c05848c000fd714da5aa5eefa09a1bc01d8469362f25cc5c4a14ec01b46557b7fff8751365522acddf21e57c488d
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^3.0.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
@@ -10010,7 +10156,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.37":
+"vue3-chessboard@npm:^1.1.8":
+  version: 1.1.8
+  resolution: "vue3-chessboard@npm:1.1.8"
+  dependencies:
+    chess.js: ^1.0.0-beta.6
+    chessground: ^8.3.7
+    vue: ^3.2.47
+  checksum: 4415595c16a186c55510015d3db8347e52796692f7bae18b60bb6ec0e63d7fd49444cd9c512e230398bfe792e4c28b32f6e9dcba8d30c275046878a288a3b259
+  languageName: node
+  linkType: hard
+
+"vue@npm:3.2.47":
   version: 3.2.47
   resolution: "vue@npm:3.2.47"
   dependencies:
@@ -10020,6 +10177,19 @@ __metadata:
     "@vue/server-renderer": 3.2.47
     "@vue/shared": 3.2.47
   checksum: 3b586f61fd2cdfdd24459a946a2831c0f164056993cc005badde4fea10d53e430f1cedf1b62d52a6992b58fe656fc5fc67b32f594a2832dfe440c6db46d6f158
+  languageName: node
+  linkType: hard
+
+"vue@npm:^3.2.47":
+  version: 3.3.4
+  resolution: "vue@npm:3.3.4"
+  dependencies:
+    "@vue/compiler-dom": 3.3.4
+    "@vue/compiler-sfc": 3.3.4
+    "@vue/runtime-dom": 3.3.4
+    "@vue/server-renderer": 3.3.4
+    "@vue/shared": 3.3.4
+  checksum: 58b6c62a66a375ce5df460fcb7ba41b37c8637c635faf06ef472ae4197f412cf9ad83586cd8e3f66c486404fbe8550e694f90ff724a571d1ba78830791099c59
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1874,6 +1874,7 @@ __metadata:
     "@types/jest": ^28.1.4
     "@typescript-eslint/eslint-plugin": ^5.40.0
     "@typescript-eslint/parser": ^5.40.0
+    chess.js: ^1.0.0-beta.6
     eslint: ^8.25.0
     jest: ^29.5.0
     ts-jest: ^29.1.0
@@ -3539,6 +3540,13 @@ __metadata:
   version: 2.24.0
   resolution: "check-more-types@npm:2.24.0"
   checksum: b09080ec3404d20a4b0ead828994b2e5913236ef44ed3033a27062af0004cf7d2091fbde4b396bf13b7ce02fb018bc9960b48305e6ab2304cd82d73ed7a51ef4
+  languageName: node
+  linkType: hard
+
+"chess.js@npm:^1.0.0-beta.6":
+  version: 1.0.0-beta.6
+  resolution: "chess.js@npm:1.0.0-beta.6"
+  checksum: fcd124be7b2316fd7104c89ba9d09ddfb87ca357d987afec94fe296bef382b8cd8782e60b554cc47aec870ef7f69d87cc4e8c91061d5191b36783554240b2e22
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #12 

The purpose of this exercise was to test the extensibility of the framework.  I feel some validation that chess.js API fit ours so perfectly - no complaints there.

The UI wasn't as easy, but that was mostly because the first two libraries I tried (chessboard.js, vue3-chessboard) weren't easy to import.  Lichess's chessground worked great, but I felt a good deal of friction getting Vanilla JS library to play nicely in a Vue component.

---

Anyway, here is the result!  The error messages aren't great, but the validator is rock solid - in this video, I didn't notice king was in check, but the validator caught it!

https://github.com/govariantsteam/govariants/assets/25233703/ebc16904-57cd-42e7-92ab-e41c929ebbf3
