### PR TITLE
Improve layout for quantum boards.

### DIFF
--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -65,14 +65,14 @@ const board_1 = computed(() => {
 </script>
 
 <template>
-  <div style="width: 50%; height: 50%; display: inline-block">
+  <div style="width: 50%; height: 100%; display: inline-block">
     <MulticolorGridBoard
       :board="board_0"
       :config="props.config"
       @click="positionClicked"
     />
   </div>
-  <div style="width: 50%; height: 50%; display: inline-block">
+  <div style="width: 50%; height: 100%; display: inline-block">
     <MulticolorGridBoard
       :board="board_1"
       :config="props.config"


### PR DESCRIPTION
The 2:1 aspect ratio is always going to be difficult, but currently, the boards are half the size they could be based on height.  There is no change on narrow screens.

Before:

<img width="865" alt="Screenshot 2024-03-27 at 12 17 16 AM" src="https://github.com/govariantsteam/govariants/assets/25233703/36e0154d-2fe0-4dde-8aea-6ccdc46bea4a">

After:

<img width="946" alt="Screenshot 2024-03-27 at 12 19 47 AM" src="https://github.com/govariantsteam/govariants/assets/25233703/badf26aa-db44-4d25-8dc2-abd388599913">

