### PR TITLE
Next to play indicator

### DIFF
--- a/packages/vue-client/src/assets/base.css
+++ b/packages/vue-client/src/assets/base.css
@@ -35,6 +35,11 @@
   --vt-c-warn-light-transparent: rgba(220, 92, 92, 0.3);
   --vt-c-warn-dark: rgb(220, 92, 92);
   --vt-c-warn-dark-transparent: rgba(220, 92, 92, 0.3);
+
+  --c-selected-seat-light: deepskyblue;
+  --c-selected-seat-dark: deepskyblue;
+
+  --to-move-shadow-width: 5px;
 }
 
 /* semantic color variables for this project */
@@ -56,6 +61,8 @@
   --color-primary-transparent: var(--vt-c-primary-light-transparent);
   --color-warn: var(--vt-c-warn-light);
   --color-warn-transparent: var(--vt-c-warn-light-transparent);
+
+  --color-selected-seat: var(--c-selected-seat-light);
 
   --section-gap: 160px;
 }
@@ -79,6 +86,8 @@
     --color-primary-transparent: var(--vt-c-primary-dark-transparent);
     --color-warn: var(--vt-c-warn-dark);
     --color-warn-transparent: var(--vt-c-warn-dark-transparent);
+
+    --color-selected-seat: var(--c-selected-seat-dark);
   }
 }
 

--- a/packages/vue-client/src/components/SeatComponent.vue
+++ b/packages/vue-client/src/components/SeatComponent.vue
@@ -11,12 +11,15 @@ defineProps<{
   player_n: number;
   selected?: number;
   time_control: IPerPlayerTimeControlBase | null;
+  is_players_turn: boolean;
 }>();
 </script>
 
 <template>
   <div
