### PR TITLE
Remove timeout button, Some time handling fixes

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -151,20 +151,19 @@ export async function handleMoveAndTime(
   ) {
     if (game_obj.phase === "gameover") {
       getTimeoutService().clearGameTimeouts(game.id);
-    } else {
-      if (Object.keys(timeControlHandlerMap).includes(game.variant)) {
-        const timeHandler = new timeControlHandlerMap[game.variant](
-          new Clock(),
-          getTimeoutService(),
-        );
-        timeControl = timeHandler.handleMove(
-          game,
-          game_obj,
-          playerNr,
-          new_move,
-          isRoundTransition,
-        );
-      }
+    }
+    if (Object.keys(timeControlHandlerMap).includes(game.variant)) {
+      const timeHandler = new timeControlHandlerMap[game.variant](
+        new Clock(),
+        getTimeoutService(),
+      );
+      timeControl = timeHandler.handleMove(
+        game,
+        game_obj,
+        playerNr,
+        new_move,
+        isRoundTransition,
+      );
     }
   }
 

--- a/packages/server/src/time-control/__tests__/sequential.test.ts
+++ b/packages/server/src/time-control/__tests__/sequential.test.ts
@@ -58,7 +58,7 @@ describe("Sequential Time Control Tests", () => {
       return new TimeHandlerSequentialMoves(
         clock,
         new TestTimeoutService(),
-      ).handleMove(gameResponse, game, player);
+      ).handleMove(gameResponse, game, player, move);
     };
 
     const seconds1 = 10;

--- a/packages/server/src/time-control/time-handler-parallel.ts
+++ b/packages/server/src/time-control/time-handler-parallel.ts
@@ -198,8 +198,7 @@ export class TimeHandlerParallelMoves implements ITimeHandler {
     timeControl.moveTimestamps.push(timestamp);
     this._timeoutService.clearPlayerTimeout(game.id, playerNr);
 
-    if (isRoundTransition) {
-      // update times for this round
+    if (isRoundTransition || game_obj.phase == "gameover") {
       for (const player of Object.keys(timeControl.forPlayer).map(Number)) {
         const playerData = timeControl.forPlayer[player];
 

--- a/packages/server/src/time-control/time-handler-parallel.ts
+++ b/packages/server/src/time-control/time-handler-parallel.ts
@@ -174,9 +174,11 @@ export class TimeHandlerParallelMoves implements ITimeHandler {
     const playerData = timeControl.forPlayer[playerNr];
 
     if (move === "resign" || move === "timeout") {
-      playerData.remainingTimeMS = 0;
       playerData.onThePlaySince = null;
       playerData.stagedMoveAt = null;
+      if (move === "timeout") {
+        playerData.remainingTimeMS = 0;
+      }
     } else {
       playerData.stagedMoveAt = timestamp;
 

--- a/packages/server/src/time-control/time-handler-parallel.ts
+++ b/packages/server/src/time-control/time-handler-parallel.ts
@@ -173,7 +173,11 @@ export class TimeHandlerParallelMoves implements ITimeHandler {
 
     const playerData = timeControl.forPlayer[playerNr];
 
-    if (!(move === "resign") && !(move === "timeout")) {
+    if (move === "resign" || move === "timeout") {
+      playerData.remainingTimeMS = 0;
+      playerData.onThePlaySince = null;
+      playerData.stagedMoveAt = null;
+    } else {
       playerData.stagedMoveAt = timestamp;
 
       // TODO: for now this should work, but I should think about this when adding
@@ -187,11 +191,6 @@ export class TimeHandlerParallelMoves implements ITimeHandler {
           "you can't change your move because it would reduce your remaining time to zero.",
         );
       }
-    } else {
-      // player dropped out
-      playerData.remainingTimeMS = 0;
-      playerData.onThePlaySince = null;
-      playerData.stagedMoveAt = null;
     }
 
     timeControl.moveTimestamps.push(timestamp);

--- a/packages/server/src/time-control/time-handler-sequential.ts
+++ b/packages/server/src/time-control/time-handler-sequential.ts
@@ -79,6 +79,11 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
     switch (config.time_control.type) {
       case TimeControlType.Absolute: {
         transition = (playerData) => {
+          if (move === "timeout") {
+            playerData.remainingTimeMS = 0;
+            return;
+          }
+
           playerData.remainingTimeMS -=
             timestamp.getTime() - playerData.onThePlaySince.getTime();
         };
@@ -88,6 +93,11 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
       case TimeControlType.Fischer: {
         const fischerConfig = config.time_control as IFischerConfig;
         transition = (playerData) => {
+          if (move === "timeout") {
+            playerData.remainingTimeMS = 0;
+            return;
+          }
+
           const uncapped =
             playerData.remainingTimeMS +
             fischerConfig.incrementMS -
@@ -161,11 +171,6 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
     const playerData = timeControl.forPlayer[playerNr];
 
     timeControl.moveTimestamps.push(timestamp);
-
-    if (move === "resign" || move === "timeout") {
-      playerData.remainingTimeMS = 0;
-      playerData.onThePlaySince = null;
-    }
 
     if (playerData.onThePlaySince !== null) {
       transition(playerData);

--- a/packages/server/src/time-control/time-handler-sequential.ts
+++ b/packages/server/src/time-control/time-handler-sequential.ts
@@ -62,6 +62,7 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
+    move: string,
   ): ITimeControlBase {
     const config = game.config as IConfigWithTimeControl;
     const timestamp = this._clock.getTimestamp();
@@ -108,6 +109,7 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
       game,
       game_obj,
       playerNr,
+      move,
       timestamp,
       transition,
     );
@@ -150,6 +152,7 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
     game: GameResponse,
     game_obj: AbstractGame<unknown, unknown>,
     playerNr: number,
+    move: string,
     timestamp: Date,
     // mutates its input
     transition: (playerTimeControl: IPerPlayerTimeControlBase) => void,
@@ -159,10 +162,15 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
 
     timeControl.moveTimestamps.push(timestamp);
 
+    if (move === "resign" || move === "timeout") {
+      playerData.remainingTimeMS = 0;
+      playerData.onThePlaySince = null;
+    }
+
     if (playerData.onThePlaySince !== null) {
       transition(playerData);
+      playerData.onThePlaySince = null;
     }
-    playerData.onThePlaySince = null;
     this._timeoutService.clearPlayerTimeout(game.id, playerNr);
 
     // time control starts only after the first move of player

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -98,8 +98,8 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
     return 2;
   }
 
-  override specialMoves() {
-    return { pass: "Pass", resign: "Resign", timeout: "Timeout" };
+  override specialMoves(): { [key: string]: string } {
+    return { pass: "Pass", resign: "Resign" };
   }
 
   private playMoveInternal(move: Coordinate): void {

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -130,7 +130,7 @@ export class BadukWithAbstractBoard extends AbstractGame<
   }
 
   specialMoves() {
-    return { pass: "Pass", resign: "Resign", timeout: "Timeout" };
+    return { pass: "Pass", resign: "Resign" };
   }
 
   defaultConfig(): BadukWithAbstractBoardConfig {

--- a/packages/shared/src/variants/capture.ts
+++ b/packages/shared/src/variants/capture.ts
@@ -12,8 +12,4 @@ export class Capture extends Baduk {
       this.result = "W+Capture";
     }
   }
-
-  override specialMoves(): { [key: string]: string } {
-    return { resign: "Resign" };
-  }
 }

--- a/packages/shared/src/variants/capture.ts
+++ b/packages/shared/src/variants/capture.ts
@@ -12,4 +12,8 @@ export class Capture extends Baduk {
       this.result = "W+Capture";
     }
   }
+
+  override specialMoves(): { [key: string]: string } {
+    return { resign: "Resign" };
+  }
 }

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -64,7 +64,7 @@ export class ParallelGo extends AbstractGame<
   }
 
   playMove(player: number, move: string): void {
-    if (!Object.keys(this.specialMoves()).includes(move)) {
+    if (!Object.keys(this.specialMoves()).includes(move) && move != "timeout") {
       const decoded_move = Coordinate.fromSgfRepr(move);
       const occupants = this.board.at(decoded_move);
       if (occupants === undefined) {

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -144,7 +144,7 @@ export class ParallelGo extends AbstractGame<
 
   specialMoves() {
     // TODO: support resign
-    return { pass: "Pass", timeout: "Timeout" };
+    return { pass: "Pass" };
   }
 
   replaceMultiColoredStonesWith(arr: number[]) {

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
 
 const time = ref(props.time_control?.remainingTimeMS ?? 0);
 const formattedTime = ref(
-  props.time_control?.remainingTimeMS
+  isDefined(props.time_control?.remainingTimeMS)
     ? msToTime(props.time_control?.remainingTimeMS)
     : "",
 );

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -10,7 +10,7 @@ const props = defineProps<{
 const time = ref(props.time_control?.remainingTimeMS ?? 0);
 const formattedTime = ref(
   isDefined(props.time_control?.remainingTimeMS)
-    ? msToTime(props.time_control?.remainingTimeMS)
+    ? msToTime(props.time_control!.remainingTimeMS)
     : "",
 );
 const isCountingDown = ref(false);


### PR DESCRIPTION
1. removes the timeout button (my bad)
2. pass is not allowed in capture variant
3. fix some issues with time handling:
Game ending moves need to be handled, otherwise the winning players time keeps running.
If A player times out, its time is set to 0, so it is displayed correctly.