### PR TITLE
Quantum fix

### DIFF
--- a/packages/shared/src/variants/__tests__/quantum.test.ts
+++ b/packages/shared/src/variants/__tests__/quantum.test.ts
@@ -236,3 +236,46 @@ test("Placing a stone in a captured quantum position", () => {
 
   expect(game.exportState().quantum_stones).toEqual(["ia", "ai"]);
 });
+
+test("Placing a white stone in a captured quantum position", () => {
+  const game = new QuantumGo({ width: 9, height: 9, komi: 0.5 });
+
+  // https://www.govariants.com/game/660248dd5e01aefcbd63df6a
+
+  //  W . . . . . W .{.}
+  //  B . . . . . . W .
+  //  B . . . . . . . W
+  //  B . . . . . . . .
+  //  . . . . W . . . .
+  //  . . . . . . . . .
+  //  . . . . . . . . .
+  //  . . . . . . . . .
+  // {.}. . . . . . . .
+
+  const moves = [
+    [0, "ia"],
+    [1, "ai"],
+    [0, "ha"],
+    [1, "ee"],
+    [0, "ib"],
+    [1, "aa"],
+    [0, "ab"],
+    [1, "ga"],
+    [0, "ac"],
+    [1, "hb"],
+    [0, "ad"],
+    [1, "ic"],
+    [0, "ii"],
+    [1, "ia"], // white stone in the corner
+  ] as const;
+
+  moves.forEach((move) => game.playMove(move[0], move[1]));
+
+  const boards = game.exportState().boards.map(Grid.from2DArray);
+  expect(boards[0].at({ x: 8, y: 0 })).toBe(Color.EMPTY);
+  expect(boards[0].at({ x: 0, y: 8 })).toBe(Color.WHITE);
+  expect(boards[1].at({ x: 8, y: 0 })).toBe(Color.WHITE);
+  expect(boards[1].at({ x: 0, y: 8 })).toBe(Color.EMPTY);
+
+  expect(game.exportState().quantum_stones).toEqual(["ia", "ai"]);
+});

--- a/packages/shared/src/variants/__tests__/quantum.test.ts
+++ b/packages/shared/src/variants/__tests__/quantum.test.ts
@@ -19,10 +19,7 @@ test("Quantum stone placement", () => {
       [_, _],
     ],
   ]);
-  expect(game.exportState().quantum_stones).toEqual([
-    ["aa", null],
-    [null, "aa"],
-  ]);
+  expect(game.exportState().quantum_stones).toEqual(["aa"]);
 
   game.playMove(1, "bb");
   expect(game.exportState().boards).toEqual([
@@ -35,10 +32,7 @@ test("Quantum stone placement", () => {
       [_, B],
     ],
   ]);
-  expect(game.exportState().quantum_stones).toEqual([
-    ["aa", "bb"],
-    ["bb", "aa"],
-  ]);
+  expect(game.exportState().quantum_stones).toEqual(["aa", "bb"]);
 });
 
 test("Test throws if incorrect player in the quantum stone phase", () => {
@@ -86,10 +80,7 @@ test("Capture quantum stone", () => {
       [_, _, _, _, _],
     ],
   ]);
-  expect(game.exportState().quantum_stones).toEqual([
-    ["ba", "bb"],
-    ["bb", "ba"],
-  ]);
+  expect(game.exportState().quantum_stones).toEqual(["ba", "bb"]);
 
   // Capture the 1-1 stone
   // And the 2-1 quantum stone at board 2 also dies
@@ -106,7 +97,7 @@ test("Capture quantum stone", () => {
       [_, B, _, _, _],
     ],
   ]);
-  expect(game.exportState().quantum_stones).toEqual([["ba", "bb"]]);
+  expect(game.exportState().quantum_stones).toEqual(["ba", "bb"]);
 });
 
 test("Capture non-quantum stone", () => {
@@ -139,10 +130,7 @@ test("Capture non-quantum stone", () => {
       [_, _, _, _, _],
     ],
   ]);
-  expect(game.exportState().quantum_stones).toEqual([
-    ["ba", "eb"],
-    ["eb", "ba"],
-  ]);
+  expect(game.exportState().quantum_stones).toEqual(["ba", "eb"]);
 
   // Capture the 1-1 stone
   // And the 1-1  stone at board 2 also dies
@@ -159,10 +147,7 @@ test("Capture non-quantum stone", () => {
       [_, B, _, _, _],
     ],
   ]);
