### PR TITLE
Support empty config for Pyramid Go

### DIFF
--- a/packages/shared/src/__tests__/game_map.test.ts
+++ b/packages/shared/src/__tests__/game_map.test.ts
@@ -1,0 +1,9 @@
+import { getDefaultConfig, getVariantList, makeGameObject } from "../game_map";
+
+test.each(getVariantList())("Build %s from default config", (variant) => {
+  const default_config = getDefaultConfig(variant);
+
+  // This is a dummy expectation
+  // This test is basically a success if neither function call throws an error
+  expect(makeGameObject(variant, default_config)).toBeDefined();
+});

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -3,14 +3,16 @@ import { Grid } from "../lib/grid";
 
 export class PyramidGo extends Baduk {
   private weights: Grid<number>;
-  constructor(config: BadukConfig) {
+  constructor(config?: BadukConfig) {
     super(config);
 
-    this.weights = new Grid(config.width, config.height)
+    // Note: config may be undefined, but this.config is
+    // defined after the AbstractGame constructor is called.
+    const { width, height } = this.config;
+
+    this.weights = new Grid(width, height)
       .fill(0)
-      .map((_, { x, y }) =>
-        Math.min(x + 1, y + 1, config.width - x, config.height - y),
-      );
+      .map((_, { x, y }) => Math.min(x + 1, y + 1, width - x, height - y));
   }
 
   get result(): string {


### PR DESCRIPTION
Fixes #163 

We had discussed some refactor of the defaut configs/game map, but actually, here is a 4 line fix, and I've also added a test which should prevent this class of bugs in the future.

(I'm still supportive of a refactor, but that takes more care and I wanted to get this variant working again)