### PR TITLE
Upgrade typescript-eslint and fix lint errors

### DIFF
--- a/packages/server/.eslintrc.cjs
+++ b/packages/server/.eslintrc.cjs
@@ -10,5 +10,12 @@ module.exports = {
   root: true,
   rules: {
     "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,8 +31,8 @@
     "typescript": "^5.1.6"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.61.0",
-    "@typescript-eslint/parser": "^5.61.0",
+    "@typescript-eslint/eslint-plugin": "^6.1.0",
+    "@typescript-eslint/parser": "^6.1.0",
     "eslint": "^8.44.0",
     "prettier": "^3.0.0"
   }

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -47,7 +47,7 @@ router.post("/games", async (req, res) => {
   return;
 });
 
-router.post("/games/:gameId/move", async (req, res, next) => {
+router.post("/games/:gameId/move", async (req, res) => {
   const move: MovesType = req.body;
   const user_id = (req.user as User)?.id;
 

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -55,7 +55,6 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
-    move: string,
   ): Promise<void> {
     if (!HasTimeControlConfig(game.config)) {
       console.log("has no time control config");
@@ -126,10 +125,10 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
 
 class TimeHandlerParallelMoves implements ITimeHandler {
   handleMove(
-    game: GameResponse,
-    game_obj: AbstractGame<unknown, unknown>,
-    playerNr: number,
-    move: string,
+    _game: GameResponse,
+    _game_obj: AbstractGame<unknown, unknown>,
+    _playerNr: number,
+    _move: string,
   ): Promise<void> {
     console.log(
       "time control handler for parallel moves is not implemented yet",

--- a/packages/shared/.eslintrc.cjs
+++ b/packages/shared/.eslintrc.cjs
@@ -1,6 +1,23 @@
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
   root: true,
+  rules: {
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
+  },
+  overrides: [
+    {
+      files: ["*.test.ts", "*/__tests__/*"],
+      rules: {
+        "@typescript-eslint/no-explicit-any": 0,
+      },
+    },
+  ],
 };

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,8 +4,8 @@
   "main": "./dist/index.js",
   "devDependencies": {
     "@types/jest": "^29.5.2",
-    "@typescript-eslint/eslint-plugin": "^5.61.0",
-    "@typescript-eslint/parser": "^5.61.0",
+    "@typescript-eslint/eslint-plugin": "^6.1.0",
+    "@typescript-eslint/parser": "^6.1.0",
     "eslint": "^8.44.0",
     "jest": "^29.6.0",
     "prettier": "^3.0.0",

--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -14,6 +14,7 @@ import { Keima } from "./variants/keima";
 import { OneColorGo } from "./variants/one_color";
 
 export const game_map: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [variant: string]: new (config?: any) => AbstractGame;
 } = {
   baduk: Baduk,

--- a/packages/shared/src/lib/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
+++ b/packages/shared/src/lib/abstractAlternatingOnGrid/abstractAlternatingOnGrid.ts
@@ -87,15 +87,15 @@ export abstract class AbstractAlternatingOnGrid<
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  protected preValidateMove(move: string): void {}
+  protected preValidateMove(_move: string): void {}
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  protected postValidateMove(move: Coordinate): void {}
+  protected postValidateMove(_move: Coordinate): void {}
 
   protected playMoveInternal(move: Coordinate): void {
     this.board.set(move, this.next_to_play === 0 ? Color.BLACK : Color.WHITE);
   }
 
-  protected prepareForNextMove(move: string, decoded_move?: Coordinate): void {
+  protected prepareForNextMove(move: string, _decoded_move?: Coordinate): void {
     this.next_to_play = this.next_to_play === 0 ? 1 : 0;
     this.last_move = move;
   }

--- a/packages/shared/src/lib/abstractBaduk/abstractBaduk.test.ts
+++ b/packages/shared/src/lib/abstractBaduk/abstractBaduk.test.ts
@@ -1,10 +1,9 @@
-import { MovesType } from "../utils";
 import { AbstractBaduk, AbstractBadukConfig } from "./abstractBaduk";
 import { BadukIntersection, AbstractBadukStone } from "./badukIntersection";
 
 type TestState = "test";
 
-type TestChainType = "a" | "e";
+type TestChainType = "a" | "b" | "c" | "d" | "e";
 type TestIntersection = BadukIntersection<
   TestChainType,
   AbstractBadukStone<TestChainType>
@@ -64,7 +63,7 @@ class AbstractBadukTestGame extends AbstractBaduk<
     return this.findChainsWithoutLiberties(this.center, types, new Map());
   }
 
-  playMove(player: number, move: string): void {
+  playMove(_player: number, _move: string): void {
     throw new Error("Not implemented");
   }
 
@@ -72,11 +71,11 @@ class AbstractBadukTestGame extends AbstractBaduk<
     return { board: { type: "grid", height: 19, width: 19 } };
   }
 
-  exportState(player?: number): TestState {
+  exportState(_player?: number): TestState {
     return "test";
   }
 
-  importState(state: TestState): void {
+  importState(_state: TestState): void {
     throw new Error("Not implemented");
   }
 

--- a/packages/shared/src/lib/grid.ts
+++ b/packages/shared/src/lib/grid.ts
@@ -44,7 +44,7 @@ export class Grid<T> {
 
   map<S>(
     callbackfn: (value: T, index: Coordinate, grid: Grid<T>) => S,
-    thisArg?: any,
+    thisArg?: this,
   ): Grid<S> {
     const ret = new Grid<S>(this.width, this.height);
     ret.arr = this.arr.map(
@@ -61,7 +61,7 @@ export class Grid<T> {
 
   forEach(
     callbackfn: (value: T, index: Coordinate, grid: Grid<T>) => void,
-    thisArg?: any,
+    thisArg?: this,
   ): void {
     this.arr.forEach((value: T, flat_index: number) => {
       callbackfn(value, flat_index_to_coordinate(flat_index, this.width), this);

--- a/packages/shared/src/variants/__tests__/chess.test.ts
+++ b/packages/shared/src/variants/__tests__/chess.test.ts
@@ -1,8 +1,5 @@
 import { ChessGame } from "../chess";
 
-// A 3-letter placeholder helps with board alignment
-const ___ = null;
-
 test("Knight can move", () => {
   const game = new ChessGame();
 

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -2,7 +2,6 @@ import {
   AbstractAlternatingOnGrid,
   AbstractAlternatingOnGridConfig,
   AbstractAlternatingOnGridState,
-  isOutOfBounds,
   Color,
 } from "../lib/abstractAlternatingOnGrid";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/PolygonalBoardHelper.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/PolygonalBoardHelper.ts
@@ -449,10 +449,8 @@ export function CreatePolygonalBoard(size: number): Intersection[] {
     tileQueue = newTilesQueue;
   }
 
-  let completed = false;
   if (size % 2 === 0) {
     Tiles.forEach((tile) => tile.Complete());
-    completed = true;
   }
 
   const intersections: Intersection[] = [];

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -90,7 +90,6 @@ export class BadukWithAbstractBoard extends AbstractGame<
       );
     }
     const player_color = player === 0 ? Color.BLACK : Color.WHITE;
-    const opponent_color = player === 0 ? Color.WHITE : Color.BLACK;
     intersection.StoneState.Color = player_color;
 
     // Capture any opponent groups
@@ -99,7 +98,7 @@ export class BadukWithAbstractBoard extends AbstractGame<
         neighbour.StoneState.Color !== player_color &&
         !groupHasLiberties(neighbour, this.board)
       ) {
-        this.captures[player] += removeGroup(neighbour, this.board);
+        this.captures[player] += removeGroup(neighbour);
       }
     });
 
@@ -166,8 +165,8 @@ function groupHasLiberties(
  * Removes the group containing pos, and returns the number of stones removed
  * from the board.
  */
-function removeGroup(intersection: Intersection, board: IBadukBoard): number {
-  return floodFill(intersection, Color.EMPTY, board);
+function removeGroup(intersection: Intersection): number {
+  return floodFill(intersection, Color.EMPTY);
 }
 
 function isOutOfBounds(i: number, board: BadukBoardAbstract): boolean {
@@ -175,11 +174,7 @@ function isOutOfBounds(i: number, board: BadukBoardAbstract): boolean {
 }
 
 /** Fills area with the given color, and returns the number of spaces filled. */
-function floodFill(
-  intersection: Intersection,
-  target_color: Color,
-  board: IBadukBoard,
-): number {
+function floodFill(intersection: Intersection, target_color: Color): number {
   const starting_color = intersection.StoneState.Color;
   if (starting_color === target_color) {
     return 0;
@@ -199,9 +194,4 @@ function floodFill(
   }
 
   return helper(intersection);
-}
-
-/** Returns the number of occurrences for the given color */
-function countValueIn2dArray<T>(value: T, array: T[][]) {
-  return array.flat().filter((val) => val === value).length;
 }

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -116,10 +116,6 @@ export class Fractional extends AbstractBaduk<
     };
   }
 
-  importState(state: FractionalState): void {
-    throw new Error("Method not implemented.");
-  }
-
   nextToPlay(): number[] {
     return [...Array(this.config.players.length).keys()];
   }

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -1,7 +1,6 @@
 import { Baduk, BadukConfig } from "./baduk";
 import { Grid } from "../lib/grid";
 import { Color } from "../lib/abstractAlternatingOnGrid";
-import { Coordinate } from "../lib/coordinate";
 
 export class PyramidGo extends Baduk {
   private weights: Grid<number>;

--- a/packages/vue-client/.eslintrc.cjs
+++ b/packages/vue-client/.eslintrc.cjs
@@ -17,5 +17,12 @@ module.exports = {
   ],
   rules: {
     "prettier/prettier": ["error", { endOfLine: "auto" }],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
@@ -22,7 +22,7 @@ function emitConfigChange() {
 }
 
 const typeRef = ref(null);
-watch(typeRef, (next) => {
+watch(typeRef, () => {
   if (typeRef.value !== null) {
     config.type = typeRef.value;
   }

--- a/packages/vue-client/src/views/LoginView.vue
+++ b/packages/vue-client/src/views/LoginView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import * as requests from "@/requests";
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useStore } from "@/stores/user";

--- a/packages/vue-client/src/views/RegisterView.vue
+++ b/packages/vue-client/src/views/RegisterView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import * as requests from "@/requests";
 import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useStore } from "@/stores/user";

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,7 +632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.3.0":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.3.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
   dependencies:
@@ -647,6 +647,13 @@ __metadata:
   version: 4.5.0
   resolution: "@eslint-community/regexpp@npm:4.5.0"
   checksum: 99c01335947dbd7f2129e954413067e217ccaa4e219fe0917b7d2bd96135789384b8fedbfb8eb09584d5130b27a7b876a7150ab7376f51b3a0c377d5ce026a10
+  languageName: node
+  linkType: hard
+
+"@eslint-community/regexpp@npm:^4.5.1":
+  version: 4.6.1
+  resolution: "@eslint-community/regexpp@npm:4.6.1"
+  checksum: 5741f457f5cc4ec89389d185c44c511fc85ef3630c6ce033a64c779e72f7aa3a7d5bcdc45d54612989f0dc6ea958438c02d363797b3e4f87952fc6878481da0e
   languageName: node
   linkType: hard
 
@@ -1125,8 +1132,8 @@ __metadata:
     "@types/jsdom": ^21.1.1
     "@types/passport": ^1.0.12
     "@types/passport-local": ^1.0.35
-    "@typescript-eslint/eslint-plugin": ^5.61.0
-    "@typescript-eslint/parser": ^5.61.0
+    "@typescript-eslint/eslint-plugin": ^6.1.0
+    "@typescript-eslint/parser": ^6.1.0
     body-parser: ^1.20.2
     connect-mongo: ^5.0.0
     cors: ^2.8.5
@@ -1150,8 +1157,8 @@ __metadata:
   resolution: "@ogfcommunity/variants-shared@workspace:packages/shared"
   dependencies:
     "@types/jest": ^29.5.2
-    "@typescript-eslint/eslint-plugin": ^5.61.0
-    "@typescript-eslint/parser": ^5.61.0
+    "@typescript-eslint/eslint-plugin": ^6.1.0
+    "@typescript-eslint/parser": ^6.1.0
     chess.js: ^1.0.0-beta.6
     eslint: ^8.44.0
     jest: ^29.6.0
@@ -1504,6 +1511,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:^7.0.12":
+  version: 7.0.12
+  resolution: "@types/json-schema@npm:7.0.12"
+  checksum: 00239e97234eeb5ceefb0c1875d98ade6e922bfec39dd365ec6bd360b5c2f825e612ac4f6e5f1d13601b8b30f378f15e6faa805a3a732f4a1bbe61915163d293
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -1597,6 +1611,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "@types/semver@npm:7.5.0"
+  checksum: 0a64b9b9c7424d9a467658b18dd70d1d781c2d6f033096a6e05762d20ebbad23c1b69b0083b0484722aabf35640b78ccc3de26368bcae1129c87e9df028a22e2
+  languageName: node
+  linkType: hard
+
 "@types/serve-static@npm:*":
   version: 1.15.1
   resolution: "@types/serve-static@npm:1.15.1"
@@ -1684,7 +1705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^5.59.1, @typescript-eslint/eslint-plugin@npm:^5.61.0":
+"@typescript-eslint/eslint-plugin@npm:^5.59.1":
   version: 5.61.0
   resolution: "@typescript-eslint/eslint-plugin@npm:5.61.0"
   dependencies:
@@ -1708,7 +1729,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.59.1, @typescript-eslint/parser@npm:^5.61.0":
+"@typescript-eslint/eslint-plugin@npm:^6.1.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:6.2.0"
+  dependencies:
+    "@eslint-community/regexpp": ^4.5.1
+    "@typescript-eslint/scope-manager": 6.2.0
+    "@typescript-eslint/type-utils": 6.2.0
+    "@typescript-eslint/utils": 6.2.0
+    "@typescript-eslint/visitor-keys": 6.2.0
+    debug: ^4.3.4
+    graphemer: ^1.4.0
+    ignore: ^5.2.4
+    natural-compare: ^1.4.0
+    natural-compare-lite: ^1.4.0
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependencies:
+    "@typescript-eslint/parser": ^6.0.0 || ^6.0.0-alpha
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 1ef46b1c2e3e2013f66b4982dcfb9e198a3824cc1503b843e553201a108a3cb6e4adfb2c486158c89d993e5e4b9d99aeb2af28297e43da98c4750dae8f5131b5
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:^5.59.1":
   version: 5.61.0
   resolution: "@typescript-eslint/parser@npm:5.61.0"
   dependencies:
@@ -1725,6 +1772,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/parser@npm:^6.1.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/parser@npm:6.2.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": 6.2.0
+    "@typescript-eslint/types": 6.2.0
+    "@typescript-eslint/typescript-estree": 6.2.0
+    "@typescript-eslint/visitor-keys": 6.2.0
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: ba79674f2d4599a24c7afa8f18ec28243b80df39f82a4a6b7a4ce7c584ec37d4ade40a3aa058d597a5cbf71647a40d0995866748d14cf4b52d8ad4420d10f669
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:5.61.0":
   version: 5.61.0
   resolution: "@typescript-eslint/scope-manager@npm:5.61.0"
@@ -1732,6 +1797,16 @@ __metadata:
     "@typescript-eslint/types": 5.61.0
     "@typescript-eslint/visitor-keys": 5.61.0
   checksum: 6dfbb42c4b7d796ae3c395398bdfd2e5a4ae8aaf1448381278ecc39a1d1045af2cb452da5a00519d265bc1a5997523de22d5021acb4dbe1648502fe61512d3c6
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:6.2.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.2.0"
+  dependencies:
+    "@typescript-eslint/types": 6.2.0
+    "@typescript-eslint/visitor-keys": 6.2.0
+  checksum: 75a650a3ede78bf841a3bf3f4880b94a06aa4c420f399a6fb9faee19a2e5998f7e330a13f78e07c4958413345bab58b0593f09fa163a77e8f6353012e795660c
   languageName: node
   linkType: hard
 
@@ -1752,10 +1827,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/type-utils@npm:6.2.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/type-utils@npm:6.2.0"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 6.2.0
+    "@typescript-eslint/utils": 6.2.0
+    debug: ^4.3.4
+    ts-api-utils: ^1.0.1
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 9adb542fb3c49bf5c1fecca98549bee3fcfd28a0ceee5227817a1ceb0841b912e322f58ba1b3ca98a47fc998cbec0a3d69cacb9cf9ac4be1d133b11bb9d53aae
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:5.61.0":
   version: 5.61.0
   resolution: "@typescript-eslint/types@npm:5.61.0"
   checksum: d311ca2141f6bcb5f0f8f97ddbc218c9911e0735aaa30f0f2e64d518fb33568410754e1b04bf157175f8783504f8ec62a7ab53a66a18507f43edb1e21fe69e90
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.2.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/types@npm:6.2.0"
+  checksum: 81878866cf7f49dbc335cce05adfbd994f348e2ebe9538fd6e934fa82e44186c16b2112b8d5f9f4c528ea127be157185be5e35e4913db4880d20ac495785baaf
   languageName: node
   linkType: hard
 
@@ -1777,6 +1876,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:6.2.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.2.0"
+  dependencies:
+    "@typescript-eslint/types": 6.2.0
+    "@typescript-eslint/visitor-keys": 6.2.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 5bfd5bf09feff6c4807cfa65cf407dd0249f7d487d6820941dd05999ee35cacdabaacadf23c92b90b57920025e93088e93924bc8df41f393ac0366538eb2902f
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:5.61.0":
   version: 5.61.0
   resolution: "@typescript-eslint/utils@npm:5.61.0"
@@ -1795,6 +1912,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:6.2.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/utils@npm:6.2.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@types/json-schema": ^7.0.12
+    "@types/semver": ^7.5.0
+    "@typescript-eslint/scope-manager": 6.2.0
+    "@typescript-eslint/types": 6.2.0
+    "@typescript-eslint/typescript-estree": 6.2.0
+    semver: ^7.5.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 54f062412a8ce23554ca4063d275327981640426b1ecd1073d30dd8b9464ff7af68b8f9f6272033bad9307815d56f2f922faa8a995421efdccd6165dd62557e1
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.61.0":
   version: 5.61.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.61.0"
@@ -1802,6 +1936,16 @@ __metadata:
     "@typescript-eslint/types": 5.61.0
     eslint-visitor-keys: ^3.3.0
   checksum: a8d589f61ddfc380787218da4d347e8f9aef0f82f4a93f1daee46786bda889a90961c7ec1b470db5e3261438a728fdfd956f5bda6ee2de22c4be2d2152d6e270
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.2.0":
+  version: 6.2.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.2.0"
+  dependencies:
+    "@typescript-eslint/types": 6.2.0
+    eslint-visitor-keys: ^3.4.1
+  checksum: b400c657c7e5c65b289304f6f5cee6536f23b3441306f82aff2d2e047e13770330715d4f7b29e734b0b2dab6030e41028894d5cd441696115bfea43ad18b2c54
   languageName: node
   linkType: hard
 
@@ -4934,7 +5078,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ignore@npm:^5.2.0":
+"ignore@npm:^5.2.0, ignore@npm:^5.2.4":
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
   checksum: 3d4c309c6006e2621659311783eaea7ebcd41fe4ca1d78c91c473157ad6666a57a2df790fe0d07a12300d9aac2888204d7be8d59f9aaf665b1c7fcdb432517ef
@@ -7718,6 +7862,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
+  languageName: node
+  linkType: hard
+
 "semver@npm:~7.0.0":
   version: 7.0.0
   resolution: "semver@npm:7.0.0"
@@ -8451,6 +8606,15 @@ __metadata:
   dependencies:
     punycode: ^2.3.0
   checksum: aeeb821ac2cd792e63ec84888b4fd6598ac6ed75d861579e21a5cf9d4ee78b2c6b94e7d45036f2ca2088bc85b9b46560ad23c4482979421063b24137349dbd96
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "ts-api-utils@npm:1.0.1"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 78794fc7270d295b36c1ac613465b5dc7e7226907a533125b30f177efef9dd630d4e503b00be31b44335eb2ebf9e136ebe97353f8fc5d383885d5fead9d54c09
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There's starting to be a lot of noise in the linter from all the warnings.  Thought we should make them errors instead.  Turns out the typescript-eslint team was way ahead of me! https://github.com/typescript-eslint/typescript-eslint/issues/5959

I've provided a couple escape hatches since it isn't always straightforward to comply with the linter:

- unused variables are allowed if they are prefixed with an underscore (`_xyz`)
   - Especially necessary with overridden methods
   - I felt that the underscore is obvious enough, but not too obtrusive
- `any` is allowed in tests
    - I would hate to leave out a test just because it broke the type system!