### PR TITLE
Pyramid Go

### DIFF
--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -6,6 +6,7 @@ import { ParallelGo } from "./variants/parallel";
 import { Capture } from "./variants/capture";
 import { ChessGame } from "./variants/chess";
 import { TetrisGo } from "./variants/tetris";
+import { PyramidGo } from "./variants/pyramid";
 
 export const game_map: {
   [variant: string]: new (config?: any) => AbstractGame;
@@ -17,6 +18,7 @@ export const game_map: {
   capture: Capture,
   chess: ChessGame,
   tetris: TetrisGo,
+  pyramid: PyramidGo,
 };
 
 class ConfigError extends Error {

--- a/packages/shared/src/lib/__tests__/grid.test.ts
+++ b/packages/shared/src/lib/__tests__/grid.test.ts
@@ -96,3 +96,14 @@ test("forEach on unset array", () => {
   expect(f).toBeCalledTimes(1);
   expect(f).toBeCalledWith(8, index, g);
 });
+
+  
+test("reduce", () => {
+  const g = Grid.from2DArray([
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ]);
+
+  expect(g.reduce((x, y) => x + y, 0)).toEqual(45);
+});

--- a/packages/shared/src/lib/grid.ts
+++ b/packages/shared/src/lib/grid.ts
@@ -118,6 +118,27 @@ export class Grid<T> {
     const w = this.width;
     const h = this.height;
     return x < w && y < h && x >= 0 && y >= 0;
+  }  
+
+  reduce(
+    callbackfn: (
+      previousValue: T,
+      currentValue: T,
+      index: Coordinate,
+      array: Grid<T>
+    ) => T,
+    initialValue: T
+  ): T {
+    return this.arr.reduce(
+      (previousValue, currentValue, flat_index) =>
+        callbackfn(
+          previousValue,
+          currentValue,
+          flat_index_to_coordinate(flat_index, this.width),
+          this
+        ),
+      initialValue
+    );
   }
 }
 

--- a/packages/shared/src/variants/__tests__/pyramid.test.ts
+++ b/packages/shared/src/variants/__tests__/pyramid.test.ts
@@ -1,0 +1,47 @@
+import { PyramidGo } from "../pyramid";
+
+test("inner group score", () => {
+  const game = new PyramidGo({ width: 9, height: 9, komi: 0 });
+
+  const rounds = [
+    ["cc", "cb"],
+    ["dc", "db"],
+    ["ec", "eb"],
+    ["fc", "fb"],
+    ["gc", "gb"],
+    ["gd", "hc"],
+    ["ge", "hd"],
+    ["gf", "he"],
+    ["gg", "hf"],
+    ["fg", "hg"],
+    ["eg", "gh"],
+    ["dg", "fh"],
+    ["cg", "eh"],
+    ["cd", "dh"],
+    ["cf", "ch"],
+    ["ce", "bg"],
+    ["pass", "bf"],
+    ["pass", "be"],
+    ["pass", "bd"],
+    ["pass", "bc"],
+    ["pass", "pass"],
+  ];
+
+  rounds.forEach((round) => {
+    game.playMove({ 0: round[0] });
+    game.playMove({ 1: round[1] });
+  });
+
+  // from https://forums.online-go.com/t/pyramid-go/36944
+  // . . . . . . . . .
+  // . . W W W W W . .
+  // . W B B B B B W .
+  // . W B . . . B W .
+  // . W B . . . B W .
+  // . W B . . . B W .
+  // . W B B B B B W .
+  // . . W W W W W . .
+  // . . . . . . . . .
+
+  expect(game.result).toBe("B+5"); // 80-85
+});

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -23,7 +23,7 @@ export interface BadukState extends AbstractAlternatingOnGridState {
 export class Baduk extends AbstractAlternatingOnGrid<BadukConfig, BadukState> {
   protected captures = { 0: 0, 1: 0 };
   private ko_detector = new SuperKoDetector();
-  private score_board?: Grid<Color>;
+  protected score_board?: Grid<Color>;
 
   constructor(config?: BadukConfig) {
     super(config);

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -1,0 +1,41 @@
+import { Baduk, BadukConfig } from "./baduk";
+import { Grid } from "../lib/grid";
+import { Color } from "../lib/abstractAlternatingOnGrid";
+import { Coordinate } from "../lib/coordinate";
+
+export class PyramidGo extends Baduk {
+  private weights: Grid<number>;
+  constructor(config: BadukConfig) {
+    super(config);
+
+    this.weights = new Grid(config.width, config.height)
+      .fill(0)
+      .map((_, { x, y }) =>
+        Math.min(x + 1, y + 1, config.width - x, config.height - y)
+      );
+  }
+
+  get result(): string {
+    if (this.score_board === undefined) {
+      return "";
+    }
+    const white_points = this.pointsForColor(Color.WHITE);
+    const black_points = this.pointsForColor(Color.BLACK);
+
+    const diff = Math.abs(white_points - black_points);
+    if (diff === 0) return "Tie";
+    return white_points > black_points ? `W+${diff}` : `B+${diff}`;
+  }
+  set result(_: string) {
+    // do nothing, we don't want super class to set this
+  }
+
+  private pointsForColor(c: Color) {
+    if (this.score_board === undefined) return 0;
+    return this.score_board
+      .map((color, index) =>
+        color === c ? (this.weights.at(index) as number) : 0
+      )
+      .reduce((x, y) => x + y, 0);
+  }
+}

--- a/packages/vue-client/src/board_map.ts
+++ b/packages/vue-client/src/board_map.ts
@@ -14,4 +14,5 @@ export const board_map: {
   capture: Baduk,
   chess: ChessBoard,
   tetris: Baduk,
+  pyramid: Baduk,
 };


### PR DESCRIPTION
Fixes #18.  The visible difference from regular go is very subtle - only the result changes.  In this screenshot, Black wins by 5, whereas White should win by 31.

There are likely some enhancements to highlight that this is a variant, for example showing the weight of each stone on the board somehow or having varying sizes for the score markings.  But this is a start :)

<img width="831" alt="Screenshot 2023-07-02 at 8 13 00 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/9dafab02-783a-4cea-b63e-8bbf61d7d6b2">