-    v-bind:class="`seat ${selected === player_n ? 'selected' : ''}`"
+    v-bind:class="`seat ${selected === player_n ? 'selected' : ''} ${
+      is_players_turn ? 'to-move' : ''
+    }`"
     @click="$emit('select')"
   >
     <p class="seat-number">{{ player_n }}</p>
@@ -25,7 +28,9 @@ defineProps<{
       <button v-if="user_id" @click.stop="$emit('sit')">Take Seat</button>
     </div>
     <div v-else>
-      <p>{{ occupant.username ?? `guest (...${occupant.id.slice(-6)})` }}</p>
+      <p class="seat-username">
+        {{ occupant.username ?? `guest (...${occupant.id.slice(-6)})` }}
+      </p>
       <button v-if="occupant.id === user_id" @click.stop="$emit('leave')">
         Leave Seat
       </button>
@@ -41,10 +46,10 @@ defineProps<{
   display: inline-block;
   width: 200px;
   padding: 10px;
-  margin: 2px;
+  margin: 5px 2px;
 }
 .seat.selected {
-  border-color: deepskyblue;
+  border-color: var(--color-selected-seat);
 }
 .seat div {
   display: inline-block;
@@ -53,5 +58,20 @@ defineProps<{
   font-size: x-large;
   display: inline-block;
   margin-right: 10px;
+}
+.seat.to-move {
+  box-shadow: 0px 0px var(--to-move-shadow-width) var(--color-shadow);
+}
+
+.seat.to-move.selected {
+  box-shadow: 0px 0px var(--to-move-shadow-width) var(--color-selected-seat);
+}
+
+.seat.to-move .seat-number {
+  font-weight: 600;
+}
+
+.seat.to-move .seat-username {
+  font-weight: bold;
 }
 </style>

--- a/packages/vue-client/src/components/SeatComponent.vue
+++ b/packages/vue-client/src/components/SeatComponent.vue
@@ -17,9 +17,8 @@ defineProps<{
 
 <template>
   <div
-    v-bind:class="`seat ${selected === player_n ? 'selected' : ''} ${
-      is_players_turn ? 'to-move' : ''
-    }`"
+    class="seat"
+    :class="{ selected: selected === player_n, 'to-move': is_players_turn }"
     @click="$emit('select')"
   >
     <p class="seat-number">{{ player_n }}</p>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -73,6 +73,7 @@ const game = computed(() => {
     result,
     state,
     round: game_obj.round,
+    next_to_play: game_obj.nextToPlay(),
   };
 });
 const specialMoves = computed(() =>
@@ -203,6 +204,7 @@ const createTimeControlPreview = (
           gameResponse.time_control?.forPlayer[idx] ??
           createTimeControlPreview(gameResponse)
         "
+        :is_players_turn="game.next_to_play?.includes(idx) ?? false"
       />
     </div>
 
@@ -214,6 +216,17 @@ const createTimeControlPreview = (
       >
         {{ value }}
       </button>
+    </div>
+    <div v-if="game.next_to_play?.length" class="players-to-move-container">
+      <span v-if="game.next_to_play?.length === 1" class="info-label"
+        >Player to move:</span
+      >
+      <span v-else class="info-label">Players to move:</span>
+      <ul>
+        <li v-for="value in game.next_to_play ?? []" :key="value">
+          Player {{ value }}
+        </li>
+      </ul>
     </div>
   </div>
   <div class="nav-buttons">
@@ -266,6 +279,16 @@ pre {
 @media (min-width: 664px) {
   .board {
     width: 600px;
+  }
+}
+
+.players-to-move-container {
+  margin: 10px 0;
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 }
 </style>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -298,10 +298,11 @@ pre {
 
 .players-to-move-container {
   margin: 5px 0;
-  ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
+}
+
+.players-to-move-container ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 </style>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -217,18 +217,22 @@ const createTimeControlPreview = (
         {{ value }}
       </button>
     </div>
+
     <div v-if="game.next_to_play?.length" class="players-to-move-container">
-      <span v-if="game.next_to_play?.length === 1" class="info-label"
-        >Player to move:</span
-      >
-      <span v-else class="info-label">Players to move:</span>
-      <ul>
-        <li v-for="value in game.next_to_play" :key="value">
-          Player {{ value }}
-        </li>
-      </ul>
+      <div v-if="game.next_to_play?.length === 1" class="info-label">
+        Player {{ game.next_to_play[0] }} to move
+      </div>
+      <div v-else>
+        <span class="info-label">Players to move:</span>
+        <ul>
+          <li v-for="value in game.next_to_play" :key="value">
+            Player {{ value }}
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
+
   <div class="nav-buttons">
     <button @click="() => navigateRounds(-(game.round ?? 0))">
       &lt;&lt;&lt;
@@ -275,16 +279,25 @@ pre {
   flex-direction: row;
   justify-content: space-between;
 }
+.seat-list {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  column-gap: 20px;
+}
 
 @media (min-width: 664px) {
   .board {
     width: 600px;
   }
+  .seat-list {
+    max-height: 600px;
+  }
 }
 
 .players-to-move-container {
-  margin: 10px 0;
-
+  margin: 5px 0;
   ul {
     list-style: none;
     margin: 0;

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -223,7 +223,7 @@ const createTimeControlPreview = (
       >
       <span v-else class="info-label">Players to move:</span>
       <ul>
-        <li v-for="value in game.next_to_play ?? []" :key="value">
+        <li v-for="value in game.next_to_play" :key="value">
           Player {{ value }}
         </li>
       </ul>


### PR DESCRIPTION
merowin and I added a next to play indicator by
- highlighting the seats of the players whose turn it is with a shadow and bolder text
- displaying a list of players to move below or next to the seat list

We also changed the styling of the seat list to make a long list of players wrap to the next column if there's space.

See issue #160 

## Baduk:
![grafik](https://github.com/govariantsteam/govariants/assets/87281301/99d1b073-04b2-4532-8283-11ec3b6e0024)
![grafik](https://github.com/govariantsteam/govariants/assets/87281301/98882784-7a1b-4668-a289-2159b74294f2)

## Parallel / Fractional:
![grafik](https://github.com/govariantsteam/govariants/assets/87281301/3ead83de-135c-43fa-9d8b-8c15fa295ada)
![grafik](https://github.com/govariantsteam/govariants/assets/87281301/7a769e95-2eac-4cb8-b9d4-7e6f9a011326)


