### PR TITLE
Board with trihexagonal tiling

### DIFF
--- a/packages/shared/src/lib/grid.ts
+++ b/packages/shared/src/lib/grid.ts
@@ -1,4 +1,4 @@
-import { Coordinate, CoordinateLike } from "./coordinate";
+import { Coordinate, type CoordinateLike } from "./coordinate";
 
 /**
  * A 2D analog to the native JavaScript array.  As much as possible,

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/BadukBoardAbstract.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/BadukBoardAbstract.ts
@@ -5,6 +5,7 @@ import { Intersection } from "./intersection";
 import { CreatePolygonalBoard } from "./PolygonalBoardHelper";
 import { CreateCircularBoard } from "./CircularBoardHelper";
 import { Vector2D } from "./Vector2D";
+import { TrihexagonalBoardHelper } from "./TrihexagonalBoardHelper";
 
 export class BadukBoardAbstract implements IBadukBoard {
   Intersections: Intersection[];
@@ -43,6 +44,14 @@ export class BadukBoardAbstract implements IBadukBoard {
       case BoardPattern.Circular:
         this.Array2D = null;
         this.Intersections = CreateCircularBoard(conf.height, conf.width);
+        return;
+      case BoardPattern.Trihexagonal:
+        this.Array2D = null;
+        this.Intersections =
+          new TrihexagonalBoardHelper().CreateTrihexagonalBoard(
+            Math.min(conf.height, conf.width),
+          );
+
         return;
       default:
         throw new Error("unknown board pattern");

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
@@ -9,8 +9,8 @@ export class TrihexagonalBoardHelper {
   constructor() {
     this.x_base_vector = new Vector2D(1, 0);
     this.y_base_vector = new Vector2D(
-      Math.sin(Math.PI / 6),
-      Math.cos(Math.PI / 6),
+      Math.cos(Math.PI / 3),
+      Math.sin(Math.PI / 3),
     );
   }
 
@@ -40,7 +40,7 @@ export class TrihexagonalBoardHelper {
 
     return new Grid<null>(_size, _size)
       .fill(null)
-      .map<Intersection | null>((value, index, grid) =>
+      .map<Intersection | null>((_value, index, _grid) =>
         ((index.x + x_shift_pattern) * 4 - (index.y + y_shift_pattern)) % 7 ===
           0 || index.x + index.y >= _size
           ? null

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
@@ -1,0 +1,76 @@
+import { Grid } from "../../../lib/grid";
+import { Vector2D } from "./Vector2D";
+import { Intersection } from "./intersection";
+
+export class TrihexagonalBoardHelper {
+  private readonly x_base_vector: Vector2D;
+  private readonly y_base_vector: Vector2D;
+
+  constructor() {
+    this.x_base_vector = new Vector2D(1, 0);
+    this.y_base_vector = new Vector2D(
+      Math.sin(Math.PI / 6),
+      Math.cos(Math.PI / 6),
+    );
+  }
+
+  CreateTrihexagonalBoard(size: number): Intersection[] {
+    const _size = size;
+
+    let x_shift_pattern = 0;
+    let y_shift_pattern = 0;
+
+    switch (_size % 3) {
+      case 0: {
+        x_shift_pattern = -(_size / 3) + 2;
+        y_shift_pattern = -(_size / 3);
+        break;
+      }
+      case 1: {
+        x_shift_pattern = -(_size - 1) / 3;
+        y_shift_pattern = -(_size - 1) / 3;
+        break;
+      }
+      case 2: {
+        x_shift_pattern = -((_size - 2) / 3) - 4;
+        y_shift_pattern = -((_size - 2) / 3) - 1;
+        break;
+      }
+    }
+
+    return new Grid<null>(_size, _size)
+      .fill(null)
+      .map<Intersection | null>((value, index, grid) =>
+        ((index.x + x_shift_pattern) * 4 - (index.y + y_shift_pattern)) % 7 ===
+          0 || index.x + index.y >= _size
+          ? null
+          : new Intersection(
+              this.x_base_vector
+                .Multiply(index.x)
+                .Add(this.y_base_vector.Multiply(index.y)),
+            ),
+      )
+      .map<Intersection | null>((intersection, index, grid) => {
+        if (!intersection) {
+          return null;
+        }
+
+        grid.at({ x: index.x + 1, y: index.y })?.ConnectTo(intersection, true);
+        grid.at({ x: index.x, y: index.y + 1 })?.ConnectTo(intersection, true);
+        if (index.x > 0) {
+          grid
+            .at({ x: index.x - 1, y: index.y + 1 })
+            ?.ConnectTo(intersection, true);
+        }
+
+        return intersection;
+      })
+      .to2DArray()
+      .flat()
+      .filter((value) => value !== null)
+      .map((intersection, index) => {
+        intersection!.Identifier = index;
+        return intersection!;
+      });
+  }
+}

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
@@ -67,10 +67,10 @@ export class TrihexagonalBoardHelper {
       })
       .to2DArray()
       .flat()
-      .filter((value) => value !== null)
+      .filter((value): value is Intersection => value !== null)
       .map((intersection, index) => {
-        intersection!.Identifier = index;
-        return intersection!;
+        intersection.Identifier = index;
+        return intersection;
       });
   }
 }

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/Vector2D.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/Vector2D.ts
@@ -15,6 +15,10 @@ export class Vector2D {
     return new Vector2D(this.X - v.X, this.Y - v.Y);
   }
 
+  Multiply(n: number): Vector2D {
+    return new Vector2D(this.X * n, this.Y * n);
+  }
+
   Export(): Vector2D {
     return new Vector2D(this.X, this.Y);
   }

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -14,6 +14,7 @@ export enum BoardPattern {
   Rectangular = 1,
   Polygonal = 2,
   Circular = 3,
+  Trihexagonal = 4,
 }
 
 export interface BadukWithAbstractBoardConfig {

--- a/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
@@ -55,6 +55,7 @@ watch(patternRef, () => {
       <option :value="BoardPattern.Rectangular">Rectangular</option>
       <option :value="BoardPattern.Polygonal">Polygonal</option>
       <option :value="BoardPattern.Circular">Circular</option>
+      <option :value="BoardPattern.Trihexagonal">Trihexagonal</option>
     </select>
     <template v-if="patternRef === BoardPattern.Rectangular">
       <label>Width</label>
@@ -62,7 +63,12 @@ watch(patternRef, () => {
       <label>Height</label>
       <input type="number" min="1" v-model="heightRef" />
     </template>
-    <template v-if="patternRef === BoardPattern.Polygonal">
+    <template
+      v-if="
+        patternRef === BoardPattern.Polygonal ||
+        patternRef === BoardPattern.Trihexagonal
+      "
+    >
       <label>Size</label>
       <input type="number" min="1" v-model="sizeRef" />
     </template>


### PR DESCRIPTION
This adds a triangular board with trihexagonal tiling.

size 6:
![grafik](https://github.com/govariantsteam/govariants/assets/77507448/dff6a3e6-4d9d-46d3-892a-1e78124ede8e)

size 7:
![grafik](https://github.com/govariantsteam/govariants/assets/77507448/5aa8c191-0e30-4f15-bf76-154802a00252)

size 8:
![grafik](https://github.com/govariantsteam/govariants/assets/77507448/9b4af4bb-8be3-4a79-b86a-ddfd0c00b182)

size 19:
![grafik](https://github.com/govariantsteam/govariants/assets/77507448/c9ad4769-36c7-44d0-b8b6-6fe5924489f4)