-  expect(game.exportState().quantum_stones).toEqual([
-    ["ba", "eb"],
-    ["eb", "ba"],
-  ]);
+  expect(game.exportState().quantum_stones).toEqual(["ba", "eb"]);
 });
 
 test("Two passes ends the game", () => {

--- a/packages/shared/src/variants/__tests__/quantum.test.ts
+++ b/packages/shared/src/variants/__tests__/quantum.test.ts
@@ -1,5 +1,6 @@
 import { QuantumGo } from "../quantum";
 import { Color } from "../baduk";
+import { Grid } from "../../lib/grid";
 
 const W = Color.WHITE;
 const B = Color.BLACK;
@@ -191,4 +192,47 @@ test("Two passes ends the game", () => {
       [_, B, W, _],
     ],
   ]);
+});
+
+test("Placing a stone in a captured quantum position", () => {
+  const game = new QuantumGo({ width: 9, height: 9, komi: 0.5 });
+
+  // https://www.govariants.com/game/660248dd5e01aefcbd63df6a
+
+  //  W . . . . . W .{.}
+  //  B . . . . . . W .
+  //  B . . . . . . . W
+  //  B . . . . . . . .
+  //  . . . . W . . . .
+  //  . . . . . . . . .
+  //  . . . . . . . . .
+  //  . . . . . . . . .
+  // {.}. . . . . . . .
+
+  const moves = [
+    [0, "ia"],
+    [1, "ai"],
+    [0, "ha"],
+    [1, "ee"],
+    [0, "ib"],
+    [1, "aa"],
+    [0, "ab"],
+    [1, "ga"],
+    [0, "ac"],
+    [1, "hb"],
+    [0, "ad"],
+    [1, "ic"],
+    [0, "ia"], // black stone in the corner
+  ] as const;
+
+  moves.forEach((move) => game.playMove(move[0], move[1]));
+
+  const boards = game.exportState().boards.map(Grid.from2DArray);
+  expect(boards[0].at({ x: 8, y: 0 })).toBe(Color.BLACK);
+  expect(boards[0].at({ x: 0, y: 8 })).toBe(Color.EMPTY);
+  expect(boards[1].at({ x: 8, y: 0 })).toBe(Color.EMPTY);
+  // Quantum stones live together
+  expect(boards[1].at({ x: 0, y: 8 })).toBe(Color.BLACK);
+
+  expect(game.exportState().quantum_stones).toEqual(["ia", "ai"]);
 });

--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -53,19 +53,13 @@ function board_with_quantum_stones(
 const board_0 = computed(() => {
   return board_with_quantum_stones(
     props.gamestate.boards[0],
-    props.gamestate.quantum_stones
-      .map((pair) => pair[0])
-      .filter((pos): pos is string => pos != null)
-      .map((pos) => Coordinate.fromSgfRepr(pos)),
+    props.gamestate.quantum_stones.map((pos) => Coordinate.fromSgfRepr(pos)),
   );
 });
 const board_1 = computed(() => {
   return board_with_quantum_stones(
     props.gamestate.boards[1],
-    props.gamestate.quantum_stones
-      .map((pair) => pair[1])
-      .filter((pos): pos is string => pos != null)
-      .map((pos) => Coordinate.fromSgfRepr(pos)),
+    props.gamestate.quantum_stones.map((pos) => Coordinate.fromSgfRepr(pos)),
   );
 });
 </script>


### PR DESCRIPTION
From Zi

> We did find a minor issue, i.e., the quantum pairs should live or die together, so once they are removed, the paired positions are still paired, meaning if a new stone is placed on one board in one of the quantum positions, it should also appear in the paired position on the other board.

![image(1)](https://github.com/govariantsteam/govariants/assets/25233703/656fe414-784f-4179-9786-0afca26c2fe9)
![image(2)](https://github.com/govariantsteam/govariants/assets/25233703/0c68d8fa-a786-4e3a-acba-b3e74e57f4d9)

---

This update actually simplifies the code because we no longer need to break entanglements.

- Move all quantum logic out of the helper class (and rename to `BadukHelper`)
- Represent quantum stones with a 1D 2-element array, instead of a 2D array
- Fix the quantum "reviving" of stones
- Add two tests