### PR TITLE
Better navbar for mobile

### DIFF
--- a/packages/vue-client/package.json
+++ b/packages/vue-client/package.json
@@ -17,6 +17,11 @@
     "gen-favicon": "rimraf public/favicon.ico && icon-gen --ico -i public/logo.svg -o public --ico-name favicon"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-brands-svg-icons": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
+    "@fortawesome/free-solid-svg-icons": "^6.5.1",
+    "@fortawesome/vue-fontawesome": "latest-3",
     "@ogfcommunity/variants-shared": "1.0.0",
     "@vueuse/core": "^10.2.1",
     "chessground": "^8.3.12",

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -59,34 +59,6 @@ nav {
   display: none;
 }
 
-header {
-  line-height: 1.5;
-  max-height: 100vh;
-}
-
-.logo {
-  display: block;
-  margin: 0 auto 2rem;
-}
-
-@media (min-width: 1024px) {
-  header {
-    display: flex;
-    place-items: center;
-    padding-right: calc(var(--section-gap) / 2);
-  }
-
-  .logo {
-    margin: 0 2rem 0 0;
-  }
-
-  header .wrapper {
-    display: flex;
-    place-items: flex-start;
-    flex-wrap: wrap;
-  }
-}
-
 @media (max-width: 768px) {
   .navContent {
     flex-direction: column;

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -17,7 +17,7 @@ const closeMenuFn = (event: MouseEvent) => {
   document.removeEventListener("click", closeMenuFn);
 };
 
-const openMenuFn = (event: MouseEvent) => {
+const toggleMenuFn = (event: MouseEvent) => {
   if (is_menu_closed.value) {
     event.stopPropagation();
     is_menu_closed.value = false;
@@ -33,7 +33,7 @@ const openMenuFn = (event: MouseEvent) => {
     <RouterLink class="navLogo" to="/"
       ><img class="navLogoImg" src="/favicon.ico"
     /></RouterLink>
-    <button class="navHamburgerContainer navElement" @click="openMenuFn">
+    <button class="navHamburgerContainer navElement" @click="toggleMenuFn">
       <font-awesome-icon icon="fa-solid fa-bars" class="navHamburgerMenu" />
     </button>
     <div class="navContent" v-bind:class="{ closedMenu: is_menu_closed }">

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -5,14 +5,18 @@ import UserNav from "./components/UserNav.vue";
 
 <template>
   <nav>
-    <div>
-      <RouterLink class="navElement" to="/"
-        ><img class="navLogo" src="/favicon.ico"
-      /></RouterLink>
-      <RouterLink class="navElement" to="/about">About</RouterLink>
-    </div>
-    <div>
-      <UserNav />
+    <RouterLink class="navLogo" to="/"
+      ><img class="navLogoImg" src="/favicon.ico"
+    /></RouterLink>
+    <button class="navElement navHamburgerMenuButton">Menu</button>
+    <div class="navContent" v-bind:class="{ closedMenu: false }">
+      <div>
+        <RouterLink class="navElement" to="/">Home</RouterLink>
+        <RouterLink class="navElement" to="/about">About</RouterLink>
+      </div>
+      <div>
+        <UserNav />
+      </div>
     </div>
   </nav>
   <div class="pageWrapper">
@@ -23,6 +27,7 @@ import UserNav from "./components/UserNav.vue";
 <style scoped>
 nav {
   width: 100%;
+  height: var(--navbar-height);
   text-align: left;
   font-size: 1rem;
   position: sticky;
@@ -30,20 +35,28 @@ nav {
   z-index: 999;
   background-color: var(--color-background-soft);
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: start;
   box-shadow: 0px 0px 5px var(--color-shadow);
   margin-bottom: 5px;
 
-  div {
+  .navContent {
     display: flex;
-    align-items: center;
+    justify-content: space-between;
+    flex-grow: 1;
+
+    div {
+      display: flex;
+    }
   }
 
-  .navLogo {
-    width: 2rem;
-    height: 2rem;
+  .navLogoImg {
+    width: calc(var(--navbar-height) * 0.85);
+    height: calc(var(--navbar-height) * 0.85);
   }
+}
+
+.navHamburgerMenuButton {
+  display: none;
 }
 
 header {
@@ -71,6 +84,33 @@ header {
     display: flex;
     place-items: flex-start;
     flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 768px) {
+  .navContent {
+    flex-direction: column;
+    z-index: 1000;
+    opacity: 1;
+    position: absolute;
+    top: var(--navbar-height);
+    left: 0;
+    background-color: var(--color-background-soft);
+    box-shadow: 0px 5px 5px -5px var(--color-shadow);
+    width: 100vw;
+
+    div {
+      flex-direction: column;
+    }
+  }
+
+  .navHamburgerMenuButton {
+    display: flex;
+  }
+
+  .closedMenu {
+    opacity: 0;
+    height: 0;
   }
 }
 </style>

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -2,7 +2,13 @@
 import { RouterLink, RouterView } from "vue-router";
 import UserNav from "./components/UserNav.vue";
 import { ref } from "vue";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faBars } from "@fortawesome/free-solid-svg-icons";
+import { faHouse } from "@fortawesome/free-solid-svg-icons";
+import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 
+library.add(faBars, faHouse, faCircleInfo);
 const is_menu_closed = ref(true);
 
 const closeMenuFn = (event: MouseEvent) => {
@@ -27,13 +33,23 @@ const openMenuFn = (event: MouseEvent) => {
     <RouterLink class="navLogo" to="/"
       ><img class="navLogoImg" src="/favicon.ico"
     /></RouterLink>
-    <button class="navElement navHamburgerMenuButton" @click="openMenuFn">
-      Menu
+    <button class="navHamburgerContainer navElement" @click="openMenuFn">
+      <font-awesome-icon icon="fa-solid fa-bars" class="navHamburgerMenu" />
     </button>
     <div class="navContent" v-bind:class="{ closedMenu: is_menu_closed }">
       <div>
-        <RouterLink class="navElement" to="/">Home</RouterLink>
-        <RouterLink class="navElement" to="/about">About</RouterLink>
+        <RouterLink class="navElement" to="/"
+          ><font-awesome-icon
+            icon="fa-solid fa-house"
+            class="icon"
+          />Home</RouterLink
+        >
+        <RouterLink class="navElement" to="/about"
+          ><font-awesome-icon
+            icon="fa-solid fa-circle-info"
+            class="icon"
+          />About</RouterLink
+        >
       </div>
       <div>
         <UserNav />
@@ -56,9 +72,23 @@ nav {
   z-index: 999;
   background-color: var(--color-background-soft);
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
+  align-items: center;
   box-shadow: 0px 0px 5px var(--color-shadow);
   margin-bottom: 5px;
+
+  .navLogoImg {
+    width: calc(var(--navbar-height) * 0.8);
+    height: calc(var(--navbar-height) * 0.8);
+  }
+
+  .navHamburgerContainer {
+    display: none;
+    .navHamburgerMenu {
+      height: calc(var(--navbar-height) * 0.8);
+      display: none;
+    }
+  }
 
   .navContent {
     display: flex;
@@ -69,42 +99,40 @@ nav {
       display: flex;
     }
   }
-
-  .navLogoImg {
-    width: calc(var(--navbar-height) * 0.8);
-    height: calc(var(--navbar-height) * 0.8);
-  }
-}
-
-.navHamburgerMenuButton {
-  display: none;
 }
 
 @media (max-width: 768px) {
-  .navContent {
-    flex-direction: column;
-    z-index: 1000;
-    opacity: 1;
-    position: absolute;
-    top: var(--navbar-height);
-    left: 0;
-    background-color: var(--color-background-soft);
-    box-shadow: 0px 5px 5px -5px var(--color-shadow);
-    width: 100%;
+  nav {
+    justify-content: space-between;
 
-    div {
-      flex-direction: column;
+    .navHamburgerContainer {
+      display: flex;
+      .navHamburgerMenu {
+        display: flex;
+      }
     }
-  }
 
-  .navHamburgerMenuButton {
-    display: flex;
-  }
+    .navContent {
+      flex-direction: column;
+      z-index: 1000;
+      opacity: 1;
+      position: absolute;
+      top: var(--navbar-height);
+      left: 0;
+      background-color: var(--color-background-soft);
+      box-shadow: 0px 5px 5px -5px var(--color-shadow);
+      width: 100%;
 
-  .closedMenu {
-    display: none;
-    * {
-      display: none !important;
+      div {
+        flex-direction: column;
+      }
+
+      &.closedMenu {
+        display: none;
+        * {
+          display: none;
+        }
+      }
     }
   }
 }

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -1,6 +1,25 @@
 <script setup lang="ts">
 import { RouterLink, RouterView } from "vue-router";
 import UserNav from "./components/UserNav.vue";
+import { ref } from "vue";
+
+const is_menu_closed = ref(true);
+
+const closeMenuFn = (event: MouseEvent) => {
+  event.stopPropagation();
+  is_menu_closed.value = true;
+  document.removeEventListener("click", closeMenuFn);
+};
+
+const openMenuFn = (event: MouseEvent) => {
+  if (is_menu_closed.value) {
+    event.stopPropagation();
+    is_menu_closed.value = false;
+    document.addEventListener("click", closeMenuFn);
+  } else {
+    closeMenuFn(event);
+  }
+};
 </script>
 
 <template>
@@ -8,8 +27,10 @@ import UserNav from "./components/UserNav.vue";
     <RouterLink class="navLogo" to="/"
       ><img class="navLogoImg" src="/favicon.ico"
     /></RouterLink>
-    <button class="navElement navHamburgerMenuButton">Menu</button>
-    <div class="navContent" v-bind:class="{ closedMenu: false }">
+    <button class="navElement navHamburgerMenuButton" @click="openMenuFn">
+      Menu
+    </button>
+    <div class="navContent" v-bind:class="{ closedMenu: is_menu_closed }">
       <div>
         <RouterLink class="navElement" to="/">Home</RouterLink>
         <RouterLink class="navElement" to="/about">About</RouterLink>
@@ -50,8 +71,8 @@ nav {
   }
 
   .navLogoImg {
-    width: calc(var(--navbar-height) * 0.85);
-    height: calc(var(--navbar-height) * 0.85);
+    width: calc(var(--navbar-height) * 0.8);
+    height: calc(var(--navbar-height) * 0.8);
   }
 }
 
@@ -69,7 +90,7 @@ nav {
     left: 0;
     background-color: var(--color-background-soft);
     box-shadow: 0px 5px 5px -5px var(--color-shadow);
-    width: 100vw;
+    width: 100%;
 
     div {
       flex-direction: column;
@@ -81,8 +102,10 @@ nav {
   }
 
   .closedMenu {
-    opacity: 0;
-    height: 0;
+    display: none;
+    * {
+      display: none !important;
+    }
   }
 }
 </style>

--- a/packages/vue-client/src/assets/base.css
+++ b/packages/vue-client/src/assets/base.css
@@ -66,6 +66,7 @@
 
   --section-gap: 160px;
   --board-side-length: 600px;
+  --navbar-height: 50px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/packages/vue-client/src/assets/main.css
+++ b/packages/vue-client/src/assets/main.css
@@ -32,11 +32,18 @@
 
 .navElement,
 .navLogo {
-  padding: 0rem 1.2rem;
   height: var(--navbar-height);
   flex-shrink: 0;
   display: flex;
   align-items: center;
+}
+
+.navElement {
+  padding: 0rem 1.2rem;
+}
+
+.navLogo {
+  padding: calc(var(--navbar-height) * 0.2);
 }
 
 a.navElement {

--- a/packages/vue-client/src/assets/main.css
+++ b/packages/vue-client/src/assets/main.css
@@ -40,6 +40,11 @@
 
 .navElement {
   padding: 0rem 1.2rem;
+  gap: 0.5rem;
+
+  .icon {
+    font-size: 1rem;
+  }
 }
 
 .navLogo {
@@ -83,7 +88,7 @@ button.navElement {
     }
   }
 
-  &.navHamburgerMenuButton {
+  &.navHamburgerContainer {
     &:hover {
       transition: 0.4s;
       background-color: var(--color-primary-transparent);

--- a/packages/vue-client/src/assets/main.css
+++ b/packages/vue-client/src/assets/main.css
@@ -30,9 +30,13 @@
   flex-direction: column;
 }
 
-.navElement {
-  padding: 0.6rem 1.2rem;
-  height: 100%;
+.navElement,
+.navLogo {
+  padding: 0rem 1.2rem;
+  height: var(--navbar-height);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
 }
 
 a.navElement {
@@ -69,6 +73,13 @@ button.navElement {
     &:hover {
       transition: 0.4s;
       background-color: var(--color-warn-transparent);
+    }
+  }
+
+  &.navHamburgerMenuButton {
+    &:hover {
+      transition: 0.4s;
+      background-color: var(--color-primary-transparent);
     }
   }
 }

--- a/packages/vue-client/src/components/UserNav.vue
+++ b/packages/vue-client/src/components/UserNav.vue
@@ -4,10 +4,10 @@ import { storeToRefs } from "pinia";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faUser } from "@fortawesome/free-solid-svg-icons";
-import { faArrowRightToBracket } from "@fortawesome/free-solid-svg-icons";
-import { faArrowRightFromBracket } from "@fortawesome/free-solid-svg-icons";
+import { faRightToBracket } from "@fortawesome/free-solid-svg-icons";
+import { faRightFromBracket } from "@fortawesome/free-solid-svg-icons";
 
-library.add(faUser, faArrowRightToBracket, faArrowRightFromBracket);
+library.add(faUser, faRightToBracket, faRightFromBracket);
 const store = useStore();
 const { user } = storeToRefs(store);
 store.update();
@@ -15,10 +15,8 @@ store.update();
 
 <template>
   <RouterLink class="navElement" v-if="!user" to="/login"
-    ><font-awesome-icon
-      icon="fa-solid fa-arrow-right-to-bracket"
-      class="icon"
-    />Log in</RouterLink
+    ><font-awesome-icon icon="fa-solid fa-right-to-bracket" class="icon" />Log
+    in</RouterLink
   >
   <template v-else>
     <!-- TODO: make this a link to the user's profile? -->
@@ -32,10 +30,7 @@ store.update();
       v-on:click="store.logout()"
       click="Log out"
     >
-      <font-awesome-icon
-        icon="fa-solid fa-arrow-right-from-bracket"
-        class="icon"
-      />
+      <font-awesome-icon icon="fa-solid fa-right-from-bracket" class="icon" />
       Log out
     </button>
   </template>

--- a/packages/vue-client/src/components/UserNav.vue
+++ b/packages/vue-client/src/components/UserNav.vue
@@ -1,21 +1,41 @@
 <script setup lang="ts">
 import { useStore } from "@/stores/user";
 import { storeToRefs } from "pinia";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faUser } from "@fortawesome/free-solid-svg-icons";
+import { faArrowRightToBracket } from "@fortawesome/free-solid-svg-icons";
+import { faArrowRightFromBracket } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faUser, faArrowRightToBracket, faArrowRightFromBracket);
 const store = useStore();
 const { user } = storeToRefs(store);
 store.update();
 </script>
 
 <template>
-  <RouterLink class="navElement" v-if="!user" to="/login">Log in</RouterLink>
+  <RouterLink class="navElement" v-if="!user" to="/login"
+    ><font-awesome-icon
+      icon="fa-solid fa-arrow-right-to-bracket"
+      class="icon"
+    />Log in</RouterLink
+  >
   <template v-else>
     <!-- TODO: make this a link to the user's profile? -->
-    <RouterLink class="navElement" to="/">{{ user.username }}</RouterLink>
+    <RouterLink class="navElement" to="/"
+      ><font-awesome-icon icon="fa-solid fa-user" class="icon" />{{
+        user.username
+      }}</RouterLink
+    >
     <button
       class="navElement logoutButton"
       v-on:click="store.logout()"
       click="Log out"
     >
+      <font-awesome-icon
+        icon="fa-solid fa-arrow-right-from-bracket"
+        class="icon"
+      />
       Log out
     </button>
   </template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,6 +929,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fortawesome/fontawesome-common-types@npm:6.5.1":
+  version: 6.5.1
+  resolution: "@fortawesome/fontawesome-common-types@npm:6.5.1"
+  checksum: c597062de8903aae591b652aa03b9b7aaa66e8c71e5950dc34a8b2812851a7f4ad743fba7396bab87d787c5359bb121496769a165bd3399d039dc214434f6f0c
+  languageName: node
+  linkType: hard
+
+"@fortawesome/fontawesome-svg-core@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "@fortawesome/fontawesome-svg-core@npm:6.5.1"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": 6.5.1
+  checksum: e17f995abe215d288163b2cd009f935c7f96bc896ab4ea7a75de72789d52a1275bd112eeb60cadd63bb20017a05ed765232157079bfb7efda7347a5614e04ce1
+  languageName: node
+  linkType: hard
+
+"@fortawesome/free-brands-svg-icons@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "@fortawesome/free-brands-svg-icons@npm:6.5.1"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": 6.5.1
+  checksum: c29f8a9ad9886c0733d3616b5ea05b08b4943c1b5231c73f31a07e7df36c337e5a51cfe7cc610e623cb2b4a0607e3f82a8a3f46107c4347aa653784489672314
+  languageName: node
+  linkType: hard
+
+"@fortawesome/free-regular-svg-icons@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "@fortawesome/free-regular-svg-icons@npm:6.5.1"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": 6.5.1
+  checksum: c1809fae5f3bffff2f06d414f552e38acf385f79bb1b1a8e34b6b9c1138e9e6be7f8ed1503da0f72e225079138b8377f95f279d0079bb04ba8d3bfb3025ec512
+  languageName: node
+  linkType: hard
+
+"@fortawesome/free-solid-svg-icons@npm:^6.5.1":
+  version: 6.5.1
+  resolution: "@fortawesome/free-solid-svg-icons@npm:6.5.1"
+  dependencies:
+    "@fortawesome/fontawesome-common-types": 6.5.1
+  checksum: c544b8389bab4ab375d172feeb334d4a591bd7c594acdcc546b5197f2bcc80be22be119a03994dbe7f13d133c11b41c471b62c92dd318fbe0378202c43c09d7d
+  languageName: node
+  linkType: hard
+
+"@fortawesome/vue-fontawesome@npm:latest-3":
+  version: 3.0.6
+  resolution: "@fortawesome/vue-fontawesome@npm:3.0.6"
+  peerDependencies:
+    "@fortawesome/fontawesome-svg-core": ~1 || ~6
+    vue: ">= 3.0.0 < 4"
+  checksum: 0ae311ed998660ae7b460ec03e5fd5f64268dd841ac000bb67172211fa3f36b2df46d6ffb95de608f716664ebc07048a17d5da8b4f93f2ccddc8a054b410bcaf
+  languageName: node
+  linkType: hard
+
 "@gar/promisify@npm:^1.1.3":
   version: 1.1.3
   resolution: "@gar/promisify@npm:1.1.3"
@@ -1435,6 +1488,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ogfcommunity/variants-vue-client@workspace:packages/vue-client"
   dependencies:
+    "@fortawesome/fontawesome-svg-core": ^6.5.1
+    "@fortawesome/free-brands-svg-icons": ^6.5.1
+    "@fortawesome/free-regular-svg-icons": ^6.5.1
+    "@fortawesome/free-solid-svg-icons": ^6.5.1
+    "@fortawesome/vue-fontawesome": latest-3
     "@ogfcommunity/variants-shared": 1.0.0
     "@rushstack/eslint-patch": ^1.3.2
     "@tsconfig/node18": ^18.2.0


### PR DESCRIPTION
An attempt to improve the nav bar for mobile. It collapses the nav bar when the screen is small and uses a hamburger menu instead. This will make it so we can safely add more stuff to the nav bar in the future :-)

Work in progress - layout and styles are basically done, menu toggle function still missing.

Before:
![grafik](https://github-production-user-asset-6210df.s3.amazonaws.com/87281301/309120391-ea8160eb-1359-4cdd-bcc9-6f57c881bcc7.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240301%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240301T185333Z&X-Amz-Expires=300&X-Amz-Signature=27f64056c982baffe9f88ed2005236b57bb93839f2583ffe10a6fc6b46c01dd0&X-Amz-SignedHeaders=host&actor_id=87281301&key_id=0&repo_id=507638125)

Current: 
![grafik](https://github-production-user-asset-6210df.s3.amazonaws.com/87281301/309120099-a4fbadf9-fbcb-4455-a8fa-189ee13c98d6.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240301%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240301T185339Z&X-Amz-Expires=300&X-Amz-Signature=e05b2664d8928da36175e785858dda0dc193447d0a346f6ccea25ba6df6e6d74&X-Amz-SignedHeaders=host&actor_id=87281301&key_id=0&repo_id=507638125)





