### PR TITLE
dedupe getOnlyMove

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -3,6 +3,7 @@ import {
   makeGameObject,
   MovesType,
   User,
+  getOnlyMove,
 } from "@ogfcommunity/variants-shared";
 import { ObjectId, WithId, Document } from "mongodb";
 import { getDb } from "./db";
@@ -184,24 +185,4 @@ function outwardFacingGame(db_game: WithId<Document>): GameResponse {
     players: db_game.players,
     time_control: db_game.time_control,
   };
-}
-
-// This is copied and pasted from baduk.ts.  I realized that we only ever consume
-// one move at a time, making me think that maybe we should be storing it in a
-// way that TS understands that.
-//
-// Ideas: [number, string], { player: number, move: string }
-//
-// TODO: remove this function once a proper data format is decided.
-/** Asserts there is exaclty one move, and returns it */
-function getOnlyMove(moves: MovesType): { player: number; move: string } {
-  const players = Object.keys(moves);
-  if (players.length > 1) {
-    throw Error(`More than one player: ${players}`);
-  }
-  if (players.length === 0) {
-    throw Error("No players specified!");
-  }
-  const player = Number(players[0]);
-  return { player, move: moves[player] };
 }

--- a/packages/shared/src/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
+++ b/packages/shared/src/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
@@ -1,5 +1,6 @@
-import { AbstractGame, MovesType } from "../abstract_game";
+import { AbstractGame } from "../abstract_game";
 import { Coordinate, CoordinateLike } from "../coordinate";
+import { getOnlyMove } from "../utils";
 
 export enum Color {
   EMPTY = 0,
@@ -123,19 +124,6 @@ export function makeGridWithValue<T>(
 
 export function copyBoard(board: Color[][]) {
   return board.map((row) => [...row]);
-}
-
-/** Asserts there is exaclty one move, and returns it */
-function getOnlyMove(moves: MovesType): { player: number; move: string } {
-  const players = Object.keys(moves);
-  if (players.length > 1) {
-    throw Error(`More than one player: ${players}`);
-  }
-  if (players.length === 0) {
-    throw Error("No players specified!");
-  }
-  const player = Number(players[0]);
-  return { player, move: moves[player] };
 }
 
 export function isOutOfBounds(

--- a/packages/shared/src/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -1,8 +1,8 @@
 import { AbstractGame } from "../abstract_game";
-import type { MovesType } from "../abstract_game";
 import type { IBadukBoard } from "./abstractBoard/Interfaces/IBadukBoard";
 import { BadukBoardAbstract } from "./abstractBoard/BadukBoardAbstract";
 import type { Intersection } from "./abstractBoard/intersection";
+import { getOnlyMove } from "../utils";
 
 export enum Color {
     EMPTY = 0,
@@ -166,19 +166,6 @@ function groupHasLiberties(intersection: Intersection, board: BadukBoardAbstract
  */
 function removeGroup(intersection: Intersection, board: IBadukBoard): number {
     return floodFill(intersection, Color.EMPTY, board);
-}
-
-/** Asserts there is exaclty one move, and returns it */
-function getOnlyMove(moves: MovesType): { player: number; move: string } {
-    const players = Object.keys(moves);
-    if (players.length > 1) {
-        throw Error(`More than one player: ${players}`);
-    }
-    if (players.length === 0) {
-        throw Error("No players specified!");
-    }
-    const player = Number(players[0]);
-    return { player, move: moves[player] };
 }
 
 function isOutOfBounds(i: number, board: BadukBoardAbstract): boolean {

--- a/packages/shared/src/chess/chess.ts
+++ b/packages/shared/src/chess/chess.ts
@@ -1,5 +1,6 @@
 import { AbstractGame, MovesType } from "../abstract_game";
 import { Chess } from "chess.js";
+import { getOnlyMove } from "../utils";
 
 export interface ChessState {
   fen: string;
@@ -32,17 +33,4 @@ export class ChessGame extends AbstractGame<object, ChessState> {
   defaultConfig(): object {
     return {};
   }
-}
-
-// TODO: dedupe
-function getOnlyMove(moves: MovesType): { player: number; move: string } {
-  const players = Object.keys(moves);
-  if (players.length > 1) {
-    throw Error(`More than one player: ${players}`);
-  }
-  if (players.length === 0) {
-    throw Error("No players specified!");
-  }
-  const player = Number(players[0]);
-  return { player, move: moves[player] };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from "./api_types";
 export * from "./grid";
 export * from "./coordinate";
 export * from "./time_control";
+export * from "./utils";

--- a/packages/shared/src/parallel/parallel.ts
+++ b/packages/shared/src/parallel/parallel.ts
@@ -1,6 +1,7 @@
 import { AbstractGame, MovesType } from "../abstract_game";
 import { Coordinate } from "../coordinate";
 import { Grid } from "../grid";
+import { getOnlyMove } from "../utils";
 
 export interface ParallelGoConfig {
   width: number;
@@ -212,19 +213,6 @@ export class ParallelGo extends AbstractGame<
       group.stones.forEach((pos) => this.board.set(pos, []));
     });
   }
-}
-
-/** Asserts there is exactly one move, and returns it */
-function getOnlyMove(moves: MovesType): { player: number; move: string } {
-  const players = Object.keys(moves);
-  if (players.length > 1) {
-    throw Error(`More than one player: ${players}`);
-  }
-  if (players.length === 0) {
-    throw Error("No players specified!");
-  }
-  const player = Number(players[0]);
-  return { player, move: moves[player] };
 }
 
 interface Group {

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -1,0 +1,20 @@
+import { getOnlyMove } from "./utils";
+
+const MOVE_STRING = "test";
+
+test("getOnlyMove", () => {
+  expect(getOnlyMove({ 1: MOVE_STRING })).toEqual({
+    player: 1,
+    move: MOVE_STRING,
+  });
+});
+
+test("getOnlyMove - more than one move", () => {
+  expect(() => getOnlyMove({ 1: MOVE_STRING, 2: MOVE_STRING })).toThrow(
+    "More than one player: 1,2"
+  );
+});
+
+test("getOnlyMove - no moves", () => {
+  expect(() => getOnlyMove({})).toThrow("No players specified!");
+});

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,4 +1,4 @@
-import { MovesType } from "./abstract_game";
+import type { MovesType } from "./abstract_game";
 
 export function getOnlyMove(moves: MovesType): {
   player: number;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,0 +1,16 @@
+import { MovesType } from "./abstract_game";
+
+export function getOnlyMove(moves: MovesType): {
+  player: number;
+  move: string;
+} {
+  const players = Object.keys(moves);
+  if (players.length > 1) {
+    throw new Error(`More than one player: ${players}`);
+  }
+  if (players.length === 0) {
+    throw new Error("No players specified!");
+  }
+  const player = Number(players[0]);
+  return { player, move: moves[player] };
+}


### PR DESCRIPTION
Long needed code health change - we currently have 5 copies of this function.

Doesn't really address the data format issue.  It's now apparent that moves will never really be more than one move even for parallel variants.  I'm wondering if we should just store moves as the output of this function, e.g. `{ player: 1; move: "jk"}`. It's a little less compact, but easy to work with and readable.