### PR TITLE
refactor play move, fix timer display delay

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -102,17 +102,6 @@ export async function playMove(
 ): Promise<GameResponse> {
   const game = await getGame(game_id);
 
-  // Verify that moves are legal
-  const game_obj = makeGameObject(game.variant, game.config);
-  game.moves.forEach((moves) => {
-    const { player, move } = getOnlyMove(moves);
-    game_obj.playMove(player, move);
-  });
-
-  if (game_obj.result !== "") {
-    throw Error("Game is already finished.");
-  }
-
   const { player: playerNr, move: new_move } = getOnlyMove(moves);
 
   if (!game.players || game.players[playerNr] == null) {
@@ -126,6 +115,27 @@ export async function playMove(
       `Not the right user: expected ${expected_player.id}, got ${user_id}`,
     );
   }
+
+  return await handleMoveAndTime(game_id, moves, game);
+}
+
+export async function handleMoveAndTime(
+  game_id: string,
+  moves: MovesType,
+  game: GameResponse,
+): Promise<GameResponse> {
+  // Verify that moves are legal
+  const game_obj = makeGameObject(game.variant, game.config);
+  game.moves.forEach((moves) => {
+    const { player, move } = getOnlyMove(moves);
+    game_obj.playMove(player, move);
+  });
+
+  if (game_obj.result !== "") {
+    throw Error("Game is already finished.");
+  }
+
+  const { player: playerNr, move: new_move } = getOnlyMove(moves);
 
   const previousRound = game_obj.round;
   game_obj.playMove(playerNr, new_move);

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -102,7 +102,7 @@ export async function playMove(
 ): Promise<GameResponse> {
   const game = await getGame(game_id);
 
-  const { player: playerNr, move: new_move } = getOnlyMove(moves);
+  const { player: playerNr, move: _new_move } = getOnlyMove(moves);
 
   if (!game.players || game.players[playerNr] == null) {
     throw Error(`Seat ${playerNr} not occupied!`);

--- a/packages/server/src/time-control/timeout.ts
+++ b/packages/server/src/time-control/timeout.ts
@@ -1,17 +1,10 @@
-import {
-  gamesCollection,
-  getGame,
-  getGamesWithTimeControl,
-  handleMoveAndTime,
-} from "../games";
+import { getGame, getGamesWithTimeControl, handleMoveAndTime } from "../games";
 import {
   MovesType,
   getOnlyMove,
   makeGameObject,
 } from "@ogfcommunity/variants-shared";
 import { timeControlHandlerMap } from "./time-handler-map";
-import { ObjectId } from "mongodb";
-import { io } from "../socket_io";
 
 type GameTimeouts = {
   // timeout for this player, or null

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -15,6 +15,7 @@ const formattedTime = ref(
 );
 const isCountingDown = ref(false);
 let timerIndex: number | null = null;
+let lastUpdated: Date;
 
 watch(time, (t: number) => {
   if (t === null) {
@@ -74,11 +75,14 @@ function resetTimer(): void {
   }
 
   if (isCountingDown.value && typeof window !== "undefined") {
+    lastUpdated = new Date();
     timerIndex = window.setInterval(() => {
       if (time.value <= 0 && timerIndex !== null) {
         clearInterval(timerIndex);
       } else {
-        time.value -= 1000;
+        const timeStamp = new Date();
+        time.value -= timeStamp.getTime() - lastUpdated.getTime();
+        lastUpdated = timeStamp;
       }
     }, 1000);
   }


### PR DESCRIPTION
This tries to simplify and reduce duplicated code in the timeout service as we briefly talked about in https://github.com/govariantsteam/govariants/pull/185

My approach is to split the playMove method into two parts: 
- playMove does the user specific validations and then calls ...
- handleMoveAndTime which does the rest (validate the move, update time control, schedule timeouts, update db game, notify clients)

Then I can reuse this second method in the timeout service, where we should skip the user specific validation (if the seat was vacated in the meantime, it still times out).

I've also included another fix, because I noticed this when testing: Over a couple of minutes, the visual timer was running a bit behind. I believe this was due to the fact that I set an interval which decreases the player time by 1s every 1s. However this was delayed by interval callback.
To counteract this, the timer now remembers the timestamp of the last visual update, and reduces the displayed time accordingly. I've tested this, and indeed seems to be much better.