### PR TITLE
prototype for drift go

### DIFF
--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -43,13 +43,13 @@ class ConfigError extends Error {
 
 export function makeGameObject(
   variant: string,
-  config: unknown
+  config: unknown,
 ): AbstractGame<unknown, unknown> {
   try {
     return new game_map[variant](config);
   } catch (e) {
     throw new ConfigError(
-      `${e}, (variant: ${variant}, config: ${JSON.stringify(config)})`
+      `${e}, (variant: ${variant}, config: ${JSON.stringify(config)})`,
     );
   }
 }

--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -12,6 +12,7 @@ import { FreezeGo } from "./variants/freeze";
 import { Fractional } from "./variants/fractional";
 import { Keima } from "./variants/keima";
 import { OneColorGo } from "./variants/one_color";
+import { DriftGo } from "./variants/drift";
 
 export const game_map: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -30,6 +31,7 @@ export const game_map: {
   fractional: Fractional,
   keima: Keima,
   "one color": OneColorGo,
+  drift: DriftGo,
 };
 
 class ConfigError extends Error {
@@ -41,13 +43,13 @@ class ConfigError extends Error {
 
 export function makeGameObject(
   variant: string,
-  config: unknown,
+  config: unknown
 ): AbstractGame<unknown, unknown> {
   try {
     return new game_map[variant](config);
   } catch (e) {
     throw new ConfigError(
-      `${e}, (variant: ${variant}, config: ${JSON.stringify(config)})`,
+      `${e}, (variant: ${variant}, config: ${JSON.stringify(config)})`
     );
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -17,3 +17,4 @@ export {
   FractionalState,
 } from "./variants/fractional";
 export { KeimaState } from "./variants/keima";
+export * from "./variants/drift";

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -37,7 +37,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
   constructor(config?: BadukConfig) {
     super(config);
     this.board = new Grid<Color>(this.config.width, this.config.height).fill(
-      Color.EMPTY
+      Color.EMPTY,
     );
   }
 
@@ -78,12 +78,12 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
       const color = this.board.at(decoded_move);
       if (color === undefined) {
         throw Error(
-          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`
+          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`,
         );
       }
       if (color !== Color.EMPTY) {
         throw Error(
-          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`
+          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`,
         );
       }
 
@@ -103,7 +103,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
     return { pass: "Pass", resign: "Resign", timeout: "Timeout" };
   }
 
-  protected playMoveInternal(move: Coordinate): void {
+  private playMoveInternal(move: Coordinate): void {
     this.board.set(move, this.next_to_play === 0 ? Color.BLACK : Color.WHITE);
 
     const opponent_color = this.next_to_play === 0 ? Color.WHITE : Color.BLACK;
@@ -166,7 +166,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
 
     const black_points: number = board.reduce(
       count_color<Color>(Color.BLACK),
-      0
+      0,
     );
     const white_points: number =
       board.reduce(count_color<Color>(Color.WHITE), 0) + this.config.komi;

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -37,7 +37,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
   constructor(config?: BadukConfig) {
     super(config);
     this.board = new Grid<Color>(this.config.width, this.config.height).fill(
-      Color.EMPTY,
+      Color.EMPTY
     );
   }
 
@@ -78,12 +78,12 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
       const color = this.board.at(decoded_move);
       if (color === undefined) {
         throw Error(
-          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`,
+          `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`
         );
       }
       if (color !== Color.EMPTY) {
         throw Error(
-          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`,
+          `Cannot place a stone on top of an existing stone. (${color} at (${x}, ${y}))`
         );
       }
 
@@ -103,7 +103,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
     return { pass: "Pass", resign: "Resign", timeout: "Timeout" };
   }
 
-  private playMoveInternal(move: Coordinate): void {
+  protected playMoveInternal(move: Coordinate): void {
     this.board.set(move, this.next_to_play === 0 ? Color.BLACK : Color.WHITE);
 
     const opponent_color = this.next_to_play === 0 ? Color.WHITE : Color.BLACK;
@@ -133,7 +133,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
     });
   }
 
-  private prepareForNextMove(move: string): void {
+  protected prepareForNextMove(move: string): void {
     if (move == "pass" && this.last_move === "pass") {
       this.finalizeScore();
     } else {
@@ -166,7 +166,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
 
     const black_points: number = board.reduce(
       count_color<Color>(Color.BLACK),
-      0,
+      0
     );
     const white_points: number =
       board.reduce(count_color<Color>(Color.WHITE), 0) + this.config.komi;
@@ -189,7 +189,7 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
 }
 
 /** Returns true if the group containing (x, y) has at least one liberty. */
-function groupHasLiberties(group: CoordinateLike[], board: Grid<Color>) {
+export function groupHasLiberties(group: CoordinateLike[], board: Grid<Color>) {
   const outer_border = getOuterBorder(group, board);
   const border_colors = outer_border.map((pos) => board.at(pos));
   return border_colors.includes(Color.EMPTY);

--- a/packages/shared/src/variants/drift.ts
+++ b/packages/shared/src/variants/drift.ts
@@ -54,7 +54,7 @@ export class DriftGo extends Baduk {
   private shift(coord: Coordinate): Coordinate {
     return new Coordinate(
       (coord.x - this.typedConfig.xShift) % this.board.width,
-      (coord.y - this.typedConfig.yShift) % this.board.height
+      (coord.y - this.typedConfig.yShift) % this.board.height,
     );
   }
 

--- a/packages/shared/src/variants/drift.ts
+++ b/packages/shared/src/variants/drift.ts
@@ -1,0 +1,69 @@
+import { Coordinate } from "../lib/coordinate";
+import { getGroup } from "../lib/group_utils";
+import { Baduk, BadukConfig, Color, groupHasLiberties } from "./baduk";
+
+export interface DriftGoConfig extends BadukConfig {
+  yShift: number;
+  xShift: number;
+}
+
+export class DriftGo extends Baduk {
+  private typedConfig: DriftGoConfig;
+
+  constructor(config?: DriftGoConfig) {
+    super(config);
+    this.typedConfig = config ?? this.defaultConfig();
+  }
+
+  defaultConfig(): DriftGoConfig {
+    return { ...super.defaultConfig(), xShift: 0, yShift: 1 };
+  }
+
+  protected prepareForNextMove(move: string): void {
+    // shift board
+    this.board = this.board.map((_, coord: Coordinate) => {
+      const ret = this.board.at(this.shift(coord));
+      if (ret === undefined) {
+        throw new Error("implementation error: index out of bounds");
+      }
+      return ret;
+    });
+
+    // check edges for groups without liberties
+    const groupsToRemove: { x: number; y: number }[][] = [];
+
+    this.board.forEach((color, coord) => {
+      if (color === Color.EMPTY || !this.isOnBoundary(coord)) {
+        return;
+      }
+
+      const group = getGroup(coord, this.board);
+      if (!groupHasLiberties(group, this.board)) {
+        groupsToRemove.push(group);
+      }
+    });
+
+    // remove simultaneously
+    for (const group of groupsToRemove) {
+      group.forEach((pos) => this.board.set(pos, Color.EMPTY));
+    }
+
+    super.prepareForNextMove(move);
+  }
+
+  private shift(coord: Coordinate): Coordinate {
+    return new Coordinate(
+      (coord.x - this.typedConfig.xShift) % this.board.width,
+      (coord.y - this.typedConfig.yShift) % this.board.height
+    );
+  }
+
+  private isOnBoundary(coord: Coordinate): boolean {
+    return (
+      coord.x === 0 ||
+      coord.x === this.board.width - 1 ||
+      coord.y === 0 ||
+      coord.y === this.board.height - 1
+    );
+  }
+}

--- a/packages/shared/src/variants/freeze.ts
+++ b/packages/shared/src/variants/freeze.ts
@@ -15,8 +15,6 @@ export class FreezeGo extends Baduk {
     super.playMove(player, move);
     const captures_after = this.captures[player as 0 | 1];
 
-    console.log("before, after", captures_before, captures_after);
-
     if (this.frozen && captures_before !== captures_after) {
       throw new Error("Cannot capture after opponent ataris");
     }

--- a/packages/vue-client/src/board_map.ts
+++ b/packages/vue-client/src/board_map.ts
@@ -23,4 +23,5 @@ export const board_map: {
   fractional: FractionalBoard,
   keima: KeimaBoard,
   "one color": Baduk,
+  drift: Baduk,
 };

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -1,0 +1,34 @@
+import { DriftGoConfig } from '../../../../shared/dist/variants/drift';
+<script setup lang="ts">
+const props = defineProps<{ initialConfig: DriftGoConfig }>();
+const config = { ...props.initialConfig } as DriftGoConfig;
+
+const emit = defineEmits<{
+  (e: "configChanged", config: DriftGoConfig): void;
+}>();
+
+function emitConfigChange() {
+  emit("configChanged", config);
+}
+</script>
+
+<template>
+  <form @change="emitConfigChange" class="config-form-column">
+    <label>Width</label>
+    <input type="number" min="1" v-model="config.width" />
+    <label>Height</label>
+    <input type="number" min="1" v-model="config.height" />
+    <label>Komi</label>
+    <input type="number" step="0.5" v-model="config.komi" />
+    <label>X-Shift</label>
+    <input type="number" step="1" v-model="config.yShift" />
+    <label>Y-Shift</label>
+    <input type="number" step="1" v-model="config.yShift" />
+  </form>
+</template>
+
+<style>
+input {
+  width: fit-content;
+}
+</style>

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -1,11 +1,14 @@
-import { DriftGoConfig } from '../../../../shared/dist/variants/drift';
 <script setup lang="ts">
+import { DriftGoConfig } from "@ogfcommunity/variants-shared";
+
 const props = defineProps<{ initialConfig: DriftGoConfig }>();
 const config = { ...props.initialConfig } as DriftGoConfig;
 
 const emit = defineEmits<{
   (e: "configChanged", config: DriftGoConfig): void;
 }>();
+
+console.log(props.initialConfig);
 
 function emitConfigChange() {
   emit("configChanged", config);
@@ -21,7 +24,7 @@ function emitConfigChange() {
     <label>Komi</label>
     <input type="number" step="0.5" v-model="config.komi" />
     <label>X-Shift</label>
-    <input type="number" step="1" v-model="config.yShift" />
+    <input type="number" step="1" v-model="config.xShift" />
     <label>Y-Shift</label>
     <input type="number" step="1" v-model="config.yShift" />
   </form>

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { DriftGoConfig } from "@ogfcommunity/variants-shared";
+import type { DriftGoConfig } from "@ogfcommunity/variants-shared";
 
 const props = defineProps<{ initialConfig: DriftGoConfig }>();
 const config = { ...props.initialConfig } as DriftGoConfig;

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -8,8 +8,6 @@ const emit = defineEmits<{
   (e: "configChanged", config: DriftGoConfig): void;
 }>();
 
-console.log(props.initialConfig);
-
 function emitConfigChange() {
   emit("configChanged", config);
 }

--- a/packages/vue-client/src/config_form_map.ts
+++ b/packages/vue-client/src/config_form_map.ts
@@ -2,6 +2,7 @@ import type { Component } from "vue";
 import BadukConfigForm from "@/components/GameCreation/BadukConfigForm.vue";
 import BadukWithAbstractBoardConfigForm from "@/components/GameCreation/BadukWithAbstractBoardConfigForm.vue";
 import ParalleGoConfigForm from "@/components/GameCreation/ParallelGoConfigForm.vue";
+import DriftGoConfigFormVue from "./components/GameCreation/DriftGoConfigForm.vue";
 
 export const config_form_map: {
   [variant: string]: Component<{ initialConfig: object }>;
@@ -17,4 +18,5 @@ export const config_form_map: {
   freeze: BadukConfigForm,
   keima: BadukConfigForm,
   "one color": BadukConfigForm,
+  drift: DriftGoConfigFormVue,
 };

--- a/packages/vue-client/src/stores/user.ts
+++ b/packages/vue-client/src/stores/user.ts
@@ -14,7 +14,6 @@ export const useStore = defineStore("user", {
   actions: {
     async update() {
       this.user = await requests.get("/checkLogin");
-      console.log(this.user);
     },
 
     async guestLogin() {


### PR DESCRIPTION
This is a prototype for a variant idea:

_Drift Go
After every move, the board shifts in a toroidal-like translation, e.g. the top row becomes the bottom row._

In this implementation, groups that lose their last liberty as a result of the shift are all removed simultaneously and grant no captures.

This is probably not the most efficient implementation (the shift can be represented by only two numbers without re-assigning the whole board), but after testing it, the performance is not bad.