### PR TITLE
Add star points (hoshi).

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from "./lib/grid";
 export * from "./lib/coordinate";
 export * from "./time_control";
 export * from "./lib/utils";
+export * from "./lib/hoshi";
 export { FreezeGoState } from "./variants/freeze";
 export {
   Color as FractionalColor,

--- a/packages/shared/src/lib/__tests__/hoshi.test.ts
+++ b/packages/shared/src/lib/__tests__/hoshi.test.ts
@@ -1,0 +1,24 @@
+import { getHoshi } from "../hoshi";
+
+test("19x19 has the standard star points", () => {
+  const hoshi = getHoshi(19, 19);
+  hoshi.sort((a, b) => {
+    if (a.x === b.x) {
+      return a.y - b.y;
+    }
+    return a.x - b.x;
+  });
+  const normalizedHoshi = hoshi.map(({ x, y }) => ({ x, y }));
+
+  expect(normalizedHoshi).toEqual([
+    { x: 3, y: 3 },
+    { x: 3, y: 9 },
+    { x: 3, y: 15 },
+    { x: 9, y: 3 },
+    { x: 9, y: 9 },
+    { x: 9, y: 15 },
+    { x: 15, y: 3 },
+    { x: 15, y: 9 },
+    { x: 15, y: 15 },
+  ]);
+});

--- a/packages/shared/src/lib/hoshi.ts
+++ b/packages/shared/src/lib/hoshi.ts
@@ -1,0 +1,65 @@
+/*
+Source borrowed (with heavy modifications) from Besogo, which is released under the MIT Licence:
+
+Copyright (c) 2015-2018 Ye Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { Coordinate } from "./coordinate";
+
+/** @returns the coordinates of the hoshi for a given board size */
+export function getHoshi(width: number, height: number): Coordinate[] {
+  const ret: Coordinate[] = [];
+  const addStar = (i: number, j: number) =>
+    // We subtract one here because the BesoGo implementation is 1-indexed
+    ret.push(new Coordinate(i - 1, j - 1));
+  let cx, cy; // Path string for drawing star points
+
+  if (width % 2 && height % 2) {
+    // Draw center hoshi if both dimensions are odd
+    cx = (width - 1) / 2 + 1; // Calculate the center of the board
+    cy = (height - 1) / 2 + 1;
+    addStar(cx, cy);
+
+    if (width >= 17 && height >= 17) {
+      // Draw side hoshi if at least 17x17 and odd
+      addStar(4, cy);
+      addStar(width - 3, cy);
+      addStar(cx, 4);
+      addStar(cx, height - 3);
+    }
+  }
+
+  if (width >= 11 && height >= 11) {
+    // Corner hoshi at (4, 4) for larger sizes
+    addStar(4, 4);
+    addStar(4, height - 3);
+    addStar(width - 3, 4);
+    addStar(width - 3, height - 3);
+  } else if (width >= 8 && height >= 8) {
+    // Corner hoshi at (3, 3) for medium sizes
+    addStar(3, 3);
+    addStar(3, height - 2);
+    addStar(width - 2, 3);
+    addStar(width - 2, height - 2);
+  } // No corner hoshi for smaller sizes
+
+  return ret;
+}

--- a/packages/vue-client/src/components/boards/BadukBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukBoard.vue
@@ -4,6 +4,7 @@ import {
   Coordinate,
   type BadukConfig,
   type BadukState,
+  getHoshi,
 } from "@ogfcommunity/variants-shared";
 import { toRefs } from "vue";
 
@@ -74,6 +75,14 @@ function positionClicked(pos: Coordinate) {
         v-bind:x2="width - 1"
         v-bind:y1="y - 1"
         v-bind:y2="y - 1"
+      />
+
+      <circle
+        v-for="{ x, y } in getHoshi(width, height)"
+        :key="`${x},${y}`"
+        :cx="x"
+        :cy="y"
+        r="0.12"
       />
     </g>
     <g>


### PR DESCRIPTION
Fixes #24 

Implementation taken from [Besogo](https://yewang.github.io/besogo/).  Note: I only added them to BadukBoard.  It's not to hard to port to other grid boards, but I'd rather focus on unification (#137).

<img width="357" alt="Screenshot 2024-02-03 at 6 36 56 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/048380a8-2aab-459a-9266-da692a7ac0b7">
<img width="570" alt="Screenshot 2024-02-03 at 6 36 45 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/1f3fe209-7e6f-4b04-bb97-b495032cb755">
<img width="594" alt="Screenshot 2024-02-03 at 6 37 26 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/41d9370b-1261-49b9-9391-177918dc182a">