### PR TITLE
wrap nested selectors in :is

### DIFF
--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -35,7 +35,7 @@ nav {
   box-shadow: 0px 0px 5px var(--color-shadow);
   margin-bottom: 5px;
 
-  div {
+  :is(div) {
     display: flex;
     align-items: center;
   }

--- a/packages/vue-client/src/components/GamesFilterForm.vue
+++ b/packages/vue-client/src/components/GamesFilterForm.vue
@@ -51,10 +51,10 @@ const filter = computed(() => {
   margin-bottom: 0.5rem;
 }
 .myGamesToggle {
-  label {
+  :is(label) {
     cursor: pointer;
   }
-  input {
+  :is(input) {
     cursor: pointer;
   }
 }

--- a/packages/vue-client/src/components/SeatComponent.vue
+++ b/packages/vue-client/src/components/SeatComponent.vue
@@ -81,7 +81,7 @@ defineProps<{
 
 .timer-and-button {
   display: inline-block;
-  button {
+  :is(button) {
     margin-left: 0.5rem;
   }
 }


### PR DESCRIPTION
issue: #190 

This fixes all warnings I'm getting, which is not all unfortunately.

I believe we can also fix the warnings about nested css syntax not being supported on some configured targets, by removing the nested css syntax (i.e.

```
.myContainer {
  &.leftContainer { ... }
}
```
->
`.myContainer.leftContainer { ... }`

That being said, I think that nested css syntax is quite handy in some cases (e.g. for deeply nested components)