### PR TITLE
fix stuff?

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,10 +28,10 @@
     "passport-local": "^1.0.0",
     "socket.io": "^4.7.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "@types/jest": "^29.5.12"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.2",
     "@typescript-eslint/eslint-plugin": "^6.1.0",
     "@typescript-eslint/parser": "^6.1.0",
     "eslint": "^8.44.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,7 +1453,7 @@ __metadata:
     "@types/bcrypt": ^5.0.0
     "@types/express": ^4.17.17
     "@types/express-session": ^1.17.7
-    "@types/jest": ^29.5.2
+    "@types/jest": ^29.5.12
     "@types/jsdom": ^21.1.1
     "@types/passport": ^1.0.12
     "@types/passport-local": ^1.0.35
@@ -1830,6 +1830,16 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "*"
   checksum: f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
+  languageName: node
+  linkType: hard
+
+"@types/jest@npm:^29.5.12":
+  version: 29.5.12
+  resolution: "@types/jest@npm:29.5.12"
+  dependencies:
+    expect: ^29.0.0
+    pretty-format: ^29.0.0
+  checksum: 19b1efdeed9d9a60a81edc8226cdeae5af7479e493eaed273e01243891c9651f7b8b4c08fc633a7d0d1d379b091c4179bbaa0807af62542325fd72f2dd17ce1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
For some reason, the `launch` script tries to build tests and Heroku doesn't look at dev dependencies 🤔  so the server crashed with these logs:

```
2024-03-05T05:36:58.861553+00:00 heroku[web.1]: Starting process with command `yarn workspace @ogfcommunity/variants-server launch`
2024-03-05T05:37:04.807589+00:00 app[web.1]: src/time-control/__tests__/sequential.test.ts(14,1): error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
2024-03-05T05:37:04.807976+00:00 app[web.1]: src/time-control/__tests__/sequential.test.ts(15,3): error TS2582: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
2024-03-05T05:37:04.807978+00:00 app[web.1]: src/time-control/__tests__/sequential.test.ts(91,5): error TS2304: Cannot find name 'expect'.
2024-03-05T05:37:04.807978+00:00 app[web.1]: src/time-control/__tests__/sequential.test.ts(92,5): error TS2304: Cannot find name 'expect'.
2024-03-05T05:37:04.807978+00:00 app[web.1]: src/time-control/__tests__/sequential.test.ts(93,5): error TS2304: Cannot find name 'expect'.
2024-03-05T05:37:04.807979+00:00 app[web.1]: src/time-control/__tests__/sequential.test.ts(96,5): error TS2304: Cannot find name 'expect'.
2024-03-05T05:37:04.807979+00:00 app[web.1]: src/time-control/__tests__/sequential.test.ts(99,5): error TS2304: Cannot find name 'expect'.
2024-03-05T05:37:04.932615+00:00 heroku[web.1]: Process exited with status 2
2024-03-05T05:37:04.959221+00:00 heroku[web.1]: State changed from starting to crashed
```

This change fixes the crash, so I already deployed 🙈 