### PR TITLE
Add Byo-Yomi, Canadian, and Simple time controls

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -71,6 +71,20 @@ export async function getGame(id: string): Promise<GameResponse> {
   if (!game.players) {
     game.players = await BACKFILL_addEmptyPlayersArray(game);
   }
+  const playerClocks = Object.values(game.time_control?.forPlayer ?? {});
+  // bpj 2024-04-04: changed playerClock.remainingTimeMS to playerClock.clockState
+  // in order to support more complex clock states such as byo-yomi
+  if (game.time_control && playerClocks.some((tc) => tc.clockState == null)) {
+    playerClocks.forEach((tc) => {
+      if (tc.clockState) return;
+
+      if ("remainingTimeMS" in tc) {
+        // This is the state for Fischer and Absolute, the only supported
+        // time controls at the time of this change.
+        tc.clockState = { remainingTimeMS: tc.remainingTimeMS };
+      }
+    });
+  }
 
   return game;
 }

--- a/packages/server/src/time-control/__tests__/parallel.test.ts
+++ b/packages/server/src/time-control/__tests__/parallel.test.ts
@@ -37,12 +37,12 @@ function baseGameResponse(): GameResponse {
       moveTimestamps: [],
       forPlayer: {
         "0": {
-          remainingTimeMS: 300000,
+          clockState: { remainingTimeMS: 300000 },
           onThePlaySince: null,
           stagedMoveAt: null,
         } as PerPlayerTimeControlParallel,
         "1": {
-          remainingTimeMS: 300000,
+          clockState: { remainingTimeMS: 300000 },
           onThePlaySince: null,
           stagedMoveAt: null,
         } as PerPlayerTimeControlParallel,
@@ -65,12 +65,12 @@ test("initialState (Fischer)", () => {
     moveTimestamps: [],
     forPlayer: {
       "0": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: null,
         stagedMoveAt: null,
       },
       "1": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: null,
         stagedMoveAt: null,
       },
@@ -94,12 +94,12 @@ test("handleMove - staged move (Fischer)", () => {
     moveTimestamps: [DATE1],
     forPlayer: {
       "0": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: null,
         stagedMoveAt: DATE1,
       },
       "1": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: null,
         stagedMoveAt: null,
       },
@@ -131,12 +131,12 @@ test("handleMove - round transition (Fischer)", () => {
     moveTimestamps: [DATE1, DATE2, DATE3, DATE4],
     forPlayer: {
       "0": {
-        remainingTimeMS: 305000,
+        clockState: { remainingTimeMS: 305000 },
         onThePlaySince: DATE4,
         stagedMoveAt: null,
       },
       "1": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: DATE4,
         stagedMoveAt: null,
       },
@@ -172,12 +172,12 @@ test("handleMove - missing time_control will be treated as initialState", () => 
     moveTimestamps: [DATE1],
     forPlayer: {
       "0": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: null,
         stagedMoveAt: DATE1,
       },
       "1": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: null,
         stagedMoveAt: null,
       },
@@ -213,12 +213,12 @@ test("handleMove - timeout sets the clock to zero (Fischer)", () => {
     moveTimestamps: [DATE1, DATE2, TIMEOUT_DATE],
     forPlayer: {
       "0": {
-        remainingTimeMS: 0,
+        clockState: { remainingTimeMS: 0 },
         onThePlaySince: null,
         stagedMoveAt: null,
       },
       "1": {
-        remainingTimeMS: 300000,
+        clockState: { remainingTimeMS: 300000 },
         onThePlaySince: DATE2,
         stagedMoveAt: null,
       },

--- a/packages/server/src/time-control/__tests__/sequential.test.ts
+++ b/packages/server/src/time-control/__tests__/sequential.test.ts
@@ -1,6 +1,7 @@
 import {
   BadukConfig,
   GameResponse,
+  IBasicTimeState,
   IConfigWithTimeControl,
   IFischerConfig,
   ITimeControlBase,
@@ -63,21 +64,29 @@ describe("Sequential Time Control Tests", () => {
 
     const seconds1 = 10;
     gameResponse.time_control = mockPlayMove(0, "aa", seconds1);
-    const time1 = gameResponse.time_control.forPlayer[0].remainingTimeMS;
+    const time1 = (
+      gameResponse.time_control.forPlayer[0].clockState as IBasicTimeState
+    ).remainingTimeMS;
 
     const seconds2 = 20;
     gameResponse.time_control = mockPlayMove(1, "bb", seconds2);
-    const time2 = gameResponse.time_control.forPlayer[1].remainingTimeMS;
+    const time2 = (
+      gameResponse.time_control.forPlayer[1].clockState as IBasicTimeState
+    ).remainingTimeMS;
 
     // time control should start here
 
     const seconds3 = 24;
     gameResponse.time_control = mockPlayMove(0, "cc", seconds3);
-    const time3 = gameResponse.time_control.forPlayer[0].remainingTimeMS;
+    const time3 = (
+      gameResponse.time_control.forPlayer[0].clockState as IBasicTimeState
+    ).remainingTimeMS;
 
     const seconds4 = 30;
     gameResponse.time_control = mockPlayMove(1, "dd", seconds4);
-    const time4 = gameResponse.time_control.forPlayer[1].remainingTimeMS;
+    const time4 = (
+      gameResponse.time_control.forPlayer[1].clockState as IBasicTimeState
+    ).remainingTimeMS;
 
     const seconds5 = 40;
     clock.setTimestamp(new Date(0, 0, 0, 0, 0, seconds5));

--- a/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
+++ b/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
@@ -19,8 +19,8 @@ test("initialState (Absolute)", () => {
   expect(initialState("baduk", ABSOLUTE_CONFIG)).toEqual({
     moveTimestamps: [],
     forPlayer: {
-      "0": { remainingTimeMS: 600000, onThePlaySince: null },
-      "1": { remainingTimeMS: 600000, onThePlaySince: null },
+      "0": { clockState: { remainingTimeMS: 600000 }, onThePlaySince: null },
+      "1": { clockState: { remainingTimeMS: 600000 }, onThePlaySince: null },
     },
   });
 });
@@ -33,11 +33,11 @@ test("makeTransition (Absolute)", () => {
     "game_id",
   );
   const playerData: IPerPlayerTimeControlBase = {
-    remainingTimeMS: 600000,
+    clockState: { remainingTimeMS: 600000 },
     onThePlaySince: null,
   };
   transition(playerData);
-  expect(playerData.remainingTimeMS).toBe(595000);
+  expect(playerData.clockState).toEqual({ remainingTimeMS: 595000 });
 });
 
 test("makeTransition: timeout (Absolute)", () => {
@@ -48,11 +48,11 @@ test("makeTransition: timeout (Absolute)", () => {
     "game_id",
   );
   const playerData: IPerPlayerTimeControlBase = {
-    remainingTimeMS: 600000,
+    clockState: { remainingTimeMS: 600000 },
     onThePlaySince: null,
   };
   transition(playerData);
-  expect(playerData.remainingTimeMS).toBe(0);
+  expect(playerData.clockState).toEqual({ remainingTimeMS: 0 });
 });
 
 test("makeTransition: timeout (Fischer)", () => {
@@ -72,11 +72,11 @@ test("makeTransition: timeout (Fischer)", () => {
     "game_id",
   );
   const playerData: IPerPlayerTimeControlBase = {
-    remainingTimeMS: 600000,
+    clockState: { remainingTimeMS: 600000 },
     onThePlaySince: null,
   };
   transition(playerData);
-  expect(playerData.remainingTimeMS).toBe(0);
+  expect(playerData.clockState).toEqual({ remainingTimeMS: 0 });
 });
 
 test("makeTransition: (Uncapped Fischer)", () => {
@@ -96,11 +96,11 @@ test("makeTransition: (Uncapped Fischer)", () => {
     "game_id",
   );
   const playerData: IPerPlayerTimeControlBase = {
-    remainingTimeMS: 600_000,
+    clockState: { remainingTimeMS: 600_000 },
     onThePlaySince: null,
   };
   transition(playerData);
-  expect(playerData.remainingTimeMS).toBe(603_000);
+  expect(playerData.clockState).toEqual({ remainingTimeMS: 603_000 });
 });
 
 test("makeTransition (Invalid)", () => {
@@ -115,7 +115,7 @@ test("makeTransition (Invalid)", () => {
 
 test("msUntilTimeout (Absolute)", () => {
   const playerData: IPerPlayerTimeControlBase = {
-    remainingTimeMS: 600000,
+    clockState: { remainingTimeMS: 600000 },
     // player has not played a move yet
     // or player is not on the play
     onThePlaySince: null,

--- a/packages/server/src/time-control/time-handler-parallel.ts
+++ b/packages/server/src/time-control/time-handler-parallel.ts
@@ -100,7 +100,10 @@ export class TimeHandlerParallelMoves implements ITimeHandler {
 
     const playerData = timeControl.forPlayer[playerNr];
 
-    const timeConfig = (game.config as IConfigWithTimeControl).time_control;
+    if (!game.config.time_control) {
+      throw new Error(`Time control not found in game ${game.id}`);
+    }
+    const timeConfig = game.config.time_control;
     const clockController = timeControlMap.get(timeConfig.type);
 
     if (move === "resign" || move === "timeout") {

--- a/packages/server/src/time-control/time-handler-utils.ts
+++ b/packages/server/src/time-control/time-handler-utils.ts
@@ -2,11 +2,11 @@ import {
   GameResponse,
   GenericTimeControl,
   IConfigWithTimeControl,
-  IFischerConfig,
   IPerPlayerTimeControlBase,
   ITimeControlBase,
-  TimeControlType,
+  TimeControl,
   makeGameObject,
+  timeControlMap,
 } from "@ogfcommunity/variants-shared";
 
 export function initialState(
@@ -26,6 +26,10 @@ export function initialState(
   ) => IPerPlayerTimeControlBase = (base) => base,
 ): ITimeControlBase {
   const numPlayers = makeGameObject(variant, config).numPlayers();
+  const clock = timeControlMap.get(config.time_control.type);
+  if (!clock) {
+    throw new Error("Received config with invalid time control type");
+  }
 
   const timeControl: ITimeControlBase = {
     moveTimestamps: [],
@@ -34,25 +38,9 @@ export function initialState(
 
   for (let i = 0; i < numPlayers; i++) {
     timeControl.forPlayer[i] = modifier({
-      remainingTimeMS: config.time_control.mainTimeMS,
+      clockState: clock.initialState(config.time_control),
       onThePlaySince: null,
     });
-  }
-
-  switch (config.time_control.type) {
-    case TimeControlType.Absolute: {
-      // nothing to do
-      break;
-    }
-
-    case TimeControlType.Fischer: {
-      // nothing to do
-      break;
-    }
-
-    default: {
-      console.error("received config with invalid time control type");
-    }
   }
 
   return timeControl;
@@ -64,41 +52,24 @@ export function makeTransition<T extends IPerPlayerTimeControlBase>(
   move: string,
   game_id: string,
 ): (playerData: T) => void {
-  switch (config.time_control.type) {
-    case TimeControlType.Absolute: {
-      return (playerData) => {
-        if (move === "timeout") {
-          playerData.remainingTimeMS = 0;
-          return;
-        }
-
-        playerData.remainingTimeMS -= getElapsedMS(playerData);
-      };
-    }
-
-    case TimeControlType.Fischer: {
-      const fischerConfig = config.time_control as IFischerConfig;
-      return (playerData) => {
-        if (move === "timeout") {
-          playerData.remainingTimeMS = 0;
-          return;
-        }
-
-        const uncapped =
-          playerData.remainingTimeMS +
-          fischerConfig.incrementMS -
-          getElapsedMS(playerData);
-
-        playerData.remainingTimeMS =
-          fischerConfig.maxTimeMS === null
-            ? uncapped
-            : Math.min(uncapped, fischerConfig.maxTimeMS);
-      };
-    }
-
-    case TimeControlType.Invalid:
-      throw Error(`game with id ${game_id} has invalid time control type`);
+  const timeConfig = config.time_control;
+  const clock = timeControlMap.get(timeConfig.type);
+  if (!clock) {
+    throw Error(`game with id ${game_id} has invalid time control type`);
   }
+  return (playerData) => {
+    if (move === "timeout") {
+      playerData.clockState = nullTimeState(clock, timeConfig);
+      return;
+    }
+
+    const elapsedState = clock.elapse(
+      getElapsedMS(playerData),
+      playerData.clockState,
+      timeConfig,
+    );
+    playerData.clockState = clock.renew(elapsedState, timeConfig);
+  };
 }
 
 export function getMsUntilTimeout(
@@ -106,34 +77,47 @@ export function getMsUntilTimeout(
   playerNr: number,
   timeMS: number,
 ): number | null {
-  const config = game.config as IConfigWithTimeControl;
+  const config = (game.config as IConfigWithTimeControl).time_control;
 
-  switch (config.time_control.type) {
-    case TimeControlType.Absolute:
-    case TimeControlType.Fischer: {
-      const times: ITimeControlBase = game.time_control;
-
-      if (times === undefined || times.forPlayer === undefined) {
-        // old game with no moves
-        return null;
-      }
-
-      const playerTime = times.forPlayer[playerNr];
-
-      if (playerTime === undefined || playerTime.onThePlaySince === null) {
-        // player has not played a move yet
-        // or player is not on the play
-        return null;
-      }
-
-      const timeoutTime =
-        playerTime.onThePlaySince.getTime() + playerTime.remainingTimeMS;
-
-      return timeoutTime - timeMS;
-    }
-    default: {
-      console.error(`game with id ${game.id} has invalid time control type`);
-      return;
-    }
+  const clock = timeControlMap.get(config.type);
+  if (clock === undefined) {
+    console.error(`game with id ${game.id} has invalid time control type`);
+    return;
   }
+
+  const times: ITimeControlBase = game.time_control;
+
+  if (times === undefined || times.forPlayer === undefined) {
+    // old game with no moves
+    return null;
+  }
+
+  const playerTime = times.forPlayer[playerNr];
+
+  if (playerTime === undefined || playerTime.onThePlaySince === null) {
+    // player has not played a move yet
+    // or player is not on the play
+    return null;
+  }
+
+  const elapsed = timeMS - playerTime.onThePlaySince.getTime();
+  const elapsedState = clock.elapse(elapsed, playerTime.clockState, config);
+  return clock.msUntilTimeout(elapsedState, config);
+}
+
+// This function is a bit of a hack to help replace instances of
+// playerData.remainingTimeMS = 0
+// It makes the assumption that timeControl.msUntilTimeout()
+// represents a homomorphism on the clockState-space, such that
+// elapsing time from a clockState is equivalent to subtracting time
+// from msUntilTimeout.
+// Therefore, this function returns the clockState equivalent of
+// t0 - t0 = 0
+export function nullTimeState(
+  timeControl: TimeControl<object, object>,
+  config: object,
+) {
+  const initialState = timeControl.initialState(config);
+  const msUntilTimeout = timeControl.msUntilTimeout(initialState, config);
+  return timeControl.elapse(msUntilTimeout, initialState, config);
 }

--- a/packages/shared/src/api_types.ts
+++ b/packages/shared/src/api_types.ts
@@ -1,5 +1,8 @@
 import { MovesType } from "./lib/utils";
-import { ITimeControlBase } from "./time_control/time_control.types";
+import {
+  ITimeControlBase,
+  ITimeControlConfig,
+} from "./time_control/time_control.types";
 
 export interface User {
   username?: string;
@@ -9,7 +12,7 @@ export interface GameResponse {
   id: string;
   variant: string;
   moves: MovesType[];
-  config: unknown;
+  config: { time_control?: ITimeControlConfig };
   players?: Array<User | undefined>;
   time_control?: ITimeControlBase;
 }

--- a/packages/shared/src/time_control/__tests__/time_control_systems.test.ts
+++ b/packages/shared/src/time_control/__tests__/time_control_systems.test.ts
@@ -1,0 +1,353 @@
+import {
+  IFischerConfig,
+  ITimeControlConfig,
+  TimeControlType,
+} from "../time_control.types";
+import {
+  AbsoluteSystem,
+  ByoYomiSystem,
+  CanadianSystem,
+  FischerSystem,
+  IBasicTimeState,
+  IByoYomiConfig,
+  IByoYomiState,
+  ICanadianTimeConfig,
+  ICanadianTimeState,
+  SimpleSystem,
+  TimeControlSystem,
+} from "../time_control_systems";
+
+describe("Fischer", () => {
+  const fischerConfig = {
+    type: TimeControlType.Fischer,
+    mainTimeMS: 600000, // 10 minutes
+    incrementMS: 5000, // 5 seconds increment
+    maxTimeMS: 1200000, // 20 minutes maximum time
+  } as const;
+
+  // FischerSystem doesn't hold its own state, so we can re-use the same
+  // object in all the tests.
+  const fischerSystem: TimeControlSystem<IFischerConfig, IBasicTimeState> =
+    new FischerSystem();
+
+  test("initialState returns the correct initial state", () => {
+    const initialState = fischerSystem.initialState(fischerConfig);
+    expect(initialState).toEqual({ remainingTimeMS: 600000 });
+  });
+
+  test("elapse subtracts elapsed time from remaining time", () => {
+    const initialState = fischerSystem.initialState(fischerConfig);
+    const updatedState = fischerSystem.elapse(
+      30000,
+      initialState,
+      fischerConfig,
+    );
+    expect(updatedState.remainingTimeMS).toEqual(570000); // 10 minutes - 30 seconds
+  });
+
+  test("renew updates the remaining time with increment if not exceeding maxTime", () => {
+    const initialState = fischerSystem.initialState(fischerConfig);
+    const renewedState = fischerSystem.renew(initialState, fischerConfig);
+    expect(renewedState.remainingTimeMS).toEqual(605000); // 10 minutes + 5 seconds increment
+  });
+
+  test("renew caps remaining time at maxTime if specified", () => {
+    const configWithMaxTime = {
+      ...fischerConfig,
+      mainTimeMS: 1190000,
+      incrementMS: 20000,
+    }; // main time + increment > max time
+    const initialState = fischerSystem.initialState(configWithMaxTime);
+    const renewedState = fischerSystem.renew(initialState, configWithMaxTime);
+    expect(renewedState.remainingTimeMS).toEqual(1200000); // Should cap at maxTime (20 minutes)
+  });
+
+  test("time is uncapped if max time is null", () => {
+    const config = {
+      ...fischerConfig,
+      maxTimeMS: null,
+      mainTimeMS: 1190000,
+      incrementMS: 20000,
+    }; // main time + increment > max time
+    const initialState = fischerSystem.initialState(config);
+    const renewedState = fischerSystem.renew(initialState, config);
+    expect(renewedState.remainingTimeMS).toEqual(1210000);
+  });
+
+  test("msUntilTimeout returns the correct time until timeout", () => {
+    const initialState = fischerSystem.initialState(fischerConfig);
+    const timeUntilTimeout = fischerSystem.msUntilTimeout(
+      initialState,
+      fischerConfig,
+    );
+    expect(timeUntilTimeout).toEqual(600000); // Initial remaining time
+  });
+
+  test("timeString returns the correct string representation of time", () => {
+    const initialState = fischerSystem.initialState(fischerConfig);
+    const timeString = fischerSystem.timeString(initialState);
+    expect(timeString).toEqual("10:00"); // Initial remaining time in MM:SS format
+  });
+});
+
+describe("Byo-Yomi", () => {
+  const byoYomiConfig = {
+    type: TimeControlType.ByoYomi,
+    mainTimeMS: 600000, // 10 minutes
+    numPeriods: 3, // 3 periods
+    periodTimeMS: 30000, // 30 seconds per period
+  } as const;
+
+  // ByoYomiSystem doesn't hold its own state, so we can re-use the same
+  // object in all the tests.
+  const byoYomiSystem: TimeControlSystem<IByoYomiConfig, IByoYomiState> =
+    new ByoYomiSystem();
+
+  test("initialState returns the correct initial state", () => {
+    const initialState = byoYomiSystem.initialState(byoYomiConfig);
+    expect(initialState).toEqual({
+      mainTimeRemainingMS: 600000,
+      periodsRemaining: 3,
+      periodTimeRemainingMS: 30000,
+    });
+  });
+
+  test("elapse subtracts elapsed time from remaining time", () => {
+    const initialState = byoYomiSystem.initialState(byoYomiConfig);
+    const updatedState = byoYomiSystem.elapse(
+      45000,
+      initialState,
+      byoYomiConfig,
+    );
+    expect(updatedState.mainTimeRemainingMS).toEqual(555000); // 10 minutes - 45 seconds
+  });
+
+  test("elapse (timeout)", () => {
+    const initialState = byoYomiSystem.initialState(byoYomiConfig);
+    const timeoutState = byoYomiSystem.elapse(
+      695000,
+      initialState,
+      byoYomiConfig,
+    ); // 5 seconds past the end
+    expect(timeoutState).toEqual({
+      mainTimeRemainingMS: 0,
+      periodsRemaining: 0,
+      periodTimeRemainingMS: 0,
+    });
+  });
+
+  test("renew resets the period time", () => {
+    const initialState = byoYomiSystem.initialState(byoYomiConfig);
+    const overtimeState = byoYomiSystem.elapse(
+      615000,
+      initialState,
+      byoYomiConfig,
+    ); // main time + 15s
+    const renewedState = byoYomiSystem.renew(overtimeState, byoYomiConfig);
+    expect(renewedState.periodTimeRemainingMS).toEqual(30000); // Should reset period time
+  });
+
+  test("msUntilTimeout returns the correct time until timeout", () => {
+    const initialState = byoYomiSystem.initialState(byoYomiConfig);
+    const timeUntilTimeout = byoYomiSystem.msUntilTimeout(
+      initialState,
+      byoYomiConfig,
+    );
+    expect(timeUntilTimeout).toEqual(690000); // 10 minutes + 30s x 3
+  });
+
+  test("timeString returns the correct string representation of time", () => {
+    const initialState = byoYomiSystem.initialState(byoYomiConfig);
+    const timeString = byoYomiSystem.timeString(initialState);
+    expect(timeString).toEqual("10:00 + 00:30 (3)"); // Initial remaining time and period time
+  });
+
+  test("timeString (overtime)", () => {
+    const initialState = byoYomiSystem.initialState(byoYomiConfig);
+    const state = byoYomiSystem.elapse(645000, initialState, byoYomiConfig); // main time + 45s
+    const timeString = byoYomiSystem.timeString(state);
+    expect(timeString).toEqual("00:15 (2)"); // period time only
+  });
+});
+
+describe("AbsoluteSystem", () => {
+  const absoluteConfig = {
+    type: TimeControlType.Absolute,
+    mainTimeMS: 600000, // 10 minutes
+  };
+
+  const absoluteSystem: TimeControlSystem<ITimeControlConfig, IBasicTimeState> =
+    new AbsoluteSystem();
+
+  test("initialState returns the correct initial state", () => {
+    const initialState = absoluteSystem.initialState(absoluteConfig);
+    expect(initialState).toEqual({ remainingTimeMS: 600000 });
+  });
+
+  test("elapse subtracts elapsed time from remaining time", () => {
+    const initialState = absoluteSystem.initialState(absoluteConfig);
+    const updatedState = absoluteSystem.elapse(
+      45000,
+      initialState,
+      absoluteConfig,
+    );
+    expect(updatedState.remainingTimeMS).toEqual(555000); // 10 minutes - 45 seconds
+  });
+
+  test("renew does nothing", () => {
+    const initialState = absoluteSystem.initialState(absoluteConfig);
+    const elapsedState = absoluteSystem.elapse(
+      45000,
+      initialState,
+      absoluteConfig,
+    );
+    const renewedState = absoluteSystem.renew(elapsedState, absoluteConfig);
+    expect(elapsedState).toEqual(renewedState);
+  });
+
+  test("msUntilTimeout returns the correct time until timeout", () => {
+    const initialState = absoluteSystem.initialState(absoluteConfig);
+    const timeUntilTimeout = absoluteSystem.msUntilTimeout(
+      initialState,
+      absoluteConfig,
+    );
+    expect(timeUntilTimeout).toEqual(600000); // Initial remaining time
+  });
+
+  test("timeString", () => {
+    const initialState = absoluteSystem.initialState(absoluteConfig);
+    const timeString = absoluteSystem.timeString(initialState);
+    expect(timeString).toBe("10:00"); // Initial remaining time in MM:SS format
+  });
+});
+
+describe("CanadianSystem", () => {
+  const canadianConfig = {
+    type: TimeControlType.Canadian,
+    mainTimeMS: 600000, // 10 minutes
+    numPeriods: 3, // 3 periods in a block
+    periodTimeMS: 30000, // 30 seconds of period time
+  } as const;
+
+  const canadianSystem: TimeControlSystem<
+    ICanadianTimeConfig,
+    ICanadianTimeState
+  > = new CanadianSystem();
+
+  test("initialState returns the correct initial state", () => {
+    const initialState = canadianSystem.initialState(canadianConfig);
+    expect(initialState).toEqual({
+      mainTimeRemainingMS: 600000,
+      periodTimeRemainingMS: 30000,
+      renewalCountdown: 3,
+    });
+  });
+
+  test("elapse & renew (main time)", () => {
+    const initialState = canadianSystem.initialState(canadianConfig);
+    const elapsedState = canadianSystem.elapse(
+      45000,
+      initialState,
+      canadianConfig,
+    );
+    const renewedState = canadianSystem.renew(elapsedState, canadianConfig);
+
+    expect(elapsedState.mainTimeRemainingMS).toBe(555000); // 10 minutes - 45 seconds
+    // renewal does nothing in main time
+    expect(elapsedState).toEqual(renewedState);
+  });
+
+  test("elapse & renew (overtime)", () => {
+    let state = canadianSystem.initialState({
+      ...canadianConfig,
+      mainTimeMS: 0, // renew
+    });
+
+    state = canadianSystem.elapse(5000, state, canadianConfig);
+    expect(state.renewalCountdown).toBe(3); // elapse doesn't update the countdown
+    state = canadianSystem.renew(state, canadianConfig);
+    expect(state.periodTimeRemainingMS).toBe(25000); // 25 seconds
+    expect(state.renewalCountdown).toBe(2);
+
+    state = canadianSystem.elapse(5000, state, canadianConfig);
+    expect(state.renewalCountdown).toBe(2); // elapse doesn't update the countdown
+    state = canadianSystem.renew(state, canadianConfig);
+    expect(state.periodTimeRemainingMS).toBe(20000); // 20 seconds
+    expect(state.renewalCountdown).toBe(1);
+
+    // fully renews once every 3 moves
+    state = canadianSystem.elapse(5000, state, canadianConfig);
+    expect(state.periodTimeRemainingMS).toBe(15000); // 15 seconds
+    expect(state.renewalCountdown).toBe(1); // elapse doesn't update the countdown
+    state = canadianSystem.renew(state, canadianConfig);
+    expect(state.periodTimeRemainingMS).toBe(30000); // 30 seconds
+    expect(state.renewalCountdown).toBe(3);
+  });
+
+  test("msUntilTimeout returns the correct time until timeout", () => {
+    const initialState = canadianSystem.initialState(canadianConfig);
+    const timeUntilTimeout = canadianSystem.msUntilTimeout(
+      initialState,
+      canadianConfig,
+    );
+    expect(timeUntilTimeout).toEqual(630000); // 10 minutes + 30 seconds (first period)
+  });
+
+  test("timeString returns the correct string representation of time", () => {
+    const initialState = canadianSystem.initialState(canadianConfig);
+    const timeString = canadianSystem.timeString(initialState);
+    expect(timeString).toEqual("10:00 + 00:30/3"); // Initial remaining time, period time, and countdown
+  });
+
+  test("timeString (overtime)", () => {
+    let state = canadianSystem.initialState(canadianConfig);
+    state = canadianSystem.elapse(615000, state, canadianConfig); // main time + 15s
+    state = canadianSystem.renew(state, canadianConfig);
+    const timeString = canadianSystem.timeString(state);
+
+    expect(timeString).toEqual("00:15/2"); // period time only
+  });
+});
+
+describe("SimpleSystem", () => {
+  const simpleConfig = {
+    type: TimeControlType.Simple,
+    mainTimeMS: 30000, // 30 seconds
+  };
+
+  const simpleSystem: TimeControlSystem<ITimeControlConfig, IBasicTimeState> =
+    new SimpleSystem();
+
+  test("initialState returns the correct initial state", () => {
+    const initialState = simpleSystem.initialState(simpleConfig);
+    expect(initialState).toEqual({ remainingTimeMS: 30000 });
+  });
+
+  test("elapse subtracts elapsed time from remaining time", () => {
+    const initialState = simpleSystem.initialState(simpleConfig);
+    const updatedState = simpleSystem.elapse(15000, initialState, simpleConfig);
+    expect(updatedState.remainingTimeMS).toEqual(15000); // 10 minutes - 45 seconds
+  });
+
+  test("renew resets the remaining time to main time", () => {
+    const initialState = simpleSystem.initialState(simpleConfig);
+    const elapsedState = simpleSystem.elapse(15000, initialState, simpleConfig);
+    const renewedState = simpleSystem.renew(elapsedState, simpleConfig);
+    expect(renewedState.remainingTimeMS).toEqual(30000); // Should reset remaining time to main time
+  });
+
+  test("msUntilTimeout returns the correct time until timeout", () => {
+    const initialState = simpleSystem.initialState(simpleConfig);
+    const timeUntilTimeout = simpleSystem.msUntilTimeout(
+      initialState,
+      simpleConfig,
+    );
+    expect(timeUntilTimeout).toEqual(30000); // Initial remaining time
+  });
+
+  test("timeString returns the correct string representation of time", () => {
+    const initialState = simpleSystem.initialState(simpleConfig);
+    const timeString = simpleSystem.timeString(initialState);
+    expect(timeString).toEqual("00:30"); // Initial remaining time in MM:SS format
+  });
+});

--- a/packages/shared/src/time_control/__tests__/time_control_systems.test.ts
+++ b/packages/shared/src/time_control/__tests__/time_control_systems.test.ts
@@ -1,25 +1,21 @@
 import {
   IFischerConfig,
   ITimeControlConfig,
-  TimeControlType,
+  TimeControlType as TC,
 } from "../time_control.types";
 import {
-  AbsoluteSystem,
-  ByoYomiSystem,
-  CanadianSystem,
-  FischerSystem,
   IBasicTimeState,
   IByoYomiConfig,
   IByoYomiState,
   ICanadianTimeConfig,
   ICanadianTimeState,
-  SimpleSystem,
-  TimeControlSystem,
+  TimeControl,
+  timeControlMap,
 } from "../time_control_systems";
 
 describe("Fischer", () => {
   const fischerConfig = {
-    type: TimeControlType.Fischer,
+    type: TC.Fischer,
     mainTimeMS: 600000, // 10 minutes
     incrementMS: 5000, // 5 seconds increment
     maxTimeMS: 1200000, // 20 minutes maximum time
@@ -27,8 +23,10 @@ describe("Fischer", () => {
 
   // FischerSystem doesn't hold its own state, so we can re-use the same
   // object in all the tests.
-  const fischerSystem: TimeControlSystem<IFischerConfig, IBasicTimeState> =
-    new FischerSystem();
+  const fischerSystem = timeControlMap.get(TC.Fischer) as TimeControl<
+    IFischerConfig,
+    IBasicTimeState
+  >;
 
   test("initialState returns the correct initial state", () => {
     const initialState = fischerSystem.initialState(fischerConfig);
@@ -92,7 +90,7 @@ describe("Fischer", () => {
 
 describe("Byo-Yomi", () => {
   const byoYomiConfig = {
-    type: TimeControlType.ByoYomi,
+    type: TC.ByoYomi,
     mainTimeMS: 600000, // 10 minutes
     numPeriods: 3, // 3 periods
     periodTimeMS: 30000, // 30 seconds per period
@@ -100,8 +98,10 @@ describe("Byo-Yomi", () => {
 
   // ByoYomiSystem doesn't hold its own state, so we can re-use the same
   // object in all the tests.
-  const byoYomiSystem: TimeControlSystem<IByoYomiConfig, IByoYomiState> =
-    new ByoYomiSystem();
+  const byoYomiSystem = timeControlMap.get(TC.ByoYomi) as TimeControl<
+    IByoYomiConfig,
+    IByoYomiState
+  >;
 
   test("initialState returns the correct initial state", () => {
     const initialState = byoYomiSystem.initialState(byoYomiConfig);
@@ -172,12 +172,14 @@ describe("Byo-Yomi", () => {
 
 describe("AbsoluteSystem", () => {
   const absoluteConfig = {
-    type: TimeControlType.Absolute,
+    type: TC.Absolute,
     mainTimeMS: 600000, // 10 minutes
   };
 
-  const absoluteSystem: TimeControlSystem<ITimeControlConfig, IBasicTimeState> =
-    new AbsoluteSystem();
+  const absoluteSystem = timeControlMap.get(TC.Absolute) as TimeControl<
+    ITimeControlConfig,
+    IBasicTimeState
+  >;
 
   test("initialState returns the correct initial state", () => {
     const initialState = absoluteSystem.initialState(absoluteConfig);
@@ -223,16 +225,16 @@ describe("AbsoluteSystem", () => {
 
 describe("CanadianSystem", () => {
   const canadianConfig = {
-    type: TimeControlType.Canadian,
+    type: TC.Canadian,
     mainTimeMS: 600000, // 10 minutes
     numPeriods: 3, // 3 periods in a block
     periodTimeMS: 30000, // 30 seconds of period time
   } as const;
 
-  const canadianSystem: TimeControlSystem<
+  const canadianSystem = timeControlMap.get(TC.Canadian) as TimeControl<
     ICanadianTimeConfig,
     ICanadianTimeState
-  > = new CanadianSystem();
+  >;
 
   test("initialState returns the correct initial state", () => {
     const initialState = canadianSystem.initialState(canadianConfig);
@@ -311,12 +313,14 @@ describe("CanadianSystem", () => {
 
 describe("SimpleSystem", () => {
   const simpleConfig = {
-    type: TimeControlType.Simple,
+    type: TC.Simple,
     mainTimeMS: 30000, // 30 seconds
   };
 
-  const simpleSystem: TimeControlSystem<ITimeControlConfig, IBasicTimeState> =
-    new SimpleSystem();
+  const simpleSystem = timeControlMap.get(TC.Simple) as TimeControl<
+    ITimeControlConfig,
+    IBasicTimeState
+  >;
 
   test("initialState returns the correct initial state", () => {
     const initialState = simpleSystem.initialState(simpleConfig);

--- a/packages/shared/src/time_control/index.ts
+++ b/packages/shared/src/time_control/index.ts
@@ -1,2 +1,3 @@
 export * from "./time_control.types";
 export * from "./time_control.utils";
+export * from "./time_control_systems";

--- a/packages/shared/src/time_control/time_control.types.ts
+++ b/packages/shared/src/time_control/time_control.types.ts
@@ -23,7 +23,7 @@ export interface IConfigWithTimeControl {
 }
 
 export interface IPerPlayerTimeControlBase {
-  remainingTimeMS: number;
+  clockState: object;
   onThePlaySince: Date | null;
 }
 export type PerPlayerTimeControlParallel = IPerPlayerTimeControlBase & {

--- a/packages/shared/src/time_control/time_control.types.ts
+++ b/packages/shared/src/time_control/time_control.types.ts
@@ -2,6 +2,9 @@ export enum TimeControlType {
   Invalid = 0,
   Absolute = 1,
   Fischer = 2,
+  Simple = 3,
+  ByoYomi = 4,
+  Canadian = 5,
   // unlimited time is configured by config.time_control = undefined
 }
 
@@ -10,6 +13,7 @@ export interface ITimeControlConfig {
   mainTimeMS: number;
 }
 export interface IFischerConfig extends ITimeControlConfig {
+  type: TimeControlType.Fischer;
   incrementMS: number;
   maxTimeMS: number | null;
 }

--- a/packages/shared/src/time_control/time_control.utils.ts
+++ b/packages/shared/src/time_control/time_control.utils.ts
@@ -15,3 +15,39 @@ export function HasTimeControlConfig(
     game_config.time_control !== null
   );
 }
+
+export function msToTime(ms: number): string {
+  let msCopy = ms;
+
+  const milliseconds = ms % 1000;
+  msCopy = (msCopy - milliseconds) / 1000;
+
+  const seconds = msCopy % 60;
+  msCopy = (msCopy - seconds) / 60;
+
+  const minutes = msCopy % 60;
+  msCopy = (msCopy - minutes) / 60;
+
+  if (msCopy < 1) {
+    return `${minutes.toLocaleString(undefined, {
+      minimumIntegerDigits: 2,
+    })}:${seconds.toLocaleString(undefined, { minimumIntegerDigits: 2 })}`;
+  }
+
+  const hours = msCopy % 24;
+  msCopy = (msCopy - hours) / 24;
+
+  if (msCopy < 1) {
+    return `${hours.toLocaleString(undefined, {
+      style: "unit",
+      unit: "hour",
+    })}`;
+  }
+
+  const days = msCopy;
+
+  return `${days.toLocaleString(undefined, {
+    style: "unit",
+    unit: "day",
+  })}`;
+}

--- a/packages/shared/src/time_control/time_control_systems.ts
+++ b/packages/shared/src/time_control/time_control_systems.ts
@@ -248,8 +248,8 @@ function nullRenewal<T>(state: T) {
 
 export const timeControlMap: ReadonlyMap<
   TimeControlType,
-  TimeControl<unknown, unknown>
-> = new Map<TimeControlType, TimeControl<unknown, unknown>>([
+  TimeControl<object, object>
+> = new Map<TimeControlType, TimeControl<object, object>>([
   [TimeControlType.Absolute, new AbsoluteTimeControl()],
   [TimeControlType.ByoYomi, new ByoYomiTimeControl()],
   [TimeControlType.Canadian, new CanadianTimeControl()],

--- a/packages/shared/src/time_control/time_control_systems.ts
+++ b/packages/shared/src/time_control/time_control_systems.ts
@@ -5,7 +5,7 @@ import {
 } from "./time_control.types";
 import { msToTime } from "./time_control.utils";
 
-export interface TimeControlSystem<ConfigT, StateT> {
+export interface TimeControl<ConfigT, StateT> {
   initialState(config: ConfigT): StateT;
   /** Return an updated state to reflect the elapsed time */
   elapse(elapsedMS: number, state: StateT, config: ConfigT): StateT;
@@ -19,8 +19,8 @@ export interface IBasicTimeState {
   remainingTimeMS: number;
 }
 
-export class FischerSystem
-  implements TimeControlSystem<IFischerConfig, IBasicTimeState>
+class FischerTimeControl
+  implements TimeControl<IFischerConfig, IBasicTimeState>
 {
   initialState(config: IFischerConfig): IBasicTimeState {
     return { remainingTimeMS: config.mainTimeMS };
@@ -50,8 +50,8 @@ export class FischerSystem
   }
 }
 
-export class AbsoluteSystem
-  implements TimeControlSystem<ITimeControlConfig, IBasicTimeState>
+class AbsoluteTimeControl
+  implements TimeControl<ITimeControlConfig, IBasicTimeState>
 {
   initialState(config: ITimeControlConfig): IBasicTimeState {
     return { remainingTimeMS: config.mainTimeMS };
@@ -83,9 +83,7 @@ export interface IByoYomiState {
   periodTimeRemainingMS: number;
 }
 
-export class ByoYomiSystem
-  implements TimeControlSystem<IByoYomiConfig, IByoYomiState>
-{
+class ByoYomiTimeControl implements TimeControl<IByoYomiConfig, IByoYomiState> {
   initialState(config: IByoYomiConfig): IByoYomiState {
     return {
       mainTimeRemainingMS: config.mainTimeMS,
@@ -149,8 +147,8 @@ export class ByoYomiSystem
   }
 }
 
-export class SimpleSystem
-  implements TimeControlSystem<ITimeControlConfig, IBasicTimeState>
+class SimpleTimeControl
+  implements TimeControl<ITimeControlConfig, IBasicTimeState>
 {
   initialState(config: ITimeControlConfig) {
     return {
@@ -186,8 +184,8 @@ export interface ICanadianTimeConfig extends ITimeControlConfig {
   periodTimeMS: number;
 }
 
-export class CanadianSystem
-  implements TimeControlSystem<ICanadianTimeConfig, ICanadianTimeState>
+class CanadianTimeControl
+  implements TimeControl<ICanadianTimeConfig, ICanadianTimeState>
 {
   initialState(config: ICanadianTimeConfig) {
     return {
@@ -247,3 +245,14 @@ export class CanadianSystem
 function nullRenewal<T>(state: T) {
   return { ...state };
 }
+
+export const timeControlMap: ReadonlyMap<
+  TimeControlType,
+  TimeControl<unknown, unknown>
+> = new Map<TimeControlType, TimeControl<unknown, unknown>>([
+  [TimeControlType.Absolute, new AbsoluteTimeControl()],
+  [TimeControlType.ByoYomi, new ByoYomiTimeControl()],
+  [TimeControlType.Canadian, new CanadianTimeControl()],
+  [TimeControlType.Fischer, new FischerTimeControl()],
+  [TimeControlType.Simple, new SimpleTimeControl()],
+]);

--- a/packages/shared/src/time_control/time_control_systems.ts
+++ b/packages/shared/src/time_control/time_control_systems.ts
@@ -242,7 +242,7 @@ class CanadianTimeControl
 }
 
 // Convenience function for when the state doesn't change at the end of a round
-function nullRenewal<T>(state: T) {
+function nullRenewal<T extends object>(state: T) {
   return { ...state };
 }
 

--- a/packages/shared/src/time_control/time_control_systems.ts
+++ b/packages/shared/src/time_control/time_control_systems.ts
@@ -1,0 +1,249 @@
+import {
+  type IFischerConfig,
+  type ITimeControlConfig,
+  TimeControlType,
+} from "./time_control.types";
+import { msToTime } from "./time_control.utils";
+
+interface TimeControlSystem<ConfigT, StateT> {
+  initialState(config: ConfigT): StateT;
+  /** Return an updated state to reflect the elapsed time */
+  elapse(elapsedMS: number, state: StateT, config: ConfigT): StateT;
+  /** Renew period time in systems like Byo-Yomi or Simple. */
+  renew(state: StateT, config: ConfigT): StateT;
+  msUntilTimeout(state: StateT, config: ConfigT): number;
+  toString(state: StateT): string;
+}
+
+interface IBasicTimeState {
+  remainingTimeMS: number;
+}
+
+export class FischerSystem
+  implements TimeControlSystem<IFischerConfig, IBasicTimeState>
+{
+  initialState(config: IFischerConfig): IBasicTimeState {
+    return { remainingTimeMS: config.mainTimeMS };
+  }
+
+  elapse(elapsedMS: number, state: IBasicTimeState) {
+    return { remainingTimeMS: state.remainingTimeMS - elapsedMS };
+  }
+
+  renew(state: IBasicTimeState, config: IFischerConfig) {
+    const uncapped = state.remainingTimeMS + config.incrementMS;
+
+    const remainingTimeMS =
+      config.maxTimeMS === null
+        ? uncapped
+        : Math.min(uncapped, config.maxTimeMS);
+
+    return { remainingTimeMS };
+  }
+
+  msUntilTimeout(state: IBasicTimeState): number {
+    return state.remainingTimeMS;
+  }
+
+  toString(state: IBasicTimeState): string {
+    return msToTime(state.remainingTimeMS);
+  }
+}
+
+export class AbsoluteSystem
+  implements TimeControlSystem<ITimeControlConfig, IBasicTimeState>
+{
+  initialState(config: ITimeControlConfig): IBasicTimeState {
+    return { remainingTimeMS: config.mainTimeMS };
+  }
+
+  elapse(elapsedMS: number, state: IBasicTimeState) {
+    return { remainingTimeMS: state.remainingTimeMS - elapsedMS };
+  }
+
+  renew = nullRenewal;
+
+  msUntilTimeout(state: IBasicTimeState): number {
+    return state.remainingTimeMS;
+  }
+
+  representation(state: IBasicTimeState): string {
+    return msToTime(state.remainingTimeMS);
+  }
+}
+
+interface IByoYomiConfig extends ITimeControlConfig {
+  type: TimeControlType.ByoYomi;
+  numPeriods: number;
+  periodTimeMS: number;
+}
+interface IByoYomiState {
+  mainTimeRemainingMS: number;
+  periodsRemaining: number;
+  periodTimeRemainingMS: number;
+}
+
+export class ByoYomiSystem
+  implements TimeControlSystem<IByoYomiConfig, IByoYomiState>
+{
+  initialState(config: IByoYomiConfig): IByoYomiState {
+    return {
+      mainTimeRemainingMS: config.mainTimeMS,
+      periodsRemaining: config.numPeriods,
+      periodTimeRemainingMS: config.periodTimeMS,
+    };
+  }
+
+  elapse(
+    elapsedMS: number,
+    state: IByoYomiState,
+    config: IByoYomiConfig,
+  ): IByoYomiState {
+    state = { ...state };
+    if (state.mainTimeRemainingMS) {
+      if (state.mainTimeRemainingMS >= elapsedMS) {
+        state.mainTimeRemainingMS -= elapsedMS;
+        return state;
+      }
+      elapsedMS -= state.mainTimeRemainingMS;
+      state.mainTimeRemainingMS = 0;
+    }
+    while (state.periodTimeRemainingMS < elapsedMS) {
+      elapsedMS -= state.periodTimeRemainingMS;
+      state.periodsRemaining--;
+      if (state.periodsRemaining === 0) {
+        state.periodTimeRemainingMS = 0;
+        return state;
+      }
+      state.periodTimeRemainingMS = config.periodTimeMS;
+    }
+    state.periodTimeRemainingMS -= elapsedMS;
+    return state;
+  }
+
+  renew(state: IByoYomiState, config: IByoYomiConfig) {
+    return { ...state, periodTimeRemainingMS: config.periodTimeMS };
+  }
+
+  msUntilTimeout(state: IByoYomiState, config: IByoYomiConfig): number {
+    const fullPeriodsRemaining = state.periodsRemaining - 1;
+    return (
+      state.mainTimeRemainingMS +
+      state.periodTimeRemainingMS +
+      fullPeriodsRemaining * config.periodTimeMS
+    );
+  }
+
+  // Arguably, we'll want styling on these more complex strings.  I see a couple options:
+  //   1) move this function into the vue-client package
+  //   2) enable rich text output (see Vue's v-html directive)
+  // But plain JS strings are easy to work with and test, so keeping it for the first pass.
+  toString(state: IByoYomiState): string {
+    const periodTimeString = `${msToTime(state.periodTimeRemainingMS)} (${
+      state.periodsRemaining
+    })`;
+    if (state.mainTimeRemainingMS > 0) {
+      return `${msToTime(state.mainTimeRemainingMS)} + ${periodTimeString}`;
+    }
+    return periodTimeString;
+  }
+}
+
+export class SimpleSystem
+  implements TimeControlSystem<ITimeControlConfig, IBasicTimeState>
+{
+  initialState(config: ITimeControlConfig) {
+    return {
+      remainingTimeMS: config.mainTimeMS,
+    };
+  }
+
+  elapse(elapsedMS: number, state: IBasicTimeState) {
+    return { remainingTimeMS: state.remainingTimeMS - elapsedMS };
+  }
+
+  renew(_state: IBasicTimeState, config: ITimeControlConfig) {
+    return { remainingTimeMS: config.mainTimeMS };
+  }
+
+  msUntilTimeout(state: IBasicTimeState): number {
+    return state.remainingTimeMS;
+  }
+
+  toString(state: IBasicTimeState): string {
+    return msToTime(state.remainingTimeMS);
+  }
+}
+
+interface ICanadianTimeState {
+  mainTimeRemainingMS: number;
+  periodTimeRemainingMS: number;
+  renewalCountdown: number;
+}
+interface ICanadianTimeConfig extends ITimeControlConfig {
+  type: TimeControlType.Canadian;
+  numPeriods: number;
+  periodTimeMS: number;
+}
+
+export class CanadianSystem
+  implements TimeControlSystem<ICanadianTimeConfig, ICanadianTimeState>
+{
+  initialState(config: ICanadianTimeConfig) {
+    return {
+      mainTimeRemainingMS: config.mainTimeMS,
+      periodTimeRemainingMS: config.periodTimeMS,
+      renewalCountdown: config.numPeriods,
+    };
+  }
+
+  elapse(elapsedMS: number, state: ICanadianTimeState) {
+    state = { ...state };
+    if (state.mainTimeRemainingMS) {
+      if (state.mainTimeRemainingMS >= elapsedMS) {
+        state.mainTimeRemainingMS -= elapsedMS;
+        return state;
+      }
+      elapsedMS -= state.mainTimeRemainingMS;
+      state.mainTimeRemainingMS = 0;
+    }
+    state.periodTimeRemainingMS -= elapsedMS;
+
+    return state;
+  }
+
+  renew(state: ICanadianTimeState, config: ICanadianTimeConfig) {
+    state = { ...state };
+    if (state.mainTimeRemainingMS > 0) {
+      // periods don't need to be renewed during main time, and we don't want
+      // to touch the countdown
+      return state;
+    }
+    state.renewalCountdown--;
+    if (state.renewalCountdown === 0) {
+      // reset
+      state.renewalCountdown = config.numPeriods;
+      state.periodTimeRemainingMS = config.periodTimeMS;
+    }
+    return state;
+  }
+
+  msUntilTimeout(state: ICanadianTimeState): number {
+    return state.mainTimeRemainingMS + state.periodTimeRemainingMS;
+  }
+
+  toString(state: ICanadianTimeState): string {
+    const periodTimeString = `${msToTime(state.periodTimeRemainingMS)}/${
+      state.renewalCountdown
+    }`;
+    if (state.mainTimeRemainingMS > 0) {
+      return `${msToTime(state.mainTimeRemainingMS)} + ${periodTimeString}`;
+    }
+    return periodTimeString;
+  }
+}
+
+// Convenience function for when the state doesn't change at the end of a round
+function nullRenewal<T>(state: T) {
+  return { ...state };
+}

--- a/packages/shared/src/time_control/time_control_systems.ts
+++ b/packages/shared/src/time_control/time_control_systems.ts
@@ -106,16 +106,22 @@ class ByoYomiTimeControl implements TimeControl<IByoYomiConfig, IByoYomiState> {
       elapsedMS -= state.mainTimeRemainingMS;
       state.mainTimeRemainingMS = 0;
     }
-    while (state.periodTimeRemainingMS < elapsedMS) {
-      elapsedMS -= state.periodTimeRemainingMS;
-      state.periodsRemaining--;
-      if (state.periodsRemaining === 0) {
-        state.periodTimeRemainingMS = 0;
-        return state;
-      }
-      state.periodTimeRemainingMS = config.periodTimeMS;
+
+    if (state.periodTimeRemainingMS > elapsedMS) {
+      state.periodTimeRemainingMS -= elapsedMS;
+      return state;
     }
-    state.periodTimeRemainingMS -= elapsedMS;
+
+    elapsedMS -= state.periodTimeRemainingMS;
+
+    const remainder = elapsedMS % config.periodTimeMS;
+    const q = (elapsedMS - remainder) / config.periodTimeMS;
+    const periodsUsed = q + 1;
+
+    state.periodsRemaining = Math.max(0, state.periodsRemaining - periodsUsed);
+    state.periodTimeRemainingMS =
+      state.periodsRemaining === 0 ? 0 : config.periodTimeMS - remainder;
+
     return state;
   }
 

--- a/packages/shared/src/time_control/time_control_systems.ts
+++ b/packages/shared/src/time_control/time_control_systems.ts
@@ -5,17 +5,17 @@ import {
 } from "./time_control.types";
 import { msToTime } from "./time_control.utils";
 
-interface TimeControlSystem<ConfigT, StateT> {
+export interface TimeControlSystem<ConfigT, StateT> {
   initialState(config: ConfigT): StateT;
   /** Return an updated state to reflect the elapsed time */
   elapse(elapsedMS: number, state: StateT, config: ConfigT): StateT;
   /** Renew period time in systems like Byo-Yomi or Simple. */
   renew(state: StateT, config: ConfigT): StateT;
   msUntilTimeout(state: StateT, config: ConfigT): number;
-  toString(state: StateT): string;
+  timeString(state: StateT): string;
 }
 
-interface IBasicTimeState {
+export interface IBasicTimeState {
   remainingTimeMS: number;
 }
 
@@ -45,7 +45,7 @@ export class FischerSystem
     return state.remainingTimeMS;
   }
 
-  toString(state: IBasicTimeState): string {
+  timeString(state: IBasicTimeState): string {
     return msToTime(state.remainingTimeMS);
   }
 }
@@ -67,17 +67,17 @@ export class AbsoluteSystem
     return state.remainingTimeMS;
   }
 
-  representation(state: IBasicTimeState): string {
+  timeString(state: IBasicTimeState): string {
     return msToTime(state.remainingTimeMS);
   }
 }
 
-interface IByoYomiConfig extends ITimeControlConfig {
+export interface IByoYomiConfig extends ITimeControlConfig {
   type: TimeControlType.ByoYomi;
   numPeriods: number;
   periodTimeMS: number;
 }
-interface IByoYomiState {
+export interface IByoYomiState {
   mainTimeRemainingMS: number;
   periodsRemaining: number;
   periodTimeRemainingMS: number;
@@ -138,7 +138,7 @@ export class ByoYomiSystem
   //   1) move this function into the vue-client package
   //   2) enable rich text output (see Vue's v-html directive)
   // But plain JS strings are easy to work with and test, so keeping it for the first pass.
-  toString(state: IByoYomiState): string {
+  timeString(state: IByoYomiState): string {
     const periodTimeString = `${msToTime(state.periodTimeRemainingMS)} (${
       state.periodsRemaining
     })`;
@@ -170,17 +170,17 @@ export class SimpleSystem
     return state.remainingTimeMS;
   }
 
-  toString(state: IBasicTimeState): string {
+  timeString(state: IBasicTimeState): string {
     return msToTime(state.remainingTimeMS);
   }
 }
 
-interface ICanadianTimeState {
+export interface ICanadianTimeState {
   mainTimeRemainingMS: number;
   periodTimeRemainingMS: number;
   renewalCountdown: number;
 }
-interface ICanadianTimeConfig extends ITimeControlConfig {
+export interface ICanadianTimeConfig extends ITimeControlConfig {
   type: TimeControlType.Canadian;
   numPeriods: number;
   periodTimeMS: number;
@@ -232,7 +232,7 @@ export class CanadianSystem
     return state.mainTimeRemainingMS + state.periodTimeRemainingMS;
   }
 
-  toString(state: ICanadianTimeState): string {
+  timeString(state: ICanadianTimeState): string {
     const periodTimeString = `${msToTime(state.periodTimeRemainingMS)}/${
       state.renewalCountdown
     }`;

--- a/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
@@ -1,6 +1,16 @@
+<script lang="ts">
+import { TimeControlType } from "@ogfcommunity/variants-shared/src/time_control";
+function shouldShowPeriodTime(type: TimeControlType) {
+  return type == TimeControlType.ByoYomi || type === TimeControlType.Canadian;
+}
+</script>
+
 <script setup lang="ts">
+import type {
+  IByoYomiConfig,
+  ICanadianTimeConfig,
+} from "@ogfcommunity/variants-shared";
 import {
-  TimeControlType,
   type ITimeControlConfig,
   type IFischerConfig,
 } from "@ogfcommunity/variants-shared/src/time_control";
@@ -8,6 +18,8 @@ import { ref } from "vue";
 
 const typeRef = ref(null);
 const mainTimeS = ref(300);
+const periodTimeS = ref(30);
+const numPeriods = ref(5);
 const fischerIncrementS = ref(20);
 const fischerMaxS = ref(600);
 const fischerCapped = ref(true);
@@ -21,9 +33,10 @@ function emitConfigChange() {
 
   if (typeRef.value !== null) {
     switch (typeRef.value) {
-      case TimeControlType.Absolute: {
+      case TimeControlType.Absolute:
+      case TimeControlType.Simple: {
         emitConfig = {
-          type: TimeControlType.Absolute,
+          type: typeRef.value,
           mainTimeMS: mainTimeS.value * 1000,
         };
         break;
@@ -35,6 +48,26 @@ function emitConfigChange() {
           incrementMS: fischerIncrementS.value * 1000,
           maxTimeMS: fischerCapped.value ? fischerMaxS.value * 1000 : null,
         };
+        break;
+      }
+      case TimeControlType.ByoYomi: {
+        const byoConfig: IByoYomiConfig = {
+          type: TimeControlType.ByoYomi,
+          mainTimeMS: mainTimeS.value * 1000,
+          numPeriods: numPeriods.value,
+          periodTimeMS: periodTimeS.value * 1000,
+        };
+        emitConfig = byoConfig;
+        break;
+      }
+      case TimeControlType.Canadian: {
+        const canadianConfig: ICanadianTimeConfig = {
+          type: TimeControlType.Canadian,
+          numPeriods: numPeriods.value,
+          periodTimeMS: periodTimeS.value * 1000,
+          mainTimeMS: mainTimeS.value * 1000,
+        };
+        emitConfig = canadianConfig;
         break;
       }
     }
@@ -51,6 +84,9 @@ function emitConfigChange() {
       <option :value="null">Unlimited Time</option>
       <option :value="TimeControlType.Absolute">Absolute</option>
       <option :value="TimeControlType.Fischer">Fischer</option>
+      <option :value="TimeControlType.ByoYomi">Byo-Yomi</option>
+      <option :value="TimeControlType.Canadian">Canadian Byo-Yomi</option>
+      <option :value="TimeControlType.Simple">Simple</option>
     </select>
     <template v-if="typeRef !== null">
       <label>Main Time (s)</label>
@@ -64,6 +100,12 @@ function emitConfigChange() {
         <input id="cappedToggle" type="checkbox" v-model="fischerCapped" />
       </div>
       <input v-if="fischerCapped" type="number" v-model="fischerMaxS" />
+    </template>
+    <template v-if="typeRef && shouldShowPeriodTime(typeRef)">
+      <label>Number of Periods</label>
+      <input type="number" v-model="numPeriods" />
+      <label>Period time</label>
+      <input type="number" v-model="periodTimeS" />
     </template>
   </form>
 </template>

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
-import type { IPerPlayerTimeControlBase } from "@ogfcommunity/variants-shared";
+import {
+  type IPerPlayerTimeControlBase,
+  msToTime,
+} from "@ogfcommunity/variants-shared";
 import { isDefined } from "@vueuse/core";
 
 const props = defineProps<{
@@ -56,42 +59,6 @@ function resetTimer(): void {
     }
     time.value = Math.max(0, time.value - elapsed);
   }
-}
-
-function msToTime(ms: number): string {
-  let msCopy = ms;
-
-  const milliseconds = ms % 1000;
-  msCopy = (msCopy - milliseconds) / 1000;
-
-  const seconds = msCopy % 60;
-  msCopy = (msCopy - seconds) / 60;
-
-  const minutes = msCopy % 60;
-  msCopy = (msCopy - minutes) / 60;
-
-  if (msCopy < 1) {
-    return `${minutes.toLocaleString(undefined, {
-      minimumIntegerDigits: 2,
-    })}:${seconds.toLocaleString(undefined, { minimumIntegerDigits: 2 })}`;
-  }
-
-  const hours = msCopy % 24;
-  msCopy = (msCopy - hours) / 24;
-
-  if (msCopy < 1) {
-    return `${hours.toLocaleString(undefined, {
-      style: "unit",
-      unit: "hour",
-    })}`;
-  }
-
-  const days = msCopy;
-
-  return `${days.toLocaleString(undefined, {
-    style: "unit",
-    unit: "day",
-  })}`;
 }
 </script>
 

--- a/packages/vue-client/src/components/SeatComponent.vue
+++ b/packages/vue-client/src/components/SeatComponent.vue
@@ -2,6 +2,7 @@
 import type {
   User,
   IPerPlayerTimeControlBase,
+  ITimeControlConfig,
 } from "@ogfcommunity/variants-shared";
 import GameTimer from "../components/GameTimer.vue";
 
@@ -11,6 +12,7 @@ defineProps<{
   player_n: number;
   selected?: number;
   time_control: IPerPlayerTimeControlBase | null;
+  time_config?: ITimeControlConfig;
   is_players_turn: boolean;
 }>();
 </script>
@@ -25,7 +27,11 @@ defineProps<{
 
     <div v-if="occupant == null">
       <div class="timer-and-button">
-        <GameTimer v-if="time_control" v-bind:time_control="time_control" />
+        <GameTimer
+          v-if="time_control && time_config"
+          v-bind:time_control="time_control"
+          v-bind:time_config="time_config"
+        />
         <button v-if="user_id" @click.stop="$emit('sit')">Take Seat</button>
       </div>
     </div>
@@ -34,7 +40,11 @@ defineProps<{
         {{ occupant.username ?? `guest (...${occupant.id.slice(-6)})` }}
       </p>
       <div class="timer-and-button">
-        <GameTimer v-if="time_control" v-bind:time_control="time_control" />
+        <GameTimer
+          v-if="time_control && time_config"
+          v-bind:time_control="time_control"
+          v-bind:time_config="time_config"
+        />
         <button v-if="occupant.id === user_id" @click.stop="$emit('leave')">
           Leave Seat
         </button>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -4,6 +4,7 @@ import {
   type GameResponse,
   getOnlyMove,
   HasTimeControlConfig,
+  timeControlMap,
 } from "@ogfcommunity/variants-shared";
 import * as requests from "../requests";
 import SeatComponent from "@/components/SeatComponent.vue";
@@ -185,9 +186,13 @@ const createTimeControlPreview = (
   game: GameResponse,
 ): IPerPlayerTimeControlBase | null => {
   if (HasTimeControlConfig(game.config)) {
-    const config = game.config as IConfigWithTimeControl;
+    const config = (game.config as IConfigWithTimeControl).time_control;
+    const clock = timeControlMap.get(config.type);
+    if (!clock) {
+      throw new Error(`Invalid time control: ${config.type}`);
+    }
     return {
-      remainingTimeMS: config.time_control.mainTimeMS,
+      clockState: clock.initialState(config),
       onThePlaySince: null,
     };
   }
@@ -250,6 +255,7 @@ const createTimeControlPreview = (
           gameResponse.time_control?.forPlayer[idx] ??
           createTimeControlPreview(gameResponse)
         "
+        :time_config="(gameResponse.config as IConfigWithTimeControl).time_control"
         :is_players_turn="game.next_to_play?.includes(idx) ?? false"
       />
     </div>


### PR DESCRIPTION
Update: I've plugged it in, and both the old and new time controls seem to work as expected!  Good test suite on the handlers too - helped me debug a lot of issues on my first pass.

Sorry it's such a big diff.  Hopefully the break down of the commits help to understand what's going on.  I'm also going to leave this open for a while so I can test some more, but publishing now because it seems ready.

---

This is a proposal for a generic interface for additional time controls.  I have not plugged it into the code yet, but I hope it demonstrates a strategy that we can use to onboard Byoyomi, Simple and Canadian to reach parity with OGS.

I am opening this PR as draft to make sure I don't collide with anyone and also gather early feedback, but I plan to do the following before marking "Ready":

- [x] plug this into the code
- [x] expose the new time controls in the UI
- [x] Add config forms
- [x] Write unit tests for each of the `TimeControlSystem`s

## Interface

`TimeControl` has the following functions:

- `initialState`
    - corresponds to code in [TimeHandlerParallelMoves.initialState](https://github.com/govariantsteam/govariants/blob/byoyomi/packages/server/src/time-control/time-handler-parallel.ts#L37-L41) and [TimeHandlerSequentialMoves.initialState](https://github.com/govariantsteam/govariants/blob/byoyomi/packages/server/src/time-control/time-handler-sequential.ts#L36-L39)
- `elapse` and `renew`
    - correspond roughly to the `transition` functions in [TimeHandlerParallelMoves](https://github.com/govariantsteam/govariants/blob/7dbf9857e52442375a7faf9aa3909aab24c89c77/packages/server/src/time-control/time-handler-parallel.ts#L82-L110) and [TimeHandlerSequentialMoves](https://github.com/govariantsteam/govariants/blob/7dbf9857e52442375a7faf9aa3909aab24c89c77/packages/server/src/time-control/time-handler-sequential.ts#L77-L116)
    - I split into two functions because we can use `elapse` to generalize the [subtraction in the client countdown timer](https://github.com/govariantsteam/govariants/blob/7dbf9857e52442375a7faf9aa3909aab24c89c77/packages/vue-client/src/components/GameTimer.vue#L84C1-L84C67)
- `msUntilTimeout`
   - corresponds to [TimeHandlerParallelMoves.getMsUntilTimeout](https://github.com/govariantsteam/govariants/blob/7dbf9857e52442375a7faf9aa3909aab24c89c77/packages/server/src/time-control/time-handler-parallel.ts#L150) and [TimeHandlerSequentialMoves.getMsUntilTimeout](https://github.com/govariantsteam/govariants/blob/7dbf9857e52442375a7faf9aa3909aab24c89c77/packages/server/src/time-control/time-handler-sequential.ts#L150)
- ~~`toString`~~`timeString`
    - for the client code ([GameTimer.vue](https://github.com/govariantsteam/govariants/blob/7dbf9857e52442375a7faf9aa3909aab24c89c77/packages/vue-client/src/components/GameTimer.vue#L24))


## Demo

https://github.com/govariantsteam/govariants/assets/25233703/604982b4-94cd-4e09-ba89-1bcd9a39e7a1
