### PR TITLE
set id of intersections in createRthBoard

### DIFF
--- a/packages/shared/src/lib/abstractBaduk/badukIntersection.ts
+++ b/packages/shared/src/lib/abstractBaduk/badukIntersection.ts
@@ -12,8 +12,8 @@ export class BadukIntersection<
 > extends Intersection {
   stone: TStone | null;
 
-  constructor(v: Vector2D) {
-    super(v);
+  constructor(v: Vector2D, id: number) {
+    super(v, id);
     this.stone = null;
   }
 }

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -87,13 +87,14 @@ function convertIntersections<TIntersection extends Intersection>(
   const intersections = new Map<TIntersection["id"], TIntersection>(
     old.map((o) => [o.Identifier, new intersectionConstructor(o.Position)]),
   );
-  old.forEach((i) =>
+  old.forEach((i) => {
+    const newIntersection = intersections.get(i.Identifier)!;
+    newIntersection.id = i.Identifier;
+
     i.Neighbours.forEach((n) =>
-      intersections
-        .get(i.Identifier)!
-        .connectTo(intersections.get(n.Identifier)!, false),
-    ),
-  );
+      newIntersection.connectTo(intersections.get(n.Identifier)!, false),
+    );
+  });
 
   return Array.from(intersections.values());
 }

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -17,7 +17,7 @@ export interface RhombitrihexagonalBoardConfig {
 }
 
 export interface IntersectionConstructor<TIntersection extends Intersection> {
-  new (vector: Vector2D): TIntersection;
+  new (vector: Vector2D, id: number): TIntersection;
 }
 
 export function createBoard<TIntersection extends Intersection>(
@@ -52,8 +52,8 @@ function createGridBoard<TIntersection extends Intersection>(
   for (let y = 0; y < config.height; y++) {
     array2D.push(new Array<TIntersection>());
     for (let x = 0; x < config.width; x++) {
-      const intersection = new intersectionConstructor(new Vector2D(x, y));
-      intersection.id = y * config.width + x;
+      const id = y * config.width + x;
+      const intersection = new intersectionConstructor(new Vector2D(x, y), id);
 
       intersections.push(intersection);
       array2D[y].push(intersection);
@@ -85,16 +85,18 @@ function convertIntersections<TIntersection extends Intersection>(
   intersectionConstructor: IntersectionConstructor<TIntersection>,
 ): TIntersection[] {
   const intersections = new Map<TIntersection["id"], TIntersection>(
-    old.map((o) => [o.Identifier, new intersectionConstructor(o.Position)]),
+    old.map((o) => [
+      o.Identifier,
+      new intersectionConstructor(o.Position, o.Identifier),
+    ]),
   );
-  old.forEach((i) => {
-    const newIntersection = intersections.get(i.Identifier)!;
-    newIntersection.id = i.Identifier;
-
+  old.forEach((i) =>
     i.Neighbours.forEach((n) =>
-      newIntersection.connectTo(intersections.get(n.Identifier)!, false),
-    );
-  });
+      intersections
+        .get(i.Identifier)!
+        .connectTo(intersections.get(n.Identifier)!, false),
+    ),
+  );
 
   return Array.from(intersections.values());
 }

--- a/packages/shared/src/lib/abstractBoard/intersection.ts
+++ b/packages/shared/src/lib/abstractBoard/intersection.ts
@@ -9,10 +9,10 @@ export class Intersection {
   neighbours: this[];
   position: Vector2D;
 
-  constructor(v: Vector2D) {
+  constructor(v: Vector2D, id: number) {
     this.position = v;
     this.neighbours = [];
-    this.id = 0;
+    this.id = id;
   }
 
   connectTo(intersection: this, bothSides: boolean) {
@@ -29,8 +29,7 @@ export class Intersection {
   export(): Intersection {
     // TODO: How to export? Why is it needed?
     // TODO: Polymorphic this as return type? Can't construct new this(), right?
-    const intersection = new Intersection(this.position.Export());
-    intersection.id = this.id;
+    const intersection = new Intersection(this.position.Export(), this.id);
     //ToDo: How to export Neighbours?
     return intersection;
   }


### PR DESCRIPTION
I love that Fractional (and AbstractBaduk) work with arbitrary graphs! For the Rhombitrihexagonal board, it seems that the intersection ids were not set after conversion. This is an attempt to fix it.