### PR TITLE
Add Freeze Go

### DIFF
--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -8,6 +8,7 @@ import { ChessGame } from "./variants/chess";
 import { TetrisGo } from "./variants/tetris";
 import { PyramidGo } from "./variants/pyramid";
 import { ThueMorse } from "./variants/thue_morse";
+import { FreezeGo } from "./variants/freeze";
 
 export const game_map: {
   [variant: string]: new (config?: any) => AbstractGame;
@@ -21,6 +22,7 @@ export const game_map: {
   tetris: TetrisGo,
   pyramid: PyramidGo,
   "thue-morse": ThueMorse,
+  freeze: FreezeGo,
 };
 
 class ConfigError extends Error {

--- a/packages/shared/src/variants/__tests__/freeze.test.ts
+++ b/packages/shared/src/variants/__tests__/freeze.test.ts
@@ -1,0 +1,20 @@
+import { FreezeGo } from "../freeze";
+
+test("four stone group throws", () => {
+  const game = new FreezeGo({ width: 5, height: 2, komi: 0.5 });
+  // B . . . .
+  // W . . . B
+  game.playMove({ 0: "aa" });
+  game.playMove({ 1: "ab" });
+  game.playMove({ 0: "ea" });
+  game.playMove({ 1: "eb" });
+  // B . . . B  <-- atari
+  // W . . .(W)
+
+  // B . . . B
+  // .(B). . W
+  //   ^ illegal capture
+  expect(() => {
+    game.playMove({ 0: "bb" });
+  }).toThrow(/capture.*atari/);
+});

--- a/packages/shared/src/variants/freeze.ts
+++ b/packages/shared/src/variants/freeze.ts
@@ -1,0 +1,35 @@
+import { Color } from "../lib/abstractAlternatingOnGrid";
+import { Coordinate, CoordinateLike } from "../lib/coordinate";
+import { Grid } from "../lib/grid";
+import { getGroup, getOuterBorder } from "../lib/group_utils";
+import { getOnlyMove } from "../lib/utils";
+import { Baduk } from "./baduk";
+
+export class FreezeGo extends Baduk {
+  private frozen = false;
+
+  playMove(moves: { 0: string } | { 1: string }) {
+    const { move, player } = getOnlyMove(moves);
+    const captures_before = this.captures[player as 0 | 1];
+    super.playMove(moves);
+    const captures_after = this.captures[player as 0 | 1];
+    if (this.frozen && captures_before !== captures_after) {
+      throw new Error("Cannot capture after opponent ataris");
+    }
+
+    const opponent = player === 0 ? Color.WHITE : Color.BLACK;
+    this.frozen = this.board
+      .neighbors(Coordinate.fromSgfRepr(move))
+      .some(
+        (pos) => this.board.at(pos) === opponent && is_in_atari(pos, this.board)
+      );
+  }
+}
+
+function is_in_atari(pos: CoordinateLike, board: Grid<Color>) {
+  const group = getGroup(pos, board);
+  const num_liberties = getOuterBorder(group, board).filter(
+    (pos) => board.at(pos) === Color.EMPTY
+  ).length;
+  return num_liberties === 1;
+}

--- a/packages/vue-client/src/board_map.ts
+++ b/packages/vue-client/src/board_map.ts
@@ -16,4 +16,5 @@ export const board_map: {
   tetris: Baduk,
   pyramid: Baduk,
   "thue-morse": Baduk,
+  freeze: Baduk,
 };

--- a/packages/vue-client/src/config_form_map.ts
+++ b/packages/vue-client/src/config_form_map.ts
@@ -14,4 +14,5 @@ export const config_form_map: {
   tetris: BadukConfigForm,
   pyramid: BadukConfigForm,
   "thue-morse": BadukConfigForm,
+  freeze: BadukConfigForm,
 };


### PR DESCRIPTION
> In addition to the regular Go rules, capturing is forbidden after an atari. That is, if white reduced the number of liberties of any black group to one, black is not allowed to capture stones in the next move. Self-ataris don’t count. This can lead to absolutely crazy variations where both players scramble to play any atari they can find, repeatedly “freezing” their opponent.

https://www.egc2023.de/schedule/atari-go-1-2/

See #132 

https://github.com/govariantsteam/govariants/assets/25233703/91225925-6650-402d-9419-97ee9d3b02ec


