### PR TITLE
Add a few tests that demonstrate when Grid.at() returns undefined

### DIFF
--- a/packages/shared/src/lib/__tests__/grid.test.ts
+++ b/packages/shared/src/lib/__tests__/grid.test.ts
@@ -97,7 +97,6 @@ test("forEach on unset array", () => {
   expect(f).toBeCalledWith(8, index, g);
 });
 
-  
 test("reduce", () => {
   const g = Grid.from2DArray([
     [1, 2, 3],
@@ -106,4 +105,19 @@ test("reduce", () => {
   ]);
 
   expect(g.reduce((x, y) => x + y, 0)).toEqual(45);
+});
+
+test("empty slots are undefined", () => {
+  const g = new Grid(5, 5);
+  expect(g.at({ x: 1, y: 1 })).toBeUndefined();
+});
+
+test("out of bounds is undefined", () => {
+  const g = Grid.from2DArray([
+    [1, 2, 3],
+    [4, 5, 6],
+    [7, 8, 9],
+  ]);
+  // out-of-bounds
+  expect(g.at({ x: 0, y: 5 })).toBeUndefined();
 });

--- a/packages/shared/src/lib/__tests__/group_utils.test.ts
+++ b/packages/shared/src/lib/__tests__/group_utils.test.ts
@@ -92,3 +92,12 @@ test("getInnerBorder", () => {
     { x: 2, y: 0 },
   ]);
 });
+
+test("getGroup - undefined group", () => {
+  const grid: Grid<undefined | number> = Grid.from2DArray([
+    [undefined, 0, 1],
+    [undefined, 0, 1],
+    [undefined, 0, 1],
+  ]);
+  expect(getGroup({ x: 0, y: 0 }, grid)).toHaveLength(3);
+});


### PR DESCRIPTION
Codifying the `undefined` output of at(), prompted by discussion in #120 