### PR TITLE
Show colors on board during scoring.

### DIFF
--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -16,11 +16,13 @@ export interface BadukConfig extends AbstractAlternatingOnGridConfig {
 export interface BadukState extends AbstractAlternatingOnGridState {
   captures: { 0: number; 1: number };
   last_move: string;
+  score_board?: Color[][];
 }
 
 export class Baduk extends AbstractAlternatingOnGrid<BadukConfig, BadukState> {
   protected captures = { 0: 0, 1: 0 };
   private ko_detector = new SuperKoDetector();
+  private score_board?: Grid<Color>;
 
   constructor(config?: BadukConfig) {
     super(config);
@@ -29,6 +31,7 @@ export class Baduk extends AbstractAlternatingOnGrid<BadukConfig, BadukState> {
   override exportState(): BadukState {
     return {
       ...super.exportState(),
+      ...(this.score_board && { score_board: this.score_board.to2DArray() }),
       captures: { 0: this.captures[0], 1: this.captures[1] },
     };
   }
@@ -107,9 +110,12 @@ export class Baduk extends AbstractAlternatingOnGrid<BadukConfig, BadukState> {
       }
     });
 
+    this.score_board = board;
+
     const black_points: number = countValueIn2dArray(Color.BLACK, board);
     const white_points: number =
       countValueIn2dArray(Color.WHITE, board) + this.config.komi;
+
     const diff = black_points - white_points;
     if (diff < 0) {
       this.result = `W+${-diff}`;

--- a/packages/vue-client/src/components/boards/BadukBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukBoard.vue
@@ -87,6 +87,26 @@ function positionClicked(pos: Coordinate) {
         r="0.4"
       />
     </g>
+    <g v-if="gamestate.score_board">
+      <template v-for="pos in positions">
+        <rect
+          v-if="gamestate.score_board[pos.y][pos.x]"
+          :key="`${pos.x},${pos.y}`"
+          v-bind:x="pos.x - 0.2"
+          v-bind:y="pos.y - 0.2"
+          v-bind:fill="
+            gamestate.score_board[pos.y][pos.x] === Color.BLACK
+              ? 'black'
+              : 'white'
+          "
+          stroke="gray"
+          stroke-width="0.05"
+          width="0.4"
+          height="0.4"
+          opacity="0.6"
+        />
+      </template>
+    </g>
   </svg>
 </template>
 


### PR DESCRIPTION
<img width="804" alt="Screenshot 2023-06-30 at 11 24 18 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/16ab13a4-582a-4923-87ef-7f8373d09fa3">

This should also make bugs like #115 more obvious and easier to debug:

<img width="820" alt="Screenshot 2023-06-30 at 11 33 00 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/b2b69a8c-d6e5-4754-bdc0-116a26fa6150">
