### PR TITLE
Clean up the GameTimer Vue component

### DIFF
--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -1,33 +1,21 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { ref, watch, computed } from "vue";
 import type { IPerPlayerTimeControlBase } from "@ogfcommunity/variants-shared";
 import { isDefined } from "@vueuse/core";
 
 const props = defineProps<{
-  time_control: IPerPlayerTimeControlBase | null;
+  time_control: IPerPlayerTimeControlBase;
 }>();
 
-const time = ref(props.time_control?.remainingTimeMS ?? 0);
-const formattedTime = ref(
-  isDefined(props.time_control?.remainingTimeMS)
-    ? msToTime(props.time_control!.remainingTimeMS)
-    : "",
-);
+const time = ref(props.time_control.remainingTimeMS);
+const formattedTime = computed(() => msToTime(time.value));
 const isCountingDown = ref(false);
 let timerIndex: number | null = null;
 let lastUpdated: Date;
 
-watch(time, (t: number) => {
-  if (t === null) {
-    formattedTime.value = "";
-  } else {
-    formattedTime.value = msToTime(t);
-  }
-});
-
 watch(
   props,
-  (value, oldValue, onCleanup) => {
+  (_value, _oldValue, onCleanup) => {
     resetTimer();
     onCleanup(() => {
       if (timerIndex !== null) {
@@ -42,10 +30,9 @@ function resetTimer(): void {
   if (timerIndex !== null) {
     clearInterval(timerIndex);
   }
-  time.value = props.time_control?.remainingTimeMS ?? 0;
+  time.value = props.time_control.remainingTimeMS;
 
   if (
-    props.time_control &&
     isDefined(props.time_control.onThePlaySince) &&
     props.time_control.remainingTimeMS !== null
   ) {

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -31,34 +31,27 @@ function resetTimer(): void {
     clearInterval(timerIndex);
   }
   time.value = props.time_control.remainingTimeMS;
+  isCountingDown.value = false;
 
   if (
     isDefined(props.time_control.onThePlaySince) &&
     props.time_control.remainingTimeMS !== null
   ) {
+    let elapsed;
+    const onThePlaySince = new Date(props.time_control.onThePlaySince);
     // this is not ideal
     if (
       "stagedMoveAt" in props.time_control &&
       props.time_control.stagedMoveAt !== null
     ) {
-      isCountingDown.value = false;
-      const onThePlaySince = new Date(props.time_control.onThePlaySince);
       const stagedMove = new Date(props.time_control.stagedMoveAt as Date);
-      time.value = Math.max(
-        0,
-        time.value - (stagedMove.getTime() - onThePlaySince.getTime()),
-      );
+      elapsed = stagedMove.getTime() - onThePlaySince.getTime();
     } else {
       isCountingDown.value = true;
-      const onThePlaySince: Date = new Date(props.time_control.onThePlaySince);
       const now = new Date();
-      time.value = Math.max(
-        0,
-        time.value - (now.getTime() - onThePlaySince.getTime()),
-      );
+      elapsed = now.getTime() - onThePlaySince.getTime();
     }
-  } else {
-    isCountingDown.value = false;
+    time.value = Math.max(0, time.value - elapsed);
   }
 
   if (isCountingDown.value && typeof window !== "undefined") {

--- a/packages/vue-client/src/components/SeatComponent.vue
+++ b/packages/vue-client/src/components/SeatComponent.vue
@@ -25,7 +25,7 @@ defineProps<{
 
     <div v-if="occupant == null">
       <div class="timer-and-button">
-        <GameTimer v-bind:time_control="time_control" />
+        <GameTimer v-if="time_control" v-bind:time_control="time_control" />
         <button v-if="user_id" @click.stop="$emit('sit')">Take Seat</button>
       </div>
     </div>
@@ -34,7 +34,7 @@ defineProps<{
         {{ occupant.username ?? `guest (...${occupant.id.slice(-6)})` }}
       </p>
       <div class="timer-and-button">
-        <GameTimer v-bind:time_control="time_control" />
+        <GameTimer v-if="time_control" v-bind:time_control="time_control" />
         <button v-if="occupant.id === user_id" @click.stop="$emit('leave')">
           Leave Seat
         </button>


### PR DESCRIPTION
The logic gets a lot simpler if we can assume time_control is not null.  Anyway, `<GameTimer time_control="null">` isn't very meaningful.  So instead we type it as non-null and guard it with a v-if.

Some other small changes: make more use of computed variables, and try to remove variables while keeping the same functionality.

Motivation: this should help a bit with #233