### PR TITLE
Change the interface of AbstractGame.playMove

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -8,7 +8,11 @@ import {
 import { ObjectId, WithId, Document } from "mongodb";
 import { getDb } from "./db";
 import { io } from "./socket_io";
-import { HasTimeControlConfig, timeControlHandlerMap, ValidateTimeControlConfig } from "./time-control";
+import {
+  HasTimeControlConfig,
+  timeControlHandlerMap,
+  ValidateTimeControlConfig,
+} from "./time-control";
 
 export function gamesCollection() {
   return getDb().db().collection("games");
@@ -81,8 +85,9 @@ export async function playMove(
 
   // Verify that moves are legal
   const game_obj = makeGameObject(game.variant, game.config);
-  game.moves.forEach((move) => {
-    game_obj.playMove(move);
+  game.moves.forEach((moves) => {
+    const { player, move } = getOnlyMove(moves);
+    game_obj.playMove(player, move);
   });
 
   if (game_obj.result !== "") {
@@ -103,9 +108,13 @@ export async function playMove(
     );
   }
 
-  game_obj.playMove(moves);
+  const { player, move: new_move } = getOnlyMove(moves);
+  game_obj.playMove(player, new_move);
 
-  if (HasTimeControlConfig(game.config) && ValidateTimeControlConfig(game.config.time_control)) {
+  if (
+    HasTimeControlConfig(game.config) &&
+    ValidateTimeControlConfig(game.config.time_control)
+  ) {
     const timeHandler = new timeControlHandlerMap[game.variant]();
     await timeHandler.handleMove(game, game_obj, move.player, move.move);
   }

--- a/packages/shared/src/abstract_game.ts
+++ b/packages/shared/src/abstract_game.ts
@@ -20,7 +20,7 @@ export abstract class AbstractGame<GameConfig = object, GameState = object> {
    * May throw if the move was invalid and we should return that information
    * to the user
    */
-  abstract playMove(move: MovesType): void;
+  abstract playMove(player: number, move: string): void;
 
   /** Returns complete representation of the game at this point in time. */
   abstract exportState(player?: number): GameState;
@@ -66,9 +66,6 @@ export abstract class AbstractGame<GameConfig = object, GameState = object> {
    * This is used in the game creation form.
    */
   abstract defaultConfig(): GameConfig;
-}
-export interface MovesType {
-  [player: number]: string;
 }
 
 export type GamePhase = "play" | "gameover";

--- a/packages/shared/src/api_types.ts
+++ b/packages/shared/src/api_types.ts
@@ -1,4 +1,4 @@
-import { MovesType } from "./abstract_game";
+import { MovesType } from "./lib/utils";
 import { ITimeControlBase } from "./time_control/time_control.types";
 
 export interface User {

--- a/packages/shared/src/lib/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
+++ b/packages/shared/src/lib/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
@@ -1,7 +1,6 @@
 import { AbstractGame } from "../../abstract_game";
 import { Coordinate, CoordinateLike } from "../coordinate";
 import { Grid } from "../grid";
-import { getOnlyMove } from "../utils";
 
 export enum Color {
   EMPTY = 0,
@@ -19,8 +18,6 @@ export interface AbstractAlternatingOnGridState {
   next_to_play: 0 | 1;
   last_move: string;
 }
-
-type AbstractAlternatingOnGridMovesType = { 0: string } | { 1: string };
 
 export abstract class AbstractAlternatingOnGrid<
   TConfig extends AbstractAlternatingOnGridConfig,
@@ -49,8 +46,7 @@ export abstract class AbstractAlternatingOnGrid<
     return [this.next_to_play];
   }
 
-  override playMove(moves: AbstractAlternatingOnGridMovesType): void {
-    const { player, move } = getOnlyMove(moves);
+  override playMove(player: number, move: string): void {
     if (player != this.next_to_play) {
       throw Error(`It's not player ${player}'s turn!`);
     }
@@ -113,6 +109,9 @@ export abstract class AbstractAlternatingOnGrid<
   }
 }
 
-export function isOutOfBounds(pos: CoordinateLike, board: Grid<Color>): boolean {
+export function isOutOfBounds(
+  pos: CoordinateLike,
+  board: Grid<Color>
+): boolean {
   return board.at(pos) === undefined;
 }

--- a/packages/shared/src/lib/abstractBaduk/abstractBaduk.test.ts
+++ b/packages/shared/src/lib/abstractBaduk/abstractBaduk.test.ts
@@ -1,4 +1,4 @@
-import { MovesType } from "../../abstract_game";
+import { MovesType } from "../utils";
 import { AbstractBaduk, AbstractBadukConfig } from "./abstractBaduk";
 import { BadukIntersection, AbstractBadukStone } from "./badukIntersection";
 
@@ -64,7 +64,7 @@ class AbstractBadukTestGame extends AbstractBaduk<
     return this.findChainsWithoutLiberties(this.center, types, new Map());
   }
 
-  playMove(move: MovesType): void {
+  playMove(player: number, move: string): void {
     throw new Error("Not implemented");
   }
 

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -1,4 +1,6 @@
-import type { MovesType } from "../abstract_game";
+export interface MovesType {
+  [player: number]: string;
+}
 
 export function getOnlyMove(moves: MovesType): {
   player: number;

--- a/packages/shared/src/variants/__tests__/baduk.test.ts
+++ b/packages/shared/src/variants/__tests__/baduk.test.ts
@@ -12,13 +12,13 @@ test("Play a game", () => {
   // - W B -
   // - W B -
   expect(game.nextToPlay()).toEqual([0]);
-  game.playMove({ 0: "ca" });
+  game.playMove(0, "ca");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "ba" });
+  game.playMove(1, "ba");
   expect(game.nextToPlay()).toEqual([0]);
-  game.playMove({ 0: "cb" });
+  game.playMove(0, "cb");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "bb" });
+  game.playMove(1, "bb");
   expect(game.nextToPlay()).toEqual([0]);
 
   // check that the final state is as expected
@@ -28,9 +28,9 @@ test("Play a game", () => {
   ]);
 
   expect(game.phase).toBe("play");
-  game.playMove({ 0: "pass" });
+  game.playMove(0, "pass");
   expect(game.phase).toBe("play");
-  game.playMove({ 1: "pass" });
+  game.playMove(1, "pass");
 
   expect(game.phase).toBe("gameover");
   expect(game.result).toBe("W+0.5");
@@ -45,9 +45,9 @@ test("Play a game with captures", () => {
   // Tiny board
   // B W
   // B .
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ba" });
-  game.playMove({ 0: "ab" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ba");
+  game.playMove(0, "ab");
   expect(game.exportState().board).toEqual([
     [B, W],
     [B, _],
@@ -56,16 +56,16 @@ test("Play a game with captures", () => {
   // Tiny board
   // . W
   // . W
-  game.playMove({ 1: "bb" });
+  game.playMove(1, "bb");
   expect(game.exportState().board).toEqual([
     [_, W],
     [_, W],
   ]);
 
   expect(game.phase).toBe("play");
-  game.playMove({ 0: "pass" });
+  game.playMove(0, "pass");
   expect(game.phase).toBe("play");
-  game.playMove({ 1: "pass" });
+  game.playMove(1, "pass");
   expect(game.phase).toBe("gameover");
   expect(game.result).toBe("W+4.5");
   expect(game.exportState().score_board).toEqual([
@@ -76,17 +76,17 @@ test("Play a game with captures", () => {
 
 test("Resign a game", () => {
   const game = new Baduk({ width: 19, height: 19, komi: 5.5 });
-  game.playMove({ 0: "resign" });
+  game.playMove(0, "resign");
   expect(game.phase).toBe("gameover");
   expect(game.result).toBe("W+R");
 });
 
 test("Scoring with open borders", () => {
   const game = new Baduk({ width: 5, height: 5, komi: 6.5 });
-  game.playMove({ "0": "cb" });
-  game.playMove({ "1": "cc" });
-  game.playMove({ "0": "pass" });
-  game.playMove({ "1": "pass" });
+  game.playMove(0, "cb");
+  game.playMove(1, "cc");
+  game.playMove(0, "pass");
+  game.playMove(1, "pass");
 
   expect(game.result).toBe("W+6.5");
 });
@@ -102,19 +102,19 @@ test("ko", () => {
     komi: 6.5,
   });
 
-  game.playMove({ "0": "ba" });
-  game.playMove({ "1": "ca" });
-  game.playMove({ "0": "ab" });
-  game.playMove({ "1": "db" });
-  game.playMove({ "0": "bc" });
-  game.playMove({ "1": "cc" });
-  game.playMove({ "0": "cb" });
+  game.playMove(0, "ba");
+  game.playMove(1, "ca");
+  game.playMove(0, "ab");
+  game.playMove(1, "db");
+  game.playMove(0, "bc");
+  game.playMove(1, "cc");
+  game.playMove(0, "cb");
 
   // White captures
-  game.playMove({ "1": "bb" });
+  game.playMove(1, "bb");
 
   // Black captures back
-  expect(() => game.playMove({ "0": "cb" })).toThrow(KoError);
+  expect(() => game.playMove(0, "cb")).toThrow(KoError);
 });
 
 test("inner group score", () => {
@@ -145,8 +145,8 @@ test("inner group score", () => {
   ];
 
   rounds.forEach((round) => {
-    game.playMove({ 0: round[0] });
-    game.playMove({ 1: round[1] });
+    game.playMove(0, round[0]);
+    game.playMove(1, round[1]);
   });
 
   // . . . . . . . . .
@@ -176,23 +176,18 @@ test("inner group score", () => {
 test("Capture test", () => {
   const game = new Baduk({ width: 3, height: 3, komi: 6.5 });
 
-  const moves = [
-    { "0": "aa" },
-    { "1": "ba" },
-    { "0": "ab" },
-    { "1": "bc" },
-    { "0": "cb" },
-    { "1": "bb" },
-    { "0": "ca" },
-    { "1": "cc" },
-    { "0": "cb" },
-    { "1": "ac" },
-    { "0": "pass" },
-    { "1": "pass" },
+  const rounds = [
+    ["aa", "ba"],
+    ["ab", "bc"],
+    ["cb", "bb"],
+    ["ca", "cc"],
+    ["cb", "ac"],
+    ["pass", "pass"],
   ];
 
-  moves.forEach((move) => {
-    game.playMove(move);
+  rounds.forEach((round) => {
+    game.playMove(0, round[0]);
+    game.playMove(1, round[1]);
   });
 
   expect(game.exportState().board).toEqual([

--- a/packages/shared/src/variants/__tests__/capture.test.ts
+++ b/packages/shared/src/variants/__tests__/capture.test.ts
@@ -6,12 +6,12 @@ test("White wins by capture", () => {
   // Tiny board
   // B W
   // B O
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ba" });
-  game.playMove({ 0: "ab" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ba");
+  game.playMove(0, "ab");
 
   // capture the black stones on the left
-  game.playMove({ 1: "bb" });
+  game.playMove(1, "bb");
 
   expect(game.exportState().board).toEqual([
     [Color.EMPTY, Color.WHITE],
@@ -27,11 +27,11 @@ test("Black wins by capture", () => {
   // Tiny board
   // B W
   // . .
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ba" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ba");
 
   // capture the white stone on the left
-  game.playMove({ 0: "bb" });
+  game.playMove(0, "bb");
 
   expect(game.exportState().board).toEqual([
     [Color.BLACK, Color.EMPTY],

--- a/packages/shared/src/variants/__tests__/chess.test.ts
+++ b/packages/shared/src/variants/__tests__/chess.test.ts
@@ -6,9 +6,9 @@ const ___ = null;
 test("Knight can move", () => {
   const game = new ChessGame();
 
-  game.playMove({ 0: "e4" });
-  game.playMove({ 1: "e5" });
-  game.playMove({ 0: "Nf3" });
+  game.playMove(0, "e4");
+  game.playMove(1, "e5");
+  game.playMove(0, "Nf3");
 
   expect(game.exportState().fen).toBe(
     "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2"
@@ -18,9 +18,9 @@ test("Knight can move", () => {
 test("Bishop can move", () => {
   const game = new ChessGame();
 
-  game.playMove({ 0: "e4" });
-  game.playMove({ 1: "e5" });
-  game.playMove({ 0: "Bc4" });
+  game.playMove(0, "e4");
+  game.playMove(1, "e5");
+  game.playMove(0, "Bc4");
 
   expect(game.exportState().fen).toEqual(
     "rnbqkbnr/pppp1ppp/8/4p3/2B1P3/8/PPPP1PPP/RNBQK1NR b KQkq - 1 2"
@@ -30,13 +30,13 @@ test("Bishop can move", () => {
 test("King's side castle", () => {
   const game = new ChessGame();
 
-  game.playMove({ 0: "e4" });
-  game.playMove({ 1: "e5" });
-  game.playMove({ 0: "Nf3" });
-  game.playMove({ 1: "Nc6" });
-  game.playMove({ 0: "Bc4" });
-  game.playMove({ 1: "d6" });
-  game.playMove({ 0: "O-O" });
+  game.playMove(0, "e4");
+  game.playMove(1, "e5");
+  game.playMove(0, "Nf3");
+  game.playMove(1, "Nc6");
+  game.playMove(0, "Bc4");
+  game.playMove(1, "d6");
+  game.playMove(0, "O-O");
 
   expect(game.exportState().fen).toEqual(
     "r1bqkbnr/ppp2ppp/2np4/4p3/2B1P3/5N2/PPPP1PPP/RNBQ1RK1 b kq - 1 4"
@@ -46,10 +46,10 @@ test("King's side castle", () => {
 test("En Passant", () => {
   const game = new ChessGame();
 
-  game.playMove({ 0: "e4" });
-  game.playMove({ 1: "e6" });
-  game.playMove({ 0: "e5" });
-  game.playMove({ 1: "d5" });
+  game.playMove(0, "e4");
+  game.playMove(1, "e6");
+  game.playMove(0, "e5");
+  game.playMove(1, "d5");
 
   // en passant target is set to d6
   expect(game.exportState().fen).toBe(
@@ -57,7 +57,7 @@ test("En Passant", () => {
   );
 
   // Capture the d5 pawn by en passant
-  game.playMove({ 0: "exd6" });
+  game.playMove(0, "exd6");
 
   expect(game.exportState().fen).toEqual(
     "rnbqkbnr/ppp2ppp/3Pp3/8/8/8/PPPP1PPP/RNBQKBNR b KQkq - 0 3"

--- a/packages/shared/src/variants/__tests__/freeze.test.ts
+++ b/packages/shared/src/variants/__tests__/freeze.test.ts
@@ -4,10 +4,10 @@ test("four stone group throws", () => {
   const game = new FreezeGo({ width: 5, height: 2, komi: 0.5 });
   // B . . . .
   // W . . . B
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ab" });
-  game.playMove({ 0: "ea" });
-  game.playMove({ 1: "eb" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ab");
+  game.playMove(0, "ea");
+  game.playMove(1, "eb");
   // B . . . B  <-- atari
   // W . . .(W)
 
@@ -15,6 +15,6 @@ test("four stone group throws", () => {
   // .(B). . W
   //   ^ illegal capture
   expect(() => {
-    game.playMove({ 0: "bb" });
+    game.playMove(0, "bb");
   }).toThrow(/capture.*atari/);
 });

--- a/packages/shared/src/variants/__tests__/parallel.test.ts
+++ b/packages/shared/src/variants/__tests__/parallel.test.ts
@@ -7,8 +7,8 @@ test("Halfway through the round, moves are staged, but not placed.", () => {
     num_players: 4,
     collision_handling: "pass",
   });
-  game.playMove({ 0: "ba" });
-  game.playMove({ 1: "ca" });
+  game.playMove(0, "ba");
+  game.playMove(1, "ca");
 
   expect(game.exportState()).toEqual({
     board: [
@@ -31,10 +31,10 @@ test("After one round, stones are placed, and no stones are staged.", () => {
     num_players: 4,
     collision_handling: "pass",
   });
-  game.playMove({ 0: "ba" });
-  game.playMove({ 1: "ca" });
-  game.playMove({ 2: "bb" });
-  game.playMove({ 3: "cb" });
+  game.playMove(0, "ba");
+  game.playMove(1, "ca");
+  game.playMove(2, "bb");
+  game.playMove(3, "cb");
 
   expect(game.exportState()).toEqual({
     board: [
@@ -53,10 +53,10 @@ test("If all players pass, the game is ended.", () => {
     num_players: 4,
     collision_handling: "pass",
   });
-  game.playMove({ 0: "pass" });
-  game.playMove({ 1: "pass" });
-  game.playMove({ 2: "pass" });
-  game.playMove({ 3: "pass" });
+  game.playMove(0, "pass");
+  game.playMove(1, "pass");
+  game.playMove(2, "pass");
+  game.playMove(3, "pass");
 
   expect(game.phase).toBe("gameover");
 });
@@ -68,8 +68,8 @@ test("Collision places no stones. (pass mode)", () => {
     num_players: 2,
     collision_handling: "pass",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "aa" });
+  game.playMove(0, "aa");
+  game.playMove(1, "aa");
 
   expect(game.exportState().board).toEqual([
     [[], []],
@@ -84,8 +84,8 @@ test("Collision places Ko Stone. (ko mode)", () => {
     num_players: 2,
     collision_handling: "ko",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "aa" });
+  game.playMove(0, "aa");
+  game.playMove(1, "aa");
 
   expect(game.exportState().board).toEqual([
     [[-1], []],
@@ -100,10 +100,10 @@ test("Ko stone disappears after one round", () => {
     num_players: 2,
     collision_handling: "ko",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "aa" });
-  game.playMove({ 0: "ba" });
-  game.playMove({ 1: "ab" });
+  game.playMove(0, "aa");
+  game.playMove(1, "aa");
+  game.playMove(0, "ba");
+  game.playMove(1, "ab");
 
   expect(game.exportState().board[0][0]).toEqual([]);
 });
@@ -115,9 +115,9 @@ test("Ko stone still exists midround", () => {
     num_players: 2,
     collision_handling: "ko",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "aa" });
-  game.playMove({ 0: "bb" });
+  game.playMove(0, "aa");
+  game.playMove(1, "aa");
+  game.playMove(0, "bb");
 
   expect(game.exportState().board).toEqual([
     [[-1], []],
@@ -132,8 +132,8 @@ test("Collision places merged stone. (merge mode)", () => {
     num_players: 2,
     collision_handling: "merge",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "aa" });
+  game.playMove(0, "aa");
+  game.playMove(1, "aa");
 
   expect(game.exportState().board).toEqual([
     [[0, 1], []],
@@ -148,10 +148,10 @@ test("Double suicide", () => {
     num_players: 2,
     collision_handling: "ko",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ab" });
-  game.playMove({ 0: "ba" });
-  game.playMove({ 1: "bb" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ab");
+  game.playMove(0, "ba");
+  game.playMove(1, "bb");
 
   expect(game.exportState().board).toEqual([
     [[], []],
@@ -166,10 +166,10 @@ test("Kill already placed groups first", () => {
     num_players: 2,
     collision_handling: "ko",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "da" });
-  game.playMove({ 0: "ca" });
-  game.playMove({ 1: "ba" });
+  game.playMove(0, "aa");
+  game.playMove(1, "da");
+  game.playMove(0, "ca");
+  game.playMove(1, "ba");
 
   expect(game.exportState().board).toEqual([[[], [1], [0], []]]);
 });
@@ -181,10 +181,10 @@ test("Merge kill", () => {
     num_players: 2,
     collision_handling: "merge",
   });
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ca" });
-  game.playMove({ 0: "ba" });
-  game.playMove({ 1: "ba" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ca");
+  game.playMove(0, "ba");
+  game.playMove(1, "ba");
 
   expect(game.exportState().board).toEqual([[[], [], [1], []]]);
 });
@@ -196,33 +196,16 @@ test("Double capture by the wall", () => {
     num_players: 2,
     collision_handling: "merge",
   });
-  const moves: Array<{ 0: string } | { 1: string }> = [
-    {
-      "0": "cd",
-    },
-    {
-      "1": "dd",
-    },
-    {
-      "0": "dc",
-    },
-    {
-      "1": "cc",
-    },
-    {
-      "0": "ed",
-    },
-    {
-      "1": "bd",
-    },
-    {
-      "0": "de",
-    },
-    {
-      "1": "ce",
-    },
+  const rounds = [
+    ["cd", "dd"],
+    ["dc", "cc"],
+    ["ed", "bd"],
+    ["de", "ce"],
   ];
-  moves.forEach((move) => game.playMove(move));
+  rounds.forEach((round) => {
+    game.playMove(0, round[0]);
+    game.playMove(1, round[1]);
+  });
 
   expect(game.exportState().board).toEqual([
     [[], [], [], [], [], []],

--- a/packages/shared/src/variants/__tests__/phantom.test.ts
+++ b/packages/shared/src/variants/__tests__/phantom.test.ts
@@ -6,10 +6,10 @@ test("Play a game", () => {
   // Tiny board:
   // - W B -
   // - W B -
-  game.playMove({ 0: "ca" });
-  game.playMove({ 1: "ba" });
-  game.playMove({ 0: "cb" });
-  game.playMove({ 1: "bb" });
+  game.playMove(0, "ca");
+  game.playMove(1, "ba");
+  game.playMove(0, "cb");
+  game.playMove(1, "bb");
 
   // check that gobal state is as expected
   expect(game.exportState().board).toEqual([
@@ -35,10 +35,10 @@ test("Play a game with captures", () => {
   // Tiny board
   // B W
   // B O
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ba" });
-  game.playMove({ 0: "ab" });
-  game.playMove({ 1: "bb" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ba");
+  game.playMove(0, "ab");
+  game.playMove(1, "bb");
 
   expect(game.exportState().board).toEqual([
     [Color.EMPTY, Color.WHITE],

--- a/packages/shared/src/variants/__tests__/pyramid.test.ts
+++ b/packages/shared/src/variants/__tests__/pyramid.test.ts
@@ -28,8 +28,8 @@ test("inner group score", () => {
   ];
 
   rounds.forEach((round) => {
-    game.playMove({ 0: round[0] });
-    game.playMove({ 1: round[1] });
+    game.playMove(0, round[0]);
+    game.playMove(1, round[1]);
   });
 
   // from https://forums.online-go.com/t/pyramid-go/36944

--- a/packages/shared/src/variants/__tests__/tetris.test.ts
+++ b/packages/shared/src/variants/__tests__/tetris.test.ts
@@ -7,13 +7,13 @@ test("Play a game", () => {
   // - W B -
   // - W B -
   expect(game.nextToPlay()).toEqual([0]);
-  game.playMove({ 0: "ca" });
+  game.playMove(0, "ca");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "ba" });
+  game.playMove(1, "ba");
   expect(game.nextToPlay()).toEqual([0]);
-  game.playMove({ 0: "cb" });
+  game.playMove(0, "cb");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "bb" });
+  game.playMove(1, "bb");
   expect(game.nextToPlay()).toEqual([0]);
 
   // check that the final state is as expected
@@ -23,9 +23,9 @@ test("Play a game", () => {
   ]);
 
   expect(game.phase).toBe("play");
-  game.playMove({ 0: "pass" });
+  game.playMove(0, "pass");
   expect(game.phase).toBe("play");
-  game.playMove({ 1: "pass" });
+  game.playMove(1, "pass");
 
   expect(game.phase).toBe("gameover");
   expect(game.result).toBe("W+0.5");
@@ -36,15 +36,15 @@ test("four stone group throws", () => {
   // Tiny board:
   // B B B<B>
   // W W W -
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ab" });
-  game.playMove({ 0: "ba" });
-  game.playMove({ 1: "bb" });
-  game.playMove({ 0: "ca" });
-  game.playMove({ 1: "cb" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ab");
+  game.playMove(0, "ba");
+  game.playMove(1, "bb");
+  game.playMove(0, "ca");
+  game.playMove(1, "cb");
 
   //check that the final state is as expected
   expect(() => {
-    game.playMove({ 0: "da" });
+    game.playMove(0, "da");
   }).toThrow("four stones");
 });

--- a/packages/shared/src/variants/__tests__/thue_morse.test.ts
+++ b/packages/shared/src/variants/__tests__/thue_morse.test.ts
@@ -9,11 +9,11 @@ test("Play a game - wrong player", () => {
   const game = new ThueMorse({ width: 2, height: 2, komi: 0.5 });
 
   expect(game.nextToPlay()).toEqual([0]);
-  game.playMove({ 0: "aa" });
+  game.playMove(0, "aa");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "ab" });
+  game.playMove(1, "ab");
   expect(game.nextToPlay()).toEqual([1]);
-  expect(() => game.playMove({ 0: "ba" })).toThrow("It's not player 0's turn!");
+  expect(() => game.playMove(0, "ba")).toThrow("It's not player 0's turn!");
 });
 
 test("Play a game", () => {
@@ -22,15 +22,15 @@ test("Play a game", () => {
   // - W B -
   // - W B -
   expect(game.nextToPlay()).toEqual([0]);
-  game.playMove({ 0: "ca" });
+  game.playMove(0, "ca");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "ba" });
+  game.playMove(1, "ba");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "bb" });
+  game.playMove(1, "bb");
   expect(game.nextToPlay()).toEqual([0]);
-  game.playMove({ 0: "cb" });
+  game.playMove(0, "cb");
   expect(game.nextToPlay()).toEqual([1]);
-  game.playMove({ 1: "aa" });
+  game.playMove(1, "aa");
 
   // check that the final state is as expected
   expect(game.exportState().board).toEqual([
@@ -39,11 +39,11 @@ test("Play a game", () => {
   ]);
 
   expect(game.phase).toBe("play");
-  game.playMove({ 0: "pass" });
+  game.playMove(0, "pass");
   // technically, 0 is the next player in Thue-Morse, but
   // don't really need to force them to pass twice...
   expect(game.phase).toBe("play");
-  game.playMove({ 1: "pass" });
+  game.playMove(1, "pass");
 
   expect(game.phase).toBe("gameover");
   expect(game.result).toBe("W+0.5");
@@ -56,16 +56,16 @@ test("Play a game", () => {
 test("Player passes, but the other player wants to continue", () => {
   const game = new ThueMorse({ width: 19, height: 19, komi: 0.5 });
 
-  game.playMove({ 0: "aa" });
-  game.playMove({ 1: "ba" });
-  game.playMove({ 1: "bb" });
-  game.playMove({ 0: "ab" });
-  game.playMove({ 1: "bc" });
-  game.playMove({ 0: "pass" });
-  // game.playMove({ 0: "pass" }); <-- 0's next turn is skipped
-  game.playMove({ 1: "bd" });
-  game.playMove({ 1: "be" }); //   <-- Thue-morse sequence continues
-  game.playMove({ 0: "ac" });
-  game.playMove({ 0: "ad" });
-  game.playMove({ 1: "bf" });
+  game.playMove(0, "aa");
+  game.playMove(1, "ba");
+  game.playMove(1, "bb");
+  game.playMove(0, "ab");
+  game.playMove(1, "bc");
+  game.playMove(0, "pass");
+  // game.playMove(0, "pass"); <-- 0's next turn is skipped
+  game.playMove(1, "bd");
+  game.playMove(1, "be"); //   <-- Thue-morse sequence continues
+  game.playMove(0, "ac");
+  game.playMove(0, "ad");
+  game.playMove(1, "bf");
 });

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -2,7 +2,6 @@ import { AbstractGame } from "../../abstract_game";
 import type { IBadukBoard } from "./abstractBoard/Interfaces/IBadukBoard";
 import { BadukBoardAbstract } from "./abstractBoard/BadukBoardAbstract";
 import type { Intersection } from "./abstractBoard/intersection";
-import { getOnlyMove } from "../../lib/utils";
 
 export enum Color {
     EMPTY = 0,
@@ -30,8 +29,6 @@ export interface BadukWithAbstractBoardState {
     captures: { 0: number; 1: number };
 }
 
-type BadukMovesType = { 0: string } | { 1: string };
-
 export class BadukWithAbstractBoard extends AbstractGame<BadukWithAbstractBoardConfig, BadukWithAbstractBoardState> {
     board: BadukBoardAbstract;
     private next_to_play: 0 | 1 = 0;
@@ -55,8 +52,7 @@ export class BadukWithAbstractBoard extends AbstractGame<BadukWithAbstractBoardC
         return [this.next_to_play];
     }
 
-    playMove(moves: BadukMovesType): void {
-        const { player, move } = getOnlyMove(moves);
+    playMove(player: number, move: string): void {
         if (player != this.next_to_play) {
             throw Error(`It's not player ${player}'s turn!`);
         }

--- a/packages/shared/src/variants/capture.ts
+++ b/packages/shared/src/variants/capture.ts
@@ -1,8 +1,8 @@
 import { Baduk } from "./baduk";
 
 export class Capture extends Baduk {
-  playMove(move: { 0: string } | { 1: string }): void {
-    super.playMove(move);
+  playMove(player: number, move: string): void {
+    super.playMove(player, move);
     if (this.captures[0]) {
       this.phase = "gameover";
       this.result = "B+Capture";

--- a/packages/shared/src/variants/chess.ts
+++ b/packages/shared/src/variants/chess.ts
@@ -1,6 +1,5 @@
-import { AbstractGame, MovesType } from "../abstract_game";
+import { AbstractGame } from "../abstract_game";
 import { Chess } from "chess.js";
-import { getOnlyMove } from "../lib/utils";
 
 export interface ChessState {
   fen: string;
@@ -10,8 +9,7 @@ export class ChessGame extends AbstractGame<object, ChessState> {
   // third-party chess object
   private chess = new Chess();
 
-  playMove(moves: MovesType): void {
-    const { move, player } = getOnlyMove(moves);
+  playMove(player: number, move: string): void {
     if (player === 1 && "b" != this.chess.turn()) {
       throw Error("Not Black's turn");
     }

--- a/packages/shared/src/variants/fractional/fractional.test.ts
+++ b/packages/shared/src/variants/fractional/fractional.test.ts
@@ -37,15 +37,15 @@ test("Surrounded merge stone", () => {
   const neighbour1Id = game.firstCorner?.neighbours[1].id.toString() ?? "";
 
   // Round 1
-  game.playMove({ 0: neighbour0Id });
-  game.playMove({ 1: neighbour1Id });
-  game.playMove({ 2: cornerId });
+  game.playMove(0, neighbour0Id);
+  game.playMove(1, neighbour1Id);
+  game.playMove(2, cornerId);
   expect(game.firstCorner?.stone).toBeNull();
 
   // Round 2
-  game.playMove({ 0: cornerId });
-  game.playMove({ 1: cornerId });
-  game.playMove({ 2: cornerId });
+  game.playMove(0, cornerId);
+  game.playMove(1, cornerId);
+  game.playMove(2, cornerId);
 
   const state = game.exportState();
   expect(state.intersections.filter((i) => i.stone).length).toBe(2);

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -1,11 +1,9 @@
-import { MovesType } from "../../abstract_game";
 import { BadukIntersection } from "../../lib/abstractBaduk/badukIntersection";
 import {
   AbstractBaduk,
   AbstractBadukConfig,
 } from "../../lib/abstractBaduk/abstractBaduk";
 import { FractionalStone } from "./fractionalStone";
-import { getOnlyMove } from "../../lib/utils";
 
 export type Color =
   | "black"
@@ -56,10 +54,10 @@ export class Fractional extends AbstractBaduk<
     this.stagedMoves = this.stagedMovesDefaults();
   }
 
-  playMove(moves: MovesType): void {
-    const move = this.decodeMove(moves);
+  playMove(p: number, m: string): void {
+    const move = this.decodeMove(p, m);
     if (!move) {
-      throw new Error(`Couldn't decode move ${moves}`);
+      throw new Error(`Couldn't decode move ${{ player: p, move: m }}`);
     }
 
     if (move.intersection.stone) {
@@ -154,14 +152,13 @@ export class Fractional extends AbstractBaduk<
   }
 
   /** Asserts there is exactly one move of type FractionalMove and returns it */
-  private decodeMove(moves: MovesType): FractionalMove | null {
-    const move = getOnlyMove(moves);
-    const player = this.config.players[move.player];
+  private decodeMove(p: number, m: string): FractionalMove | null {
+    const player = this.config.players[p];
     const intersection = this.intersections.find(
-      (intersection) => intersection.id === Number.parseInt(move.move)
+      (intersection) => intersection.id === Number.parseInt(m)
     );
     return player && intersection
-      ? { player: { ...player, index: move.player }, intersection }
+      ? { player: { ...player, index: p }, intersection }
       : null;
   }
 

--- a/packages/shared/src/variants/freeze.ts
+++ b/packages/shared/src/variants/freeze.ts
@@ -2,16 +2,14 @@ import { Color } from "../lib/abstractAlternatingOnGrid";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";
 import { Grid } from "../lib/grid";
 import { getGroup, getOuterBorder } from "../lib/group_utils";
-import { getOnlyMove } from "../lib/utils";
 import { Baduk } from "./baduk";
 
 export class FreezeGo extends Baduk {
   private frozen = false;
 
-  playMove(moves: { 0: string } | { 1: string }) {
-    const { move, player } = getOnlyMove(moves);
+  playMove(player: number, move: string) {
     const captures_before = this.captures[player as 0 | 1];
-    super.playMove(moves);
+    super.playMove(player, move);
     const captures_after = this.captures[player as 0 | 1];
     if (this.frozen && captures_before !== captures_after) {
       throw new Error("Cannot capture after opponent ataris");

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -1,7 +1,7 @@
-import { AbstractGame, MovesType } from "../abstract_game";
+import { AbstractGame } from "../abstract_game";
 import { Coordinate } from "../lib/coordinate";
 import { Grid } from "../lib/grid";
-import { getOnlyMove } from "../lib/utils";
+import { MovesType } from "../lib/utils";
 
 export interface ParallelGoConfig {
   width: number;
@@ -54,9 +54,7 @@ export class ParallelGo extends AbstractGame<
     return [...Array(this.config.num_players).keys()];
   }
 
-  playMove(moves: MovesType): void {
-    const { player, move } = getOnlyMove(moves);
-
+  playMove(player: number, move: string): void {
     if (!Object.keys(this.specialMoves()).includes(move)) {
       const decoded_move = Coordinate.fromSgfRepr(move);
       const occupants = this.board.at(decoded_move);

--- a/packages/shared/src/variants/phantom.ts
+++ b/packages/shared/src/variants/phantom.ts
@@ -1,4 +1,3 @@
-import { MovesType } from "../abstract_game";
 import { Baduk, BadukState } from "./baduk";
 import { Color } from "../lib/abstractAlternatingOnGrid";
 import { Grid } from "../lib/grid";

--- a/packages/shared/src/variants/thue_morse.ts
+++ b/packages/shared/src/variants/thue_morse.ts
@@ -1,13 +1,10 @@
-import { getOnlyMove } from "../lib/utils";
-import { Baduk, BadukMove } from "./baduk";
+import { Baduk } from "./baduk";
 
 export class ThueMorse extends Baduk {
   private move_number = 0;
 
-  playMove(moves: BadukMove): void {
-    const { player, move } = getOnlyMove(moves);
-
-    super.playMove(moves);
+  playMove(player: number, move: string): void {
+    super.playMove(player, move);
 
     this.increment_next_to_play();
 

--- a/packages/vue-client/src/components/GameListItem.vue
+++ b/packages/vue-client/src/components/GameListItem.vue
@@ -2,6 +2,7 @@
 import {
   makeGameObject,
   type GameResponse,
+  getOnlyMove,
 } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import { board_map } from "@/board_map";
@@ -10,8 +11,9 @@ const props = defineProps<{ game: GameResponse }>();
 
 const game = computed(() => {
   const game_obj = makeGameObject(props.game.variant, props.game.config);
-  props.game.moves.forEach((move) => {
-    game_obj.playMove(move);
+  props.game.moves.forEach((m) => {
+    const { player, move } = getOnlyMove(m);
+    game_obj.playMove(player, move);
   });
   const state = game_obj.exportState();
   return {

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -2,6 +2,7 @@
 import {
   makeGameObject,
   type GameResponse,
+  getOnlyMove,
 } from "@ogfcommunity/variants-shared";
 import * as requests from "../requests";
 import SeatComponent from "@/components/SeatComponent.vue";
@@ -25,8 +26,9 @@ const game = computed(() => {
     return { result: null, state: null };
   }
   const game_obj = makeGameObject(gameResponse.variant, gameResponse.config);
-  gameResponse.moves.forEach((move) => {
-    game_obj.playMove(move);
+  gameResponse.moves.forEach((m) => {
+    const { player, move } = getOnlyMove(m);
+    game_obj.playMove(player, move);
   });
   const result =
     game_obj.phase === "gameover" ? game_obj.result || "Game over" : null;


### PR DESCRIPTION
Big PR, but the idea is simple:

```
- abstract playMove(moves: { [player: number]: string }): void;
+ abstract playMove(player: number, move: string): void;
```

Most variants are interested in the player and the move string, and they use `getOnlyMove` to parse these out of the `MovesType`.  Musings in #108 consider changing the format of the moves to reflect what the variant author needs.

In this PR, we parse out `player` and `move` before passing them into `playMove`.  There is no database migration necessary because it does not modify the format of the moves in the database.

**Note to reviewers:** I am mostly interested in your thoughts on the interface; does this API for `playMove` feel better than what we had before?