### PR TITLE
Use Grid in Baduk

### DIFF
--- a/packages/shared/src/lib/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
+++ b/packages/shared/src/lib/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
@@ -113,22 +113,6 @@ export abstract class AbstractAlternatingOnGrid<
   }
 }
 
-function makeEmptyBoard(width: number, height: number): Color[][] {
-  return makeGridWithValue(width, height, Color.EMPTY);
-}
-
-export function makeGridWithValue<T>(
-  width: number,
-  height: number,
-  value: T
-): T[][] {
-  return new Array(height).fill(null).map(() => new Array(width).fill(value));
-}
-
-export function copyBoard(board: Color[][]) {
-  return board.map((row) => [...row]);
-}
-
 export function isOutOfBounds(pos: CoordinateLike, board: Grid<Color>): boolean {
   return board.at(pos) === undefined;
 }

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -2,8 +2,6 @@ import {
   AbstractAlternatingOnGrid,
   AbstractAlternatingOnGridConfig,
   AbstractAlternatingOnGridState,
-  makeGridWithValue,
-  copyBoard,
   isOutOfBounds,
   Color,
 } from "../lib/abstractAlternatingOnGrid";

--- a/packages/shared/src/variants/tetris.ts
+++ b/packages/shared/src/variants/tetris.ts
@@ -13,9 +13,7 @@ export class TetrisGo extends Baduk {
   }
 }
 
-function getGroup(pos: CoordinateLike, board_arr: Color[][]) {
-  // Not efficient to copy, but eventually I'd like to convert baduk to use Grid too.
-  const board = Grid.from2DArray(board_arr);
+function getGroup(pos: CoordinateLike, board: Grid<Color>) {
   const starting_color = board.at(pos);
   const visited = board.map(() => false);
   const group: Coordinate[] = [];


### PR DESCRIPTION
Most gridded variants are using the Grid class.  Adding this to Baduk will make it easier to perform grid operations, and also it may be easier to generalize to graphs with a similar API.