### PR TITLE
add singleton service for timeout scheduling

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -49,14 +49,12 @@ export async function getGame(id: string): Promise<GameResponse> {
 
   // TODO: db_game might be undefined if unknown ID is provided
 
-  //console.log(db_game);
   const game = outwardFacingGame(db_game);
   // Legacy games don't have a players field
   // TODO: remove this code after doing proper db migration
   if (!game.players) {
     game.players = await BACKFILL_addEmptyPlayersArray(game);
   }
-  //console.log(game);
 
   return game;
 }

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -8,7 +8,7 @@ import {
 import { ObjectId, WithId, Document } from "mongodb";
 import { getDb } from "./db";
 import { io } from "./socket_io";
-import { getTimeoutService } from './index';
+import { getTimeoutService } from "./index";
 import {
   GetInitialTimeControl,
   HasTimeControlConfig,
@@ -38,7 +38,9 @@ export async function getGames(
 }
 
 export async function getGamesWithTimeControl(): Promise<GameResponse[]> {
-const games = gamesCollection().find({ time_control: { $ne: null } }).toArray();
+  const games = gamesCollection()
+    .find({ time_control: { $ne: null } })
+    .toArray();
   return (await games).map(outwardFacingGame);
 }
 
@@ -67,7 +69,7 @@ export async function createGame(
     variant: variant,
     moves: [] as MovesType[],
     config: config,
-    time_control: GetInitialTimeControl(variant, config)
+    time_control: GetInitialTimeControl(variant, config),
   };
 
   const result = await gamesCollection().insertOne(game);
@@ -121,10 +123,8 @@ export async function playMove(
     HasTimeControlConfig(game.config) &&
     ValidateTimeControlConfig(game.config.time_control)
   ) {
-
-    if (game_obj.result !== '') {
+    if (game_obj.result !== "") {
       getTimeoutService().clearGameTimeouts(game.id);
-
     } else {
       const timeHandler = new timeControlHandlerMap[game.variant]();
       timeControl = timeHandler.handleMove(game, game_obj, playerNr, new_move);
@@ -132,7 +132,10 @@ export async function playMove(
   }
 
   gamesCollection()
-    .updateOne({ _id: new ObjectId(game_id) }, { $push: { moves: moves }, $set: { time_control: timeControl } })
+    .updateOne(
+      { _id: new ObjectId(game_id) },
+      { $push: { moves: moves }, $set: { time_control: timeControl } },
+    )
     .catch(console.log);
 
   game.moves.push(moves);

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -49,14 +49,14 @@ export async function getGame(id: string): Promise<GameResponse> {
 
   // TODO: db_game might be undefined if unknown ID is provided
 
-  console.log(db_game);
+  //console.log(db_game);
   const game = outwardFacingGame(db_game);
   // Legacy games don't have a players field
   // TODO: remove this code after doing proper db migration
   if (!game.players) {
     game.players = await BACKFILL_addEmptyPlayersArray(game);
   }
-  console.log(game);
+  //console.log(game);
 
   return game;
 }
@@ -102,13 +102,13 @@ export async function playMove(
     throw Error("Game is already finished.");
   }
 
-  const move = getOnlyMove(moves);
+  const { player: playerNr, move: new_move } = getOnlyMove(moves);
 
-  if (!game.players || game.players[move.player] == null) {
-    throw Error(`Seat ${move.player} not occupied!`);
+  if (!game.players || game.players[playerNr] == null) {
+    throw Error(`Seat ${playerNr} not occupied!`);
   }
 
-  const expected_player = game.players[move.player];
+  const expected_player = game.players[playerNr];
 
   if (expected_player.id !== user_id) {
     throw Error(
@@ -116,8 +116,7 @@ export async function playMove(
     );
   }
 
-  const { player, move: new_move } = getOnlyMove(moves);
-  game_obj.playMove(player, new_move);
+  game_obj.playMove(playerNr, new_move);
 
   let timeControl = game.time_control;
   if (
@@ -130,7 +129,7 @@ export async function playMove(
 
     } else {
       const timeHandler = new timeControlHandlerMap[game.variant]();
-      timeControl = timeHandler.handleMove(game, game_obj, move.player, move.move);
+      timeControl = timeHandler.handleMove(game, game_obj, playerNr, new_move);
     }
   }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,7 +20,7 @@ import { router as apiRouter } from "./api";
 import * as socket_io from "./socket_io";
 import { TimeoutService } from "./timeout";
 
-const LOCAL_ORIGIN = "http://localhost:3000";
+const LOCAL_ORIGIN = "http://localhost:5173";
 
 passport.use(
   new LocalStrategy(async function (username, password, callback) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -43,10 +43,12 @@ export function getTimeoutService(): TimeoutService {
 }
 
 // Initialize MongoDB
-connectToDb().then(() => timeoutService.initialize()).catch((e) => {
-  console.log("Unable to connect to the database.");
-  console.log(e);
-});
+connectToDb()
+  .then(() => timeoutService.initialize())
+  .catch((e) => {
+    console.log("Unable to connect to the database.");
+    console.log(e);
+  });
 
 passport.use(
   "guest",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -37,8 +37,13 @@ passport.use(
   }),
 );
 
+const timeoutService = new TimeoutService();
+export function getTimeoutService(): TimeoutService {
+  return timeoutService;
+}
+
 // Initialize MongoDB
-connectToDb().catch((e) => {
+connectToDb().then(() => timeoutService.initialize()).catch((e) => {
   console.log("Unable to connect to the database.");
   console.log(e);
 });
@@ -131,8 +136,3 @@ const PORT = process.env.PORT || 3001;
 server.listen(PORT, () => {
   console.log(`listening on *:${PORT}`);
 });
-
-const timeoutService = new TimeoutService();
-export function getTimeoutService(): TimeoutService {
-  return timeoutService;
-}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -18,6 +18,7 @@ import { Strategy as LocalStrategy } from "passport-local";
 import { UserResponse } from "@ogfcommunity/variants-shared";
 import { router as apiRouter } from "./api";
 import * as socket_io from "./socket_io";
+import { TimeoutService } from "./timeout";
 
 const LOCAL_ORIGIN = "http://localhost:3000";
 
@@ -130,3 +131,8 @@ const PORT = process.env.PORT || 3001;
 server.listen(PORT, () => {
   console.log(`listening on *:${PORT}`);
 });
+
+const timeoutService = new TimeoutService();
+export function getTimeoutService(): TimeoutService {
+  return timeoutService;
+}

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -122,7 +122,8 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
         const timestamp = new Date();
 
         timeControl.moveTimestamps.push(timestamp);
-        if (!playerData.onThePlaySince === null) {
+        
+        if (playerData.onThePlaySince !== null) {
           playerData.remainingTimeMS -= timestamp.getTime() - playerData.onThePlaySince.getTime();
         }
         playerData.onThePlaySince = null;

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -15,7 +15,7 @@ import { getTimeoutService } from "./index";
  * properties for being a config with time control.
  */
 export function HasTimeControlConfig(
-  game_config: unknown,
+  game_config: unknown
 ): game_config is IConfigWithTimeControl {
   return (
     game_config &&
@@ -29,7 +29,7 @@ export function HasTimeControlConfig(
  * properties for being a time control config.
  */
 export function ValidateTimeControlConfig(
-  time_control_config: unknown,
+  time_control_config: unknown
 ): time_control_config is ITimeControlConfig {
   return (
     time_control_config &&
@@ -44,7 +44,7 @@ export function ValidateTimeControlConfig(
  * properties for being a basic time control data object.
  */
 export function ValidateTimeControlBase(
-  time_control: unknown,
+  time_control: unknown
 ): time_control is ITimeControlBase {
   return (
     time_control &&
@@ -60,7 +60,7 @@ export function ValidateTimeControlBase(
  */
 export function GetInitialTimeControl(
   variant: string,
-  config: object,
+  config: object
 ): ITimeControlBase | null {
   if (!HasTimeControlConfig(config)) return null;
 
@@ -76,7 +76,7 @@ export interface ITimeHandler {
    */
   initialState(
     variant: string,
-    config: IConfigWithTimeControl,
+    config: IConfigWithTimeControl
   ): ITimeControlBase;
 
   /**
@@ -88,7 +88,7 @@ export interface ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
-    move: string,
+    move: string
   ): ITimeControlBase;
 
   /**
@@ -106,7 +106,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
 
   initialState(
     variant: string,
-    config: IConfigWithTimeControl,
+    config: IConfigWithTimeControl
   ): ITimeControlBase {
     const numPlayers = makeGameObject(variant, config).numPlayers();
 
@@ -144,7 +144,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
   handleMove(
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
-    playerNr: number,
+    playerNr: number
   ): ITimeControlBase {
     const config = game.config as IConfigWithTimeControl;
 
@@ -176,7 +176,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
           this._timeoutService.scheduleTimeout(
             game.id,
             player,
-            timeControl.forPlayer[player].remainingTimeMS,
+            timeControl.forPlayer[player].remainingTimeMS
           );
         });
 
@@ -234,7 +234,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
 
   initialState(
     variant: string,
-    config: IConfigWithTimeControl,
+    config: IConfigWithTimeControl
   ): TimeControlParallel {
     const numPlayers = makeGameObject(variant, config).numPlayers();
 
@@ -274,7 +274,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
-    move: string,
+    move: string
   ): ITimeControlBase {
     const config = game.config as IConfigWithTimeControl;
 
@@ -289,7 +289,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
         const playerTimeControl = timeControl.forPlayer[playerNr];
         const timestamp = new Date();
 
-        if (!Object.keys(game_obj.specialMoves()).includes(move)) {
+        if (!(move === "resign") && !(move === "timeout")) {
           timeControl.forPlayer[playerNr].stagedMoveAt = timestamp;
 
           if (
@@ -298,7 +298,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
               timestamp.getTime() - playerTimeControl.onThePlaySince.getTime()
           ) {
             throw new Error(
-              "you can't change your move because it would reduce your remaining time to zero.",
+              "you can't change your move because it would reduce your remaining time to zero."
             );
           }
         }
@@ -316,7 +316,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
             .nextToPlay()
             .every(
               (player_nr) =>
-                timeControl.forPlayer[player_nr].stagedMoveAt !== null,
+                timeControl.forPlayer[player_nr].stagedMoveAt !== null
             )
         ) {
           for (const player_nr of game_obj.nextToPlay()) {
@@ -335,7 +335,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
             this._timeoutService.scheduleTimeout(
               game.id,
               player_nr,
-              timeControl.forPlayer[player_nr].remainingTimeMS,
+              timeControl.forPlayer[player_nr].remainingTimeMS
             );
             playerData.onThePlaySince = timestamp;
             playerData.stagedMoveAt = null;

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -15,7 +15,7 @@ import { getTimeoutService } from "./index";
  * properties for being a config with time control.
  */
 export function HasTimeControlConfig(
-  game_config: unknown
+  game_config: unknown,
 ): game_config is IConfigWithTimeControl {
   return (
     game_config &&
@@ -29,7 +29,7 @@ export function HasTimeControlConfig(
  * properties for being a time control config.
  */
 export function ValidateTimeControlConfig(
-  time_control_config: unknown
+  time_control_config: unknown,
 ): time_control_config is ITimeControlConfig {
   return (
     time_control_config &&
@@ -44,7 +44,7 @@ export function ValidateTimeControlConfig(
  * properties for being a basic time control data object.
  */
 export function ValidateTimeControlBase(
-  time_control: unknown
+  time_control: unknown,
 ): time_control is ITimeControlBase {
   return (
     time_control &&
@@ -60,7 +60,7 @@ export function ValidateTimeControlBase(
  */
 export function GetInitialTimeControl(
   variant: string,
-  config: object
+  config: object,
 ): ITimeControlBase | null {
   if (!HasTimeControlConfig(config)) return null;
 
@@ -76,7 +76,7 @@ export interface ITimeHandler {
    */
   initialState(
     variant: string,
-    config: IConfigWithTimeControl
+    config: IConfigWithTimeControl,
   ): ITimeControlBase;
 
   /**
@@ -88,7 +88,7 @@ export interface ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
-    move: string
+    move: string,
   ): ITimeControlBase;
 
   /**
@@ -106,7 +106,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
 
   initialState(
     variant: string,
-    config: IConfigWithTimeControl
+    config: IConfigWithTimeControl,
   ): ITimeControlBase {
     const numPlayers = makeGameObject(variant, config).numPlayers();
 
@@ -144,7 +144,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
   handleMove(
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
-    playerNr: number
+    playerNr: number,
   ): ITimeControlBase {
     const config = game.config as IConfigWithTimeControl;
 
@@ -176,7 +176,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
           this._timeoutService.scheduleTimeout(
             game.id,
             player,
-            timeControl.forPlayer[player].remainingTimeMS
+            timeControl.forPlayer[player].remainingTimeMS,
           );
         });
 
@@ -234,7 +234,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
 
   initialState(
     variant: string,
-    config: IConfigWithTimeControl
+    config: IConfigWithTimeControl,
   ): TimeControlParallel {
     const numPlayers = makeGameObject(variant, config).numPlayers();
 
@@ -274,7 +274,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
-    move: string
+    move: string,
   ): ITimeControlBase {
     const config = game.config as IConfigWithTimeControl;
 
@@ -298,7 +298,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
               timestamp.getTime() - playerTimeControl.onThePlaySince.getTime()
           ) {
             throw new Error(
-              "you can't change your move because it would reduce your remaining time to zero."
+              "you can't change your move because it would reduce your remaining time to zero.",
             );
           }
         }
@@ -316,7 +316,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
             .nextToPlay()
             .every(
               (player_nr) =>
-                timeControl.forPlayer[player_nr].stagedMoveAt !== null
+                timeControl.forPlayer[player_nr].stagedMoveAt !== null,
             )
         ) {
           for (const player_nr of game_obj.nextToPlay()) {
@@ -335,7 +335,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
             this._timeoutService.scheduleTimeout(
               game.id,
               player_nr,
-              timeControl.forPlayer[player_nr].remainingTimeMS
+              timeControl.forPlayer[player_nr].remainingTimeMS,
             );
             playerData.onThePlaySince = timestamp;
             playerData.stagedMoveAt = null;

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -81,7 +81,7 @@ export interface ITimeHandler {
 
   /**
    * Transitions the time control data when a move is played.
-   * Schedules timeouts for next players, and cancels old 
+   * Schedules timeouts for next players, and cancels old
    * scheduled timeouts if necessary.
    */
   handleMove(
@@ -288,9 +288,14 @@ class TimeHandlerParallelMoves implements ITimeHandler {
         const playerTimeControl = timeControl.forPlayer[playerNr];
         const timestamp = new Date();
 
-        if (playerTimeControl.onThePlaySince !== null && 
-          timeControl.forPlayer[playerNr].remainingTimeMS <= timestamp.getTime() - playerTimeControl.onThePlaySince.getTime()) {
-          throw new Error("you can't change your move because it would reduce your remaining time to zero.")
+        if (
+          playerTimeControl.onThePlaySince !== null &&
+          timeControl.forPlayer[playerNr].remainingTimeMS <=
+            timestamp.getTime() - playerTimeControl.onThePlaySince.getTime()
+        ) {
+          throw new Error(
+            "you can't change your move because it would reduce your remaining time to zero.",
+          );
         }
 
         timeControl.moveTimestamps.push(timestamp);

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -15,7 +15,7 @@ import { getTimeoutService } from "./index";
  * properties for being a config with time control.
  */
 export function HasTimeControlConfig(
-  game_config: unknown,
+  game_config: unknown
 ): game_config is IConfigWithTimeControl {
   return (
     game_config &&
@@ -29,7 +29,7 @@ export function HasTimeControlConfig(
  * properties for being a time control config.
  */
 export function ValidateTimeControlConfig(
-  time_control_config: unknown,
+  time_control_config: unknown
 ): time_control_config is ITimeControlConfig {
   return (
     time_control_config &&
@@ -44,7 +44,7 @@ export function ValidateTimeControlConfig(
  * properties for being a basic time control data object.
  */
 export function ValidateTimeControlBase(
-  time_control: unknown,
+  time_control: unknown
 ): time_control is ITimeControlBase {
   return (
     time_control &&
@@ -60,7 +60,7 @@ export function ValidateTimeControlBase(
  */
 export function GetInitialTimeControl(
   variant: string,
-  config: object,
+  config: object
 ): ITimeControlBase | null {
   if (!HasTimeControlConfig(config)) return null;
 
@@ -76,7 +76,7 @@ export interface ITimeHandler {
    */
   initialState(
     variant: string,
-    config: IConfigWithTimeControl,
+    config: IConfigWithTimeControl
   ): ITimeControlBase;
 
   /**
@@ -88,7 +88,7 @@ export interface ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
-    move: string,
+    move: string
   ): ITimeControlBase;
 
   /**
@@ -106,7 +106,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
 
   initialState(
     variant: string,
-    config: IConfigWithTimeControl,
+    config: IConfigWithTimeControl
   ): ITimeControlBase {
     const numPlayers = makeGameObject(variant, config).numPlayers();
 
@@ -144,7 +144,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
   handleMove(
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
-    playerNr: number,
+    playerNr: number
   ): ITimeControlBase {
     const config = game.config as IConfigWithTimeControl;
 
@@ -176,7 +176,7 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
           this._timeoutService.scheduleTimeout(
             game.id,
             player,
-            timeControl.forPlayer[player].remainingTimeMS,
+            timeControl.forPlayer[player].remainingTimeMS
           );
         });
 
@@ -234,7 +234,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
 
   initialState(
     variant: string,
-    config: IConfigWithTimeControl,
+    config: IConfigWithTimeControl
   ): TimeControlParallel {
     const numPlayers = makeGameObject(variant, config).numPlayers();
 
@@ -274,6 +274,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
+    move: string
   ): ITimeControlBase {
     const config = game.config as IConfigWithTimeControl;
 
@@ -288,18 +289,21 @@ class TimeHandlerParallelMoves implements ITimeHandler {
         const playerTimeControl = timeControl.forPlayer[playerNr];
         const timestamp = new Date();
 
-        if (
-          playerTimeControl.onThePlaySince !== null &&
-          timeControl.forPlayer[playerNr].remainingTimeMS <=
-            timestamp.getTime() - playerTimeControl.onThePlaySince.getTime()
-        ) {
-          throw new Error(
-            "you can't change your move because it would reduce your remaining time to zero.",
-          );
+        if (!Object.keys(game_obj.specialMoves()).includes(move)) {
+          timeControl.forPlayer[playerNr].stagedMoveAt = timestamp;
+
+          if (
+            playerTimeControl.onThePlaySince !== null &&
+            timeControl.forPlayer[playerNr].remainingTimeMS <=
+              timestamp.getTime() - playerTimeControl.onThePlaySince.getTime()
+          ) {
+            throw new Error(
+              "you can't change your move because it would reduce your remaining time to zero."
+            );
+          }
         }
 
         timeControl.moveTimestamps.push(timestamp);
-        timeControl.forPlayer[playerNr].stagedMoveAt = timestamp;
         this._timeoutService.clearPlayerTimeout(game.id, playerNr);
 
         // check if the round finishes with this move
@@ -312,7 +316,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
             .nextToPlay()
             .every(
               (player_nr) =>
-                timeControl.forPlayer[player_nr].stagedMoveAt !== null,
+                timeControl.forPlayer[player_nr].stagedMoveAt !== null
             )
         ) {
           for (const player_nr of game_obj.nextToPlay()) {
@@ -331,7 +335,7 @@ class TimeHandlerParallelMoves implements ITimeHandler {
             this._timeoutService.scheduleTimeout(
               game.id,
               player_nr,
-              timeControl.forPlayer[player_nr].remainingTimeMS,
+              timeControl.forPlayer[player_nr].remainingTimeMS
             );
             playerData.onThePlaySince = timestamp;
             playerData.stagedMoveAt = null;

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -120,7 +120,8 @@ class TimeHandlerSequentialMoves implements ITimeHandler {
         playerData.onThePlaySince = null;
         this._timeoutService.clearPlayerTimeout(game.id, playerNr);
 
-        const nextPlayers = game_obj.nextToPlay();
+        // filter out players who have not played any move yet
+        const nextPlayers = game_obj.nextToPlay().filter(playerNr => game.moves.some(move => playerNr in move));
         nextPlayers.forEach((player) => {
           timeControl.forPlayer[player].onThePlaySince = timestamp;
           this._timeoutService.scheduleTimeout(game.id, player, timeControl.forPlayer[player].remainingTimeMS)

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -12,7 +12,7 @@ import { getTimeoutService } from "./index";
 
 /**
  * Validates whether game_config has type and
- * properties for being a config with time control
+ * properties for being a config with time control.
  */
 export function HasTimeControlConfig(
   game_config: unknown,
@@ -26,7 +26,7 @@ export function HasTimeControlConfig(
 
 /**
  * Validates whether time_control_config has type and
- * properties for being a time control config
+ * properties for being a time control config.
  */
 export function ValidateTimeControlConfig(
   time_control_config: unknown,
@@ -41,7 +41,7 @@ export function ValidateTimeControlConfig(
 
 /**
  * Validates whether time_control has type and
- * properties for being a basic time control data object
+ * properties for being a basic time control data object.
  */
 export function ValidateTimeControlBase(
   time_control: unknown,
@@ -56,7 +56,7 @@ export function ValidateTimeControlBase(
 
 /**
  * Returns the initial state of a time control data object
- * for a new game, if it has time control at all
+ * for a new game, if it has time control at all.
  */
 export function GetInitialTimeControl(
   variant: string,
@@ -72,7 +72,7 @@ export function GetInitialTimeControl(
 export interface ITimeHandler {
   /**
    * Returns the initial state of a time control data object
-   * that this handler works with
+   * that this handler works with.
    */
   initialState(
     variant: string,
@@ -80,7 +80,9 @@ export interface ITimeHandler {
   ): ITimeControlBase;
 
   /**
-   * transition for the time control data when a move is played
+   * Transitions the time control data when a move is played.
+   * Schedules timeouts for next players, and cancels old 
+   * scheduled timeouts if necessary.
    */
   handleMove(
     game: GameResponse,
@@ -91,7 +93,7 @@ export interface ITimeHandler {
 
   /**
    * Returns the time in milliseconds until this player
-   * times out, provided no moves are played
+   * times out, provided no moves are played.
    */
   getMsUntilTimeout(game: GameResponse, playerNr: number): number;
 }
@@ -283,7 +285,13 @@ class TimeHandlerParallelMoves implements ITimeHandler {
           timeControl = this.initialState(game.variant, config);
         }
 
+        const playerTimeControl = timeControl.forPlayer[playerNr];
         const timestamp = new Date();
+
+        if (playerTimeControl.onThePlaySince !== null && 
+          timeControl.forPlayer[playerNr].remainingTimeMS <= timestamp.getTime() - playerTimeControl.onThePlaySince.getTime()) {
+          throw new Error("you can't change your move because it would reduce your remaining time to zero.")
+        }
 
         timeControl.moveTimestamps.push(timestamp);
         timeControl.forPlayer[playerNr].stagedMoveAt = timestamp;

--- a/packages/server/src/time-control.ts
+++ b/packages/server/src/time-control.ts
@@ -10,6 +10,10 @@ import { AbstractGame, GameResponse } from "@ogfcommunity/variants-shared";
 import { TimeoutService } from './timeout';
 import { getTimeoutService } from './index';
 
+/**
+ * Validates whether game_config has type and 
+ * properties for being a config with time control
+ */
 export function HasTimeControlConfig(
   game_config: unknown,
 ): game_config is IConfigWithTimeControl {
@@ -20,6 +24,10 @@ export function HasTimeControlConfig(
   );
 }
 
+/**
+ * Validates whether time_control_config has type and 
+ * properties for being a time control config
+ */
 export function ValidateTimeControlConfig(
   time_control_config: unknown,
 ): time_control_config is ITimeControlConfig {
@@ -31,6 +39,10 @@ export function ValidateTimeControlConfig(
   );
 }
 
+/**
+ * Validates whether time_control has type and 
+ * properties for being a basic time control data object
+ */
 export function ValidateTimeControlBase(
   time_control: unknown,
 ): time_control is ITimeControlBase {
@@ -42,6 +54,10 @@ export function ValidateTimeControlBase(
   );
 }
 
+/**
+ * Returns the initial state of a time control data object
+ * for a new game, if it has time control at all
+ */
 export function GetInitialTimeControl(variant: string, config: object): ITimeControlBase | null {
   if (!HasTimeControlConfig(config)) return null;
 
@@ -51,8 +67,16 @@ export function GetInitialTimeControl(variant: string, config: object): ITimeCon
 
 // validation of the config should happen before this is called
 export interface ITimeHandler {
+
+  /**
+   * Returns the initial state of a time control data object
+   * that this handler works with
+   */
   initialState(variant: string, config: IConfigWithTimeControl): ITimeControlBase;
 
+  /**
+   * transition for the time control data when a move is played
+   */
   handleMove(
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
@@ -60,6 +84,10 @@ export interface ITimeHandler {
     move: string,
   ): ITimeControlBase;
 
+  /**
+   * Returns the time in milliseconds until this player
+   * times out, provided no moves are played
+   */
   getMsUntilTimeout(game: GameResponse, playerNr: number): number;
 }
 

--- a/packages/server/src/timeout.ts
+++ b/packages/server/src/timeout.ts
@@ -1,135 +1,152 @@
 import { gamesCollection, getGame, getGamesWithTimeControl } from "./games";
 import {
-    MovesType,
-    getOnlyMove,
-    makeGameObject,
-  } from "@ogfcommunity/variants-shared";
+  MovesType,
+  getOnlyMove,
+  makeGameObject,
+} from "@ogfcommunity/variants-shared";
 import { timeControlHandlerMap } from "./time-control";
 import { ObjectId } from "mongodb";
 import { io } from "./socket_io";
 
 type GameTimeouts = {
-    // timeout for this player, or null
-    // used to clear the timeout timer
-    [player: number]: ReturnType<typeof setTimeout> | null
-}
+  // timeout for this player, or null
+  // used to clear the timeout timer
+  [player: number]: ReturnType<typeof setTimeout> | null;
+};
 
 export class TimeoutService {
-    private timeoutsByGame = new Map<string, GameTimeouts>();
+  private timeoutsByGame = new Map<string, GameTimeouts>();
 
-    constructor() {
-    }
+  constructor() {}
 
-    /**
-     * initializes timeout schedules
-     */
-    public async initialize(): Promise<void> {
-        // I would like to improve this by only querying unfinished games from db
-        // but currently I think its not possible, because of the game result
-        // is not being stored in the db directly
-        for (const game of (await getGamesWithTimeControl())) {
-            const game_object = makeGameObject(game.variant, game.config);
+  /**
+   * initializes timeout schedules
+   */
+  public async initialize(): Promise<void> {
+    // I would like to improve this by only querying unfinished games from db
+    // but currently I think its not possible, because of the game result
+    // is not being stored in the db directly
+    for (const game of await getGamesWithTimeControl()) {
+      const game_object = makeGameObject(game.variant, game.config);
 
-            try {
-                // check if game is already finished
-                game.moves.forEach((moves) => {
-                    const { player, move } = getOnlyMove(moves);
-                    game_object.playMove(player, move);
-                });
+      try {
+        // check if game is already finished
+        game.moves.forEach((moves) => {
+          const { player, move } = getOnlyMove(moves);
+          game_object.playMove(player, move);
+        });
 
-                if (game_object.result !== '') {
-                    continue
-                }
-
-                const timeHandler = new timeControlHandlerMap[game.variant]()
-                for (const playerNr of game_object.nextToPlay()) {
-                    const t = timeHandler.getMsUntilTimeout(game, playerNr)
-                    this.scheduleTimeout(game.id, playerNr, t);
-                }
-            }
-            catch (error) {
-                console.error(error);
-                continue;
-            }
-        }
-    }
-
-    /**
-     * stores a timeout-id or null for this player + game
-     * if an id was previously stored, the timeout is cleared
-     */
-    private setPlayerTimeout(gameId: string, playerNr: number, timeout: ReturnType<typeof setTimeout> | null): void {
-        let gameTimeouts = this.timeoutsByGame.get(gameId);
-
-        if (gameTimeouts === undefined) {
-            gameTimeouts = {};
-            this.timeoutsByGame.set(gameId, gameTimeouts);
-        }
-        else {
-            const playerTimeout = gameTimeouts[playerNr]
-            if (playerTimeout) {
-                clearTimeout(playerTimeout)
-            }
+        if (game_object.result !== "") {
+          continue;
         }
 
-        gameTimeouts[playerNr] = timeout;
-    }
-
-    /**
-     * clears the timeout-ids of this game
-     */
-    public clearGameTimeouts(gameId: string): void {
-        const gameTimeouts = this.timeoutsByGame.get(gameId)
-
-        if (gameTimeouts !== undefined) {
-            Object.values(gameTimeouts).filter(t => t !== null).forEach(clearTimeout);
-            this.timeoutsByGame.delete(gameId)
+        const timeHandler = new timeControlHandlerMap[game.variant]();
+        for (const playerNr of game_object.nextToPlay()) {
+          const t = timeHandler.getMsUntilTimeout(game, playerNr);
+          this.scheduleTimeout(game.id, playerNr, t);
         }
+      } catch (error) {
+        console.error(error);
+        continue;
+      }
+    }
+  }
+
+  /**
+   * stores a timeout-id or null for this player + game
+   * if an id was previously stored, the timeout is cleared
+   */
+  private setPlayerTimeout(
+    gameId: string,
+    playerNr: number,
+    timeout: ReturnType<typeof setTimeout> | null,
+  ): void {
+    let gameTimeouts = this.timeoutsByGame.get(gameId);
+
+    if (gameTimeouts === undefined) {
+      gameTimeouts = {};
+      this.timeoutsByGame.set(gameId, gameTimeouts);
+    } else {
+      const playerTimeout = gameTimeouts[playerNr];
+      if (playerTimeout) {
+        clearTimeout(playerTimeout);
+      }
     }
 
-    public clearPlayerTimeout(gameId: string, playerNr: number): void {
-        this.setPlayerTimeout(gameId, playerNr, null);
+    gameTimeouts[playerNr] = timeout;
+  }
+
+  /**
+   * clears the timeout-ids of this game
+   */
+  public clearGameTimeouts(gameId: string): void {
+    const gameTimeouts = this.timeoutsByGame.get(gameId);
+
+    if (gameTimeouts !== undefined) {
+      Object.values(gameTimeouts)
+        .filter((t) => t !== null)
+        .forEach(clearTimeout);
+      this.timeoutsByGame.delete(gameId);
     }
+  }
 
-    /**
-     * schedules a timeout for this player + game
-     * timeout is resolved by adding a timeout move
-     * and applying the time control handler again
-     */
-    public scheduleTimeout(gameId: string, playerNr: number, inTimeMs: number): void {
-        const timeoutResolver = async () => {
-            const game = await getGame(gameId)
+  public clearPlayerTimeout(gameId: string, playerNr: number): void {
+    this.setPlayerTimeout(gameId, playerNr, null);
+  }
 
-            const timeoutMove: MovesType = {[playerNr]: 'timeout'};
-            game.moves.push(timeoutMove);
-            let timeControl = game.time_control;
+  /**
+   * schedules a timeout for this player + game
+   * timeout is resolved by adding a timeout move
+   * and applying the time control handler again
+   */
+  public scheduleTimeout(
+    gameId: string,
+    playerNr: number,
+    inTimeMs: number,
+  ): void {
+    const timeoutResolver = async () => {
+      const game = await getGame(gameId);
 
-            // this next part is somewhat duplicated from the playMove function
-            // which I don't like. But for parallel variants and consistency (move timestamps),
-            // the timeout move needs to be handled as well.
-            const game_object = makeGameObject(game.variant, game.config);
-            game.moves.forEach((moves) => {
-                const { player, move } = getOnlyMove(moves);
-                game_object.playMove(player, move);
-            });
+      const timeoutMove: MovesType = { [playerNr]: "timeout" };
+      game.moves.push(timeoutMove);
+      let timeControl = game.time_control;
 
-            if (game_object.result !== '') {
-                this.clearGameTimeouts(game.id);
-          
-              } else {
-                const timeHandler = new timeControlHandlerMap[game.variant]();
-                timeControl = timeHandler.handleMove(game, game_object, playerNr, 'timeout');
-              }
+      // this next part is somewhat duplicated from the playMove function
+      // which I don't like. But for parallel variants and consistency (move timestamps),
+      // the timeout move needs to be handled as well.
+      const game_object = makeGameObject(game.variant, game.config);
+      game.moves.forEach((moves) => {
+        const { player, move } = getOnlyMove(moves);
+        game_object.playMove(player, move);
+      });
 
-            // TODO: improving the error handling would be great in future
-            await gamesCollection()
-            .updateOne({ _id: new ObjectId(gameId) }, { $push: { moves: timeoutMove }, $set: { time_control: timeControl } })
-            .catch(console.log);
+      if (game_object.result !== "") {
+        this.clearGameTimeouts(game.id);
+      } else {
+        const timeHandler = new timeControlHandlerMap[game.variant]();
+        timeControl = timeHandler.handleMove(
+          game,
+          game_object,
+          playerNr,
+          "timeout",
+        );
+      }
 
-            io().emit(`game/${gameId}`, game)
-        }
+      // TODO: improving the error handling would be great in future
+      await gamesCollection()
+        .updateOne(
+          { _id: new ObjectId(gameId) },
+          {
+            $push: { moves: timeoutMove },
+            $set: { time_control: timeControl },
+          },
+        )
+        .catch(console.log);
 
-        const timeout = setTimeout(timeoutResolver, inTimeMs);
-        this.setPlayerTimeout(gameId, playerNr, timeout);
-    }
+      io().emit(`game/${gameId}`, game);
+    };
+
+    const timeout = setTimeout(timeoutResolver, inTimeMs);
+    this.setPlayerTimeout(gameId, playerNr, timeout);
+  }
 }

--- a/packages/server/src/timeout.ts
+++ b/packages/server/src/timeout.ts
@@ -57,7 +57,7 @@ export class TimeoutService {
   private setPlayerTimeout(
     gameId: string,
     playerNr: number,
-    timeout: ReturnType<typeof setTimeout> | null
+    timeout: ReturnType<typeof setTimeout> | null,
   ): void {
     let gameTimeouts = this.timeoutsByGame.get(gameId);
 
@@ -100,7 +100,7 @@ export class TimeoutService {
   public scheduleTimeout(
     gameId: string,
     playerNr: number,
-    inTimeMs: number
+    inTimeMs: number,
   ): void {
     const timeoutResolver = async () => {
       const game = await getGame(gameId);
@@ -127,7 +127,7 @@ export class TimeoutService {
             game,
             game_object,
             playerNr,
-            "timeout"
+            "timeout",
           );
         }
       } catch (error) {
@@ -141,7 +141,7 @@ export class TimeoutService {
           {
             $push: { moves: timeoutMove },
             $set: { time_control: timeControl },
-          }
+          },
         )
         .catch(console.log);
 

--- a/packages/server/src/timeout.ts
+++ b/packages/server/src/timeout.ts
@@ -57,7 +57,7 @@ export class TimeoutService {
   private setPlayerTimeout(
     gameId: string,
     playerNr: number,
-    timeout: ReturnType<typeof setTimeout> | null,
+    timeout: ReturnType<typeof setTimeout> | null
   ): void {
     let gameTimeouts = this.timeoutsByGame.get(gameId);
 
@@ -100,7 +100,7 @@ export class TimeoutService {
   public scheduleTimeout(
     gameId: string,
     playerNr: number,
-    inTimeMs: number,
+    inTimeMs: number
   ): void {
     const timeoutResolver = async () => {
       const game = await getGame(gameId);
@@ -127,7 +127,7 @@ export class TimeoutService {
             game,
             game_object,
             playerNr,
-            "timeout",
+            "timeout"
           );
         }
       } catch (error) {
@@ -141,7 +141,7 @@ export class TimeoutService {
           {
             $push: { moves: timeoutMove },
             $set: { time_control: timeControl },
-          },
+          }
         )
         .catch(console.log);
 

--- a/packages/server/src/timeout.ts
+++ b/packages/server/src/timeout.ts
@@ -118,7 +118,7 @@ export class TimeoutService {
           const { player, move } = getOnlyMove(moves);
           game_object.playMove(player, move);
         });
-  
+
         if (game_object.result !== "" || game_object.phase === "gameover") {
           this.clearGameTimeouts(game.id);
         } else {
@@ -131,7 +131,7 @@ export class TimeoutService {
           );
         }
       } catch (error) {
-        console.error(error)
+        console.error(error);
       }
 
       // TODO: improving the error handling would be great in future

--- a/packages/server/src/timeout.ts
+++ b/packages/server/src/timeout.ts
@@ -83,7 +83,6 @@ export class TimeoutService {
 
     public scheduleTimeout(gameId: string, playerNr: number, inTimeMs: number): void {
         const timeoutResolver = async () => {
-            console.log('timeout triggered')
             const game = await getGame(gameId)
 
             const timeoutMove: MovesType = {[playerNr]: 'timeout'};

--- a/packages/server/src/timeout.ts
+++ b/packages/server/src/timeout.ts
@@ -20,6 +20,9 @@ export class TimeoutService {
     constructor() {
     }
 
+    /**
+     * initializes timeout schedules
+     */
     public async initialize(): Promise<void> {
         // I would like to improve this by only querying unfinished games from db
         // but currently I think its not possible, because of the game result
@@ -51,6 +54,10 @@ export class TimeoutService {
         }
     }
 
+    /**
+     * stores a timeout-id or null for this player + game
+     * if an id was previously stored, the timeout is cleared
+     */
     private setPlayerTimeout(gameId: string, playerNr: number, timeout: ReturnType<typeof setTimeout> | null): void {
         let gameTimeouts = this.timeoutsByGame.get(gameId);
 
@@ -68,6 +75,9 @@ export class TimeoutService {
         gameTimeouts[playerNr] = timeout;
     }
 
+    /**
+     * clears the timeout-ids of this game
+     */
     public clearGameTimeouts(gameId: string): void {
         const gameTimeouts = this.timeoutsByGame.get(gameId)
 
@@ -81,6 +91,11 @@ export class TimeoutService {
         this.setPlayerTimeout(gameId, playerNr, null);
     }
 
+    /**
+     * schedules a timeout for this player + game
+     * timeout is resolved by adding a timeout move
+     * and applying the time control handler again
+     */
     public scheduleTimeout(gameId: string, playerNr: number, inTimeMs: number): void {
         const timeoutResolver = async () => {
             const game = await getGame(gameId)

--- a/packages/server/src/timeout.ts
+++ b/packages/server/src/timeout.ts
@@ -1,0 +1,56 @@
+type GameTimeouts = {
+    // timeout for this player, or null
+    // used to clear the timer
+    [player: number]: ReturnType<typeof setTimeout> | null
+}
+
+export class TimeoutService {
+    private timeoutsByGame = new Map<string, GameTimeouts>();
+
+    constructor() {
+        
+    }
+
+    public initialize(): void {
+
+    }
+
+    private setPlayerTimeout(gameId: string, playerNr: number, timeout: ReturnType<typeof setTimeout> | null): void {
+        let gameTimeouts = this.timeoutsByGame.get(gameId);
+
+        if (gameTimeouts === undefined) {
+            gameTimeouts = {};
+            this.timeoutsByGame.set(gameId, gameTimeouts);
+        }
+        else {
+            const playerTimeout = gameTimeouts[playerNr]
+            if (playerTimeout) {
+                clearTimeout(playerTimeout)
+            }
+        }
+
+        gameTimeouts[playerNr] = timeout;
+    }
+
+    public clearGameTimeouts(gameId: string): void {
+        let gameTimeouts = this.timeoutsByGame.get(gameId)
+
+        if (gameTimeouts !== undefined) {
+            Object.values(gameTimeouts).filter(t => t !== null).forEach(clearTimeout);
+            this.timeoutsByGame.delete(gameId)
+        }
+    }
+
+    public clearPlayerTimeout(gameId: string, playerNr: number): void {
+        this.setPlayerTimeout(gameId, playerNr, null);
+    }
+
+    public scheduleTimeout(gameId: string, playerNr: number, inTimeMs: number): void {
+        let timeout = setTimeout(() => {
+            // TODO
+            console.log(`player nr ${playerNr} timed out`)
+        }, inTimeMs);
+
+        this.setPlayerTimeout(gameId, playerNr, timeout);
+    }
+}

--- a/packages/shared/src/abstract_game.ts
+++ b/packages/shared/src/abstract_game.ts
@@ -27,6 +27,7 @@ export abstract class AbstractGame<GameConfig = object, GameState = object> {
 
   /**
    * Returns the list of players that need to play a move the next round.
+   * Returns empty array when the game is finished.
    */
   abstract nextToPlay(): number[];
 

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -18,6 +18,6 @@ export function getOnlyMove(moves: MovesType): {
 }
 
 export type Participation = {
-  playerNr: number,
-  dropOutAtRound: number | null
+  playerNr: number;
+  dropOutAtRound: number | null;
 };

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -16,3 +16,8 @@ export function getOnlyMove(moves: MovesType): {
   const player = Number(players[0]);
   return { player, move: moves[player] };
 }
+
+export type Participation = {
+  playerNr: number,
+  dropOutAtRound: number | null
+};

--- a/packages/shared/src/time_control/time_control.types.ts
+++ b/packages/shared/src/time_control/time_control.types.ts
@@ -29,3 +29,14 @@ export interface ITimeControlBase {
     [player: number]: IPerPlayerTimeControlBase;
   };
 }
+
+export type PerPlayerTimeControlParallel = IPerPlayerTimeControlBase & {
+  stagedMoveAt: Date | null;
+}
+
+export type TimeControlParallel = {
+  moveTimestamps: Date[];
+  forPlayer: {
+    [player: number]: PerPlayerTimeControlParallel;
+  };
+}

--- a/packages/shared/src/time_control/time_control.types.ts
+++ b/packages/shared/src/time_control/time_control.types.ts
@@ -32,11 +32,11 @@ export interface ITimeControlBase {
 
 export type PerPlayerTimeControlParallel = IPerPlayerTimeControlBase & {
   stagedMoveAt: Date | null;
-}
+};
 
 export type TimeControlParallel = {
   moveTimestamps: Date[];
   forPlayer: {
     [player: number]: PerPlayerTimeControlParallel;
   };
-}
+};

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -52,7 +52,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
   }
 
   override nextToPlay(): number[] {
-    return [this.next_to_play];
+    return this.phase === "gameover" ? [] : [this.next_to_play];
   }
 
   override playMove(player: number, move: string): void {

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -37,7 +37,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
   constructor(config?: BadukConfig) {
     super(config);
     this.board = new Grid<Color>(this.config.width, this.config.height).fill(
-      Color.EMPTY
+      Color.EMPTY,
     );
   }
 
@@ -78,12 +78,12 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
       const color = this.board.at(decoded_move);
       if (color === undefined) {
         throw Error(
-          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`
+          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`,
         );
       }
       if (color !== Color.EMPTY) {
         throw Error(
-          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`
+          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`,
         );
       }
 
@@ -166,7 +166,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
 
     const black_points: number = board.reduce(
       count_color<Color>(Color.BLACK),
-      0
+      0,
     );
     const white_points: number =
       board.reduce(count_color<Color>(Color.WHITE), 0) + this.config.komi;

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -66,6 +66,12 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
       return;
     }
 
+    if (move === "timeout") {
+      this.phase = "gameover"
+      this.result = player === 0 ? "W+T" : "B+T"
+      return;
+    }
+
     if (move != "pass") {
       const decoded_move = Coordinate.fromSgfRepr(move);
       const { x, y } = decoded_move;
@@ -94,7 +100,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
   }
 
   override specialMoves() {
-    return { pass: "Pass", resign: "Resign" };
+    return { pass: "Pass", resign: "Resign", timeout: "Timeout" };
   }
 
   private playMoveInternal(move: Coordinate): void {

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -37,7 +37,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
   constructor(config?: BadukConfig) {
     super(config);
     this.board = new Grid<Color>(this.config.width, this.config.height).fill(
-      Color.EMPTY,
+      Color.EMPTY
     );
   }
 
@@ -67,8 +67,8 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
     }
 
     if (move === "timeout") {
-      this.phase = "gameover"
-      this.result = player === 0 ? "W+T" : "B+T"
+      this.phase = "gameover";
+      this.result = player === 0 ? "W+T" : "B+T";
       return;
     }
 
@@ -78,12 +78,12 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
       const color = this.board.at(decoded_move);
       if (color === undefined) {
         throw Error(
-          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`,
+          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`
         );
       }
       if (color !== Color.EMPTY) {
         throw Error(
-          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`,
+          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`
         );
       }
 
@@ -166,7 +166,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
 
     const black_points: number = board.reduce(
       count_color<Color>(Color.BLACK),
-      0,
+      0
     );
     const white_points: number =
       board.reduce(count_color<Color>(Color.WHITE), 0) + this.config.komi;

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -77,22 +77,22 @@ export class BadukWithAbstractBoard extends AbstractGame<
     }
 
     if (move === "timeout") {
-      this.phase = "gameover"
-      this.result = player === 0 ? "W+T" : "B+T"
+      this.phase = "gameover";
+      this.result = player === 0 ? "W+T" : "B+T";
       return;
     }
 
     const decoded_move = decodeMove(move);
     if (isOutOfBounds(decoded_move, this.board)) {
       throw Error(
-        `Move out of bounds. (move: ${decoded_move}, intersections: ${this.board.Intersections.length}`,
+        `Move out of bounds. (move: ${decoded_move}, intersections: ${this.board.Intersections.length}`
       );
     }
     const intersection = this.board.Intersections[decoded_move];
 
     if (intersection.StoneState.Color != Color.EMPTY) {
       throw Error(
-        `Cannot place a stone on top of an existing stone. (${intersection.StoneState.Color} at (${decoded_move}))`,
+        `Cannot place a stone on top of an existing stone. (${intersection.StoneState.Color} at (${decoded_move}))`
       );
     }
     const player_color = player === 0 ? Color.BLACK : Color.WHITE;
@@ -141,7 +141,7 @@ function decodeMove(move: string): number {
 /** Returns true if the group containing intersection has at least one liberty. */
 function groupHasLiberties(
   intersection: Intersection,
-  board: BadukBoardAbstract,
+  board: BadukBoardAbstract
 ) {
   const color = intersection.StoneState.Color;
   const visited: { [key: string]: boolean } = {};
@@ -195,7 +195,7 @@ function floodFill(intersection: Intersection, target_color: Color): number {
 
     return intersection.Neighbours.map(helper).reduce(
       (acc, val) => acc + val,
-      1,
+      1
     );
   }
 

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -52,7 +52,7 @@ export class BadukWithAbstractBoard extends AbstractGame<
   }
 
   nextToPlay(): number[] {
-    return [this.next_to_play];
+    return this.phase === "gameover" ? [] : [this.next_to_play];
   }
 
   playMove(player: number, move: string): void {

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -76,6 +76,12 @@ export class BadukWithAbstractBoard extends AbstractGame<
       return;
     }
 
+    if (move === "timeout") {
+      this.phase = "gameover"
+      this.result = player === 0 ? "W+T" : "B+T"
+      return;
+    }
+
     const decoded_move = decodeMove(move);
     if (isOutOfBounds(decoded_move, this.board)) {
       throw Error(
@@ -120,7 +126,7 @@ export class BadukWithAbstractBoard extends AbstractGame<
   }
 
   specialMoves() {
-    return { pass: "Pass", resign: "Resign" };
+    return { pass: "Pass", resign: "Resign", timeout: "Timeout" };
   }
 
   defaultConfig(): BadukWithAbstractBoardConfig {

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -85,14 +85,14 @@ export class BadukWithAbstractBoard extends AbstractGame<
     const decoded_move = decodeMove(move);
     if (isOutOfBounds(decoded_move, this.board)) {
       throw Error(
-        `Move out of bounds. (move: ${decoded_move}, intersections: ${this.board.Intersections.length}`
+        `Move out of bounds. (move: ${decoded_move}, intersections: ${this.board.Intersections.length}`,
       );
     }
     const intersection = this.board.Intersections[decoded_move];
 
     if (intersection.StoneState.Color != Color.EMPTY) {
       throw Error(
-        `Cannot place a stone on top of an existing stone. (${intersection.StoneState.Color} at (${decoded_move}))`
+        `Cannot place a stone on top of an existing stone. (${intersection.StoneState.Color} at (${decoded_move}))`,
       );
     }
     const player_color = player === 0 ? Color.BLACK : Color.WHITE;
@@ -141,7 +141,7 @@ function decodeMove(move: string): number {
 /** Returns true if the group containing intersection has at least one liberty. */
 function groupHasLiberties(
   intersection: Intersection,
-  board: BadukBoardAbstract
+  board: BadukBoardAbstract,
 ) {
   const color = intersection.StoneState.Color;
   const visited: { [key: string]: boolean } = {};
@@ -195,7 +195,7 @@ function floodFill(intersection: Intersection, target_color: Color): number {
 
     return intersection.Neighbours.map(helper).reduce(
       (acc, val) => acc + val,
-      1
+      1,
     );
   }
 

--- a/packages/shared/src/variants/chess.ts
+++ b/packages/shared/src/variants/chess.ts
@@ -17,7 +17,7 @@ export class ChessGame extends AbstractGame<object, ChessState> {
     }
 
     if (move === "timeout") {
-      this.phase = "gameover"
+      this.phase = "gameover";
       this.result = player === 0 ? "B+T" : "W+T";
       return;
     }

--- a/packages/shared/src/variants/chess.ts
+++ b/packages/shared/src/variants/chess.ts
@@ -10,6 +10,18 @@ export class ChessGame extends AbstractGame<object, ChessState> {
   private chess = new Chess();
 
   playMove(player: number, move: string): void {
+    if (move === "resign") {
+      this.phase = "gameover";
+      this.result = player === 0 ? "B+R" : "W+R";
+      return;
+    }
+
+    if (move === "timeout") {
+      this.phase = "gameover"
+      this.result = player === 0 ? "B+T" : "W+T";
+      return;
+    }
+
     if (player === 1 && "b" != this.chess.turn()) {
       throw Error("Not Black's turn");
     }

--- a/packages/shared/src/variants/chess.ts
+++ b/packages/shared/src/variants/chess.ts
@@ -35,7 +35,7 @@ export class ChessGame extends AbstractGame<object, ChessState> {
     return { fen: this.chess.fen() };
   }
   nextToPlay(): number[] {
-    return [this.chess.turn() == "b" ? 1 : 0];
+    return this.phase === "gameover" ? [] : [this.chess.turn() == "b" ? 1 : 0];
   }
   numPlayers(): number {
     return 2;

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -62,7 +62,7 @@ export class Fractional extends AbstractBaduk<
 
     if (move.intersection.stone) {
       throw new Error(
-        `There is already a stone at intersection ${move.intersection.id}`
+        `There is already a stone at intersection ${move.intersection.id}`,
       );
     }
 
@@ -71,7 +71,7 @@ export class Fractional extends AbstractBaduk<
     if (
       this.stagedMoves.every(
         (stagedMove): stagedMove is FractionalIntersection =>
-          stagedMove !== null
+          stagedMove !== null,
       )
     ) {
       this.intersections.forEach((intersection) => {
@@ -153,7 +153,7 @@ export class Fractional extends AbstractBaduk<
   private decodeMove(p: number, m: string): FractionalMove | null {
     const player = this.config.players[p];
     const intersection = this.intersections.find(
-      (intersection) => intersection.id === Number.parseInt(m)
+      (intersection) => intersection.id === Number.parseInt(m),
     );
     return player && intersection
       ? { player: { ...player, index: p }, intersection }
@@ -162,7 +162,7 @@ export class Fractional extends AbstractBaduk<
 
   private stagedMovesDefaults(): (FractionalIntersection | null)[] {
     return new Array<FractionalIntersection | null>(this.numPlayers()).fill(
-      null
+      null,
     );
   }
 }

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -64,26 +64,31 @@ export class Fractional extends AbstractBaduk<
       if (this.nextToPlay().length < 2) {
         this.phase = 'gameover';
         // TODO: declare winner
+
+        return;
+      }
+    } else {
+      // stage move
+
+      const move = this.decodeMove(p, m);
+      if (!move) {
+        throw new Error(`Couldn't decode move ${{ player: p, move: m }}`);
       }
 
-      return;
+      if (move.intersection.stone) {
+        throw new Error(
+          `There is already a stone at intersection ${move.intersection.id}`,
+        );
+      }
+
+      if (!this.nextToPlay().includes(p)) {
+        throw new Error('Not your turn')
+      }
+
+      this.stagedMoves[move.player.index] = move.intersection;
     }
 
-    const move = this.decodeMove(p, m);
-    if (!move) {
-      throw new Error(`Couldn't decode move ${{ player: p, move: m }}`);
-    }
-
-    if (move.intersection.stone) {
-      throw new Error(
-        `There is already a stone at intersection ${move.intersection.id}`,
-      );
-    }
-
-    this.stagedMoves[move.player.index] = move.intersection;
-
-    if (
-      this.stagedMoves.every(
+    if (this.stagedMoves.every(
         (stagedMove, playerNr): stagedMove is FractionalIntersection =>
           stagedMove !== null || !this.nextToPlay().includes(playerNr),
       )
@@ -94,7 +99,7 @@ export class Fractional extends AbstractBaduk<
 
       // place all moves and proceed to next round
       const playedIntersections = new Set<FractionalIntersection>();
-      this.stagedMoves.forEach((intersection, playerId) => {
+      this.stagedMoves.filter(x => x !== null).forEach((intersection, playerId) => {
         playedIntersections.add(intersection);
         const colors =
           intersection.stone?.colors ??

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -62,7 +62,7 @@ export class Fractional extends AbstractBaduk<
 
     if (move.intersection.stone) {
       throw new Error(
-        `There is already a stone at intersection ${move.intersection.id}`,
+        `There is already a stone at intersection ${move.intersection.id}`
       );
     }
 
@@ -71,7 +71,7 @@ export class Fractional extends AbstractBaduk<
     if (
       this.stagedMoves.every(
         (stagedMove): stagedMove is FractionalIntersection =>
-          stagedMove !== null,
+          stagedMove !== null
       )
     ) {
       this.intersections.forEach((intersection) => {
@@ -117,7 +117,9 @@ export class Fractional extends AbstractBaduk<
   }
 
   nextToPlay(): number[] {
-    return this.phase === "gameover" ? [] : [...Array(this.config.players.length).keys()];
+    return this.phase === "gameover"
+      ? []
+      : [...Array(this.config.players.length).keys()];
   }
 
   numPlayers(): number {
@@ -151,7 +153,7 @@ export class Fractional extends AbstractBaduk<
   private decodeMove(p: number, m: string): FractionalMove | null {
     const player = this.config.players[p];
     const intersection = this.intersections.find(
-      (intersection) => intersection.id === Number.parseInt(m),
+      (intersection) => intersection.id === Number.parseInt(m)
     );
     return player && intersection
       ? { player: { ...player, index: p }, intersection }
@@ -160,7 +162,7 @@ export class Fractional extends AbstractBaduk<
 
   private stagedMovesDefaults(): (FractionalIntersection | null)[] {
     return new Array<FractionalIntersection | null>(this.numPlayers()).fill(
-      null,
+      null
     );
   }
 }

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -76,10 +76,11 @@ export class ParallelGo extends AbstractGame<
       this.playerParticipation[player].dropOutAtRound = this.numberOfRounds;
 
       if (this.nextToPlay().length < 2) {
-        this.phase = 'gameover';
         if (this.nextToPlay().length === 1) {
           this.result = `Player ${this.nextToPlay()[0]} wins!`;
         }
+        
+        this.phase = 'gameover';
         return
       }
     }

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -78,16 +78,19 @@ export class ParallelGo extends AbstractGame<
       if (this.nextToPlay().length < 2) {
         this.phase = 'gameover';
         // TODO: declare winner
+        return
       }
-
-      return;
     }
-
-    if (!this.nextToPlay().includes(player)) {
-      throw new Error('Not your turn')
+    else
+    {
+      // stage move
+      
+      if (!this.nextToPlay().includes(player)) {
+        throw new Error('Not your turn')
+      }
+  
+      this.staged[player] = move;
     }
-
-    this.staged[player] = move;
 
     if (this.nextToPlay().some(playerNr => !(playerNr in this.staged))) {
       // Don't play moves until everybody has staged a move
@@ -127,7 +130,6 @@ export class ParallelGo extends AbstractGame<
     this.last_round = this.staged;
     this.staged = {};
     this.numberOfRounds++;
-    console.log(this.numberOfRounds)
   }
 
   numPlayers(): number {

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -53,7 +53,7 @@ export class ParallelGo extends AbstractGame<
   }
 
   nextToPlay(): number[] {
-    return this.playerParticipation
+    return this.phase === "gameover" ? [] : this.playerParticipation
     .filter(x => x.dropOutAtRound === null || x.dropOutAtRound > this.numberOfRounds)
     .map(p => p.playerNr)
   }
@@ -77,7 +77,9 @@ export class ParallelGo extends AbstractGame<
 
       if (this.nextToPlay().length < 2) {
         this.phase = 'gameover';
-        // TODO: declare winner
+        if (this.nextToPlay().length === 1) {
+          this.result = `Player ${this.nextToPlay()[0]} wins!`;
+        }
         return
       }
     }

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -30,7 +30,9 @@ export class ParallelGo extends AbstractGame<
   private board: Grid<number[]>;
   private staged: MovesType = {};
   private last_round: MovesType = {};
-  private playerParticipation = this.initializeParticipation(this.config.num_players);
+  private playerParticipation = this.initializeParticipation(
+    this.config.num_players
+  );
   private numberOfRounds: number = 0;
 
   constructor(config?: ParallelGoConfig) {
@@ -53,9 +55,15 @@ export class ParallelGo extends AbstractGame<
   }
 
   nextToPlay(): number[] {
-    return this.phase === "gameover" ? [] : this.playerParticipation
-    .filter(x => x.dropOutAtRound === null || x.dropOutAtRound > this.numberOfRounds)
-    .map(p => p.playerNr)
+    return this.phase === "gameover"
+      ? []
+      : this.playerParticipation
+          .filter(
+            (x) =>
+              x.dropOutAtRound === null ||
+              x.dropOutAtRound > this.numberOfRounds
+          )
+          .map((p) => p.playerNr);
   }
 
   playMove(player: number, move: string): void {
@@ -64,7 +72,7 @@ export class ParallelGo extends AbstractGame<
       const occupants = this.board.at(decoded_move);
       if (occupants === undefined) {
         throw Error(
-          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.board.width}x${this.board.height}`,
+          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.board.width}x${this.board.height}`
         );
       }
       if (occupants.length !== 0) {
@@ -72,30 +80,28 @@ export class ParallelGo extends AbstractGame<
       }
     }
 
-    if (move === 'resign' || move === 'timeout') {
+    if (move === "resign" || move === "timeout") {
       this.playerParticipation[player].dropOutAtRound = this.numberOfRounds;
 
       if (this.nextToPlay().length < 2) {
         if (this.nextToPlay().length === 1) {
           this.result = `Player ${this.nextToPlay()[0]} wins!`;
         }
-        
-        this.phase = 'gameover';
-        return
+
+        this.phase = "gameover";
+        return;
       }
-    }
-    else
-    {
+    } else {
       // stage move
-      
+
       if (!this.nextToPlay().includes(player)) {
-        throw new Error('Not your turn')
+        throw new Error("Not your turn");
       }
-  
+
       this.staged[player] = move;
     }
 
-    if (this.nextToPlay().some(playerNr => !(playerNr in this.staged))) {
+    if (this.nextToPlay().some((playerNr) => !(playerNr in this.staged))) {
       // Don't play moves until everybody has staged a move
       return;
     }
@@ -125,8 +131,7 @@ export class ParallelGo extends AbstractGame<
     }
 
     this.removeGroupsIf(
-      ({ has_liberties, contains_staged }) =>
-        !has_liberties && !contains_staged,
+      ({ has_liberties, contains_staged }) => !has_liberties && !contains_staged
     );
     this.removeGroupsIf(({ has_liberties }) => !has_liberties);
 
@@ -146,7 +151,7 @@ export class ParallelGo extends AbstractGame<
 
   replaceMultiColoredStonesWith(arr: number[]) {
     this.board = this.board.map((intersection) =>
-      intersection.length > 1 ? [...arr] : intersection,
+      intersection.length > 1 ? [...arr] : intersection
     );
   }
 
@@ -162,7 +167,7 @@ export class ParallelGo extends AbstractGame<
   private getGroup(
     pos: Coordinate,
     color: number,
-    checked: Grid<{ [color: number]: boolean }>,
+    checked: Grid<{ [color: number]: boolean }>
   ): Group {
     if (this.isOutOfBounds(pos)) {
       return { stones: [], has_liberties: false, contains_staged: false };
@@ -242,7 +247,7 @@ export class ParallelGo extends AbstractGame<
   initializeParticipation(numPlayers: number): Participation[] {
     const participation = new Array(numPlayers);
     for (let i = 0; i < numPlayers; i++) {
-      participation[i] = {playerNr: i, dropOutAtRound: null};
+      participation[i] = { playerNr: i, dropOutAtRound: null };
     }
     return participation;
   }

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -31,7 +31,7 @@ export class ParallelGo extends AbstractGame<
   private staged: MovesType = {};
   private last_round: MovesType = {};
   private playerParticipation = this.initializeParticipation(
-    this.config.num_players
+    this.config.num_players,
   );
   private numberOfRounds: number = 0;
 
@@ -61,7 +61,7 @@ export class ParallelGo extends AbstractGame<
           .filter(
             (x) =>
               x.dropOutAtRound === null ||
-              x.dropOutAtRound > this.numberOfRounds
+              x.dropOutAtRound > this.numberOfRounds,
           )
           .map((p) => p.playerNr);
   }
@@ -72,7 +72,7 @@ export class ParallelGo extends AbstractGame<
       const occupants = this.board.at(decoded_move);
       if (occupants === undefined) {
         throw Error(
-          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.board.width}x${this.board.height}`
+          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.board.width}x${this.board.height}`,
         );
       }
       if (occupants.length !== 0) {
@@ -131,7 +131,8 @@ export class ParallelGo extends AbstractGame<
     }
 
     this.removeGroupsIf(
-      ({ has_liberties, contains_staged }) => !has_liberties && !contains_staged
+      ({ has_liberties, contains_staged }) =>
+        !has_liberties && !contains_staged,
     );
     this.removeGroupsIf(({ has_liberties }) => !has_liberties);
 
@@ -151,7 +152,7 @@ export class ParallelGo extends AbstractGame<
 
   replaceMultiColoredStonesWith(arr: number[]) {
     this.board = this.board.map((intersection) =>
-      intersection.length > 1 ? [...arr] : intersection
+      intersection.length > 1 ? [...arr] : intersection,
     );
   }
 
@@ -167,7 +168,7 @@ export class ParallelGo extends AbstractGame<
   private getGroup(
     pos: Coordinate,
     color: number,
-    checked: Grid<{ [color: number]: boolean }>
+    checked: Grid<{ [color: number]: boolean }>,
   ): Group {
     if (this.isOutOfBounds(pos)) {
       return { stones: [], has_liberties: false, contains_staged: false };

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -48,18 +48,32 @@ function resetTimer(): void {
     isDefined(props.time_control.onThePlaySince) &&
     props.time_control.remainingTimeMS !== null
   ) {
-    isCountingDown.value = true;
-    const onThePlaySince: Date = new Date(props.time_control.onThePlaySince);
-    const now = new Date();
-    time.value -= now.getTime() - onThePlaySince.getTime();
+    // this is not ideal
+    if (
+      "stagedMoveAt" in props.time_control &&
+      props.time_control.stagedMoveAt !== null
+    ) {
+      isCountingDown.value = false;
+      const onThePlaySince = new Date(props.time_control.onThePlaySince);
+      const stagedMove = new Date(props.time_control.stagedMoveAt as Date);
+      time.value = Math.max(
+        0,
+        time.value - (stagedMove.getTime() - onThePlaySince.getTime())
+      );
+    } else {
+      isCountingDown.value = true;
+      const onThePlaySince: Date = new Date(props.time_control.onThePlaySince);
+      const now = new Date();
+      time.value = Math.max(
+        0,
+        time.value - (now.getTime() - onThePlaySince.getTime())
+      );
+    }
   } else {
     isCountingDown.value = false;
   }
 
-  if (
-    isDefined(props.time_control?.onThePlaySince) &&
-    typeof window !== "undefined"
-  ) {
+  if (isCountingDown.value && typeof window !== "undefined") {
     timerIndex = window.setInterval(() => {
       if (time.value <= 0 && timerIndex !== null) {
         clearInterval(timerIndex);


### PR DESCRIPTION
# Changes

## Server
- add a singleton service for scheduling timeouts (including initialising timeout scheduling for all games on reboot) When a scheduled timeout is resolved, a timeout move is played
- expand the time control handler interface and simplify the move handling as a result
- implement time control handler for parallel moves (note that this will only work as long as we keep the workflow with staged moves)

## Shared
- Add handling of timeout moves in all variants. For variants with parallel moves, I believe the same handling can be used for resignation (and player dropout in general). But I did not take any other steps to enable resignation in those variants. Also I was not able to test the fractional variant yet, because the client UI for creating a game config with time control is unfortunately still bugged for that variant.

## Client
- small change in the timer component for parallel moves variants