### PR TITLE
Fixes for circular config form

### DIFF
--- a/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
@@ -39,6 +39,13 @@ watch(patternRef, emitConfigChange);
 watch(sizeRef, emitConfigChange);
 watch(widthRef, emitConfigChange);
 watch(heightRef, emitConfigChange);
+watch(patternRef, () => {
+  // defaults for circular board need to be larger
+  if (patternRef.value === BoardPattern.Circular) {
+    widthRef.value = 9;
+    heightRef.value = 9;
+  }
+});
 </script>
 
 <template>
@@ -60,10 +67,10 @@ watch(heightRef, emitConfigChange);
       <input type="number" min="1" v-model="sizeRef" />
     </template>
     <template v-if="patternRef === BoardPattern.Circular">
-      <label>Rings</label>
-      <input type="number" min="1" v-model="widthRef" />
       <label>Nodes per Ring</label>
-      <input type="number" min="1" v-model="heightRef" />
+      <input type="number" min="3" v-model="widthRef" />
+      <label>Number of Rings</label>
+      <input type="number" min="3" v-model="heightRef" />
     </template>
     <label>Komi</label>
     <input type="number" step="0.5" v-model="komiRef" />


### PR DESCRIPTION
See [ArsenLapin's comment](https://forums.online-go.com/t/collective-development-of-a-server-for-variants/43682/119)

> I think the two parameters:
> 
> - number of rings;
> - number of nodes per ring
> 
> are inverted for circular go.
> 
> When I ask for 3 rings with 9 nodes per ring I get:
> ![](https://ogs-forums.s3.dualstack.us-east-1.amazonaws.com/original/3X/d/6/d6479807caaa893ff401485672b36c5fce75577a.png)
> 
> Also, the default parameters are 4, 4, which is way too small for any reasonable game.