### PR TITLE
Test parallel and shared handler code

### DIFF
--- a/packages/server/src/time-control/__tests__/parallel.test.ts
+++ b/packages/server/src/time-control/__tests__/parallel.test.ts
@@ -1,0 +1,251 @@
+import {
+  GameResponse,
+  IFischerConfig,
+  ParallelGo,
+  PerPlayerTimeControlParallel,
+  TimeControlType,
+} from "@ogfcommunity/variants-shared";
+import { TestClock } from "../clock";
+import { TimeHandlerParallelMoves } from "../time-handler-parallel";
+import { TestTimeoutService } from "../mocks/timeout-service.mock";
+
+const MS_SINCE_EPOCH = 1_700_000_000_000;
+const DATE1 = new Date(MS_SINCE_EPOCH);
+const DATE2 = new Date(MS_SINCE_EPOCH + 5000);
+const DATE3 = new Date(MS_SINCE_EPOCH + 10_000);
+const DATE4 = new Date(MS_SINCE_EPOCH + 15_000);
+const TIMEOUT_DATE = new Date(MS_SINCE_EPOCH + 400000); // timeout and then some
+
+function baseGameConfig() {
+  return {
+    ...new ParallelGo().defaultConfig(),
+    time_control: {
+      type: TimeControlType.Fischer,
+      mainTimeMS: 300000,
+      maxTimeMS: 500000,
+      incrementMS: 10000,
+    } as IFischerConfig,
+  };
+}
+function baseGameResponse(): GameResponse {
+  return {
+    id: "xxxxxx",
+    variant: "parallel",
+    moves: [],
+    config: baseGameConfig(),
+    time_control: {
+      moveTimestamps: [],
+      forPlayer: {
+        "0": {
+          remainingTimeMS: 300000,
+          onThePlaySince: null,
+          stagedMoveAt: null,
+        } as PerPlayerTimeControlParallel,
+        "1": {
+          remainingTimeMS: 300000,
+          onThePlaySince: null,
+          stagedMoveAt: null,
+        } as PerPlayerTimeControlParallel,
+      },
+    },
+  };
+}
+function makeHandlerWithCurrentTime(date: Date) {
+  const clock = new TestClock(date);
+  const timeoutService = new TestTimeoutService();
+  return new TimeHandlerParallelMoves(clock, timeoutService);
+}
+
+test("initialState (Fischer)", () => {
+  const handler = makeHandlerWithCurrentTime(new Date(1_700_000_000_000));
+
+  const state = handler.initialState("parallel", baseGameConfig());
+
+  expect(state).toEqual({
+    moveTimestamps: [],
+    forPlayer: {
+      "0": {
+        remainingTimeMS: 300000,
+        onThePlaySince: null,
+        stagedMoveAt: null,
+      },
+      "1": {
+        remainingTimeMS: 300000,
+        onThePlaySince: null,
+        stagedMoveAt: null,
+      },
+    },
+  });
+});
+
+test("handleMove - staged move (Fischer)", () => {
+  const handler = makeHandlerWithCurrentTime(DATE1);
+  const game = new ParallelGo(baseGameConfig());
+
+  const time_control = handler.handleMove(
+    baseGameResponse(),
+    game,
+    0,
+    "aa",
+    false,
+  );
+
+  expect(time_control).toEqual({
+    moveTimestamps: [DATE1],
+    forPlayer: {
+      "0": {
+        remainingTimeMS: 300000,
+        onThePlaySince: null,
+        stagedMoveAt: DATE1,
+      },
+      "1": {
+        remainingTimeMS: 300000,
+        onThePlaySince: null,
+        stagedMoveAt: null,
+      },
+    },
+  });
+});
+
+test("handleMove - round transition (Fischer)", () => {
+  const handler = makeHandlerWithCurrentTime(DATE4);
+  const game = new ParallelGo(baseGameConfig());
+
+  const gameResponse = baseGameResponse();
+  gameResponse.moves.push({ 0: "aa" }, { 1: "bb" }, { 0: "cc" });
+  gameResponse.time_control.moveTimestamps.push(DATE1, DATE2, DATE3);
+
+  const black_tc = gameResponse.time_control.forPlayer[
+    "0"
+  ] as PerPlayerTimeControlParallel;
+  const white_tc = gameResponse.time_control.forPlayer[
+    "1"
+  ] as PerPlayerTimeControlParallel;
+  black_tc.stagedMoveAt = DATE3;
+  black_tc.onThePlaySince = DATE2;
+  white_tc.onThePlaySince = DATE2;
+
+  const time_control = handler.handleMove(gameResponse, game, 1, "dd", true);
+
+  expect(time_control).toEqual({
+    moveTimestamps: [DATE1, DATE2, DATE3, DATE4],
+    forPlayer: {
+      "0": {
+        remainingTimeMS: 305000,
+        onThePlaySince: DATE4,
+        stagedMoveAt: null,
+      },
+      "1": {
+        remainingTimeMS: 300000,
+        onThePlaySince: DATE4,
+        stagedMoveAt: null,
+      },
+    },
+  });
+});
+
+test("getMSUntilTimeout (Fischer)", () => {
+  const handler = makeHandlerWithCurrentTime(DATE1);
+  // missing time_control
+  expect(
+    handler.getMsUntilTimeout(
+      {
+        id: "",
+        variant: "",
+        moves: [],
+        config: {},
+      },
+      0,
+    ),
+  ).toBe(null);
+});
+
+test("handleMove - missing time_control will be treated as initialState", () => {
+  const handler = makeHandlerWithCurrentTime(DATE1);
+  const game = new ParallelGo(baseGameConfig());
+  const gameResponse = baseGameResponse();
+  delete gameResponse.time_control;
+
+  const time_control = handler.handleMove(gameResponse, game, 0, "aa", false);
+
+  expect(time_control).toEqual({
+    moveTimestamps: [DATE1],
+    forPlayer: {
+      "0": {
+        remainingTimeMS: 300000,
+        onThePlaySince: null,
+        stagedMoveAt: DATE1,
+      },
+      "1": {
+        remainingTimeMS: 300000,
+        onThePlaySince: null,
+        stagedMoveAt: null,
+      },
+    },
+  });
+});
+
+test("handleMove - timeout sets the clock to zero (Fischer)", () => {
+  const handler = makeHandlerWithCurrentTime(TIMEOUT_DATE);
+  const game = new ParallelGo(baseGameConfig());
+  const gameResponse = baseGameResponse();
+  gameResponse.time_control.moveTimestamps = [DATE1, DATE2];
+  const black_tc = gameResponse.time_control.forPlayer[
+    "0"
+  ] as PerPlayerTimeControlParallel;
+  const white_tc = gameResponse.time_control.forPlayer[
+    "1"
+  ] as PerPlayerTimeControlParallel;
+  black_tc.stagedMoveAt = null;
+  white_tc.stagedMoveAt = null;
+  black_tc.onThePlaySince = DATE2;
+  white_tc.onThePlaySince = DATE2;
+
+  const time_control = handler.handleMove(
+    gameResponse,
+    game,
+    0,
+    "timeout",
+    false,
+  );
+
+  expect(time_control).toEqual({
+    moveTimestamps: [DATE1, DATE2, TIMEOUT_DATE],
+    forPlayer: {
+      "0": {
+        remainingTimeMS: 0,
+        onThePlaySince: null,
+        stagedMoveAt: null,
+      },
+      "1": {
+        remainingTimeMS: 300000,
+        onThePlaySince: DATE2,
+        stagedMoveAt: null,
+      },
+    },
+  });
+});
+
+test("handleMove - re-stage move not allowed if it will cause timeout", () => {
+  const handler = makeHandlerWithCurrentTime(TIMEOUT_DATE);
+  const game = new ParallelGo(baseGameConfig());
+
+  const gameResponse = baseGameResponse();
+  gameResponse.moves.push({ 0: "aa" }, { 1: "bb" }, { 0: "cc" });
+  gameResponse.time_control.moveTimestamps.push(DATE1, DATE2, DATE3);
+
+  const black_tc = gameResponse.time_control.forPlayer[
+    "0"
+  ] as PerPlayerTimeControlParallel;
+  const white_tc = gameResponse.time_control.forPlayer[
+    "1"
+  ] as PerPlayerTimeControlParallel;
+  black_tc.stagedMoveAt = DATE3;
+  white_tc.stagedMoveAt = null;
+  black_tc.onThePlaySince = DATE2;
+  white_tc.onThePlaySince = DATE2;
+
+  expect(() => handler.handleMove(gameResponse, game, 0, "dd", false)).toThrow(
+    "you can't change your move because it would reduce your remaining time to zero.",
+  );
+});

--- a/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
+++ b/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
@@ -1,0 +1,153 @@
+import {
+  Baduk,
+  IFischerConfig,
+  IPerPlayerTimeControlBase,
+  TimeControlType,
+} from "@ogfcommunity/variants-shared";
+import {
+  getMsUntilTimeout,
+  initialState,
+  makeTransition,
+} from "../time-handler-utils";
+
+const ABSOLUTE_CONFIG = {
+  ...new Baduk().defaultConfig(),
+  time_control: { type: TimeControlType.Absolute, mainTimeMS: 600_000 },
+};
+
+test("initialState (Absolute)", () => {
+  expect(initialState("baduk", ABSOLUTE_CONFIG)).toEqual({
+    moveTimestamps: [],
+    forPlayer: {
+      "0": { remainingTimeMS: 600000, onThePlaySince: null },
+      "1": { remainingTimeMS: 600000, onThePlaySince: null },
+    },
+  });
+});
+
+test("makeTransition (Absolute)", () => {
+  const transition = makeTransition(
+    () => 5000,
+    ABSOLUTE_CONFIG,
+    "aa",
+    "game_id",
+  );
+  const playerData: IPerPlayerTimeControlBase = {
+    remainingTimeMS: 600000,
+    onThePlaySince: null,
+  };
+  transition(playerData);
+  expect(playerData.remainingTimeMS).toBe(595000);
+});
+
+test("makeTransition: timeout (Absolute)", () => {
+  const transition = makeTransition(
+    () => 600005, // Timeout plus a bit
+    ABSOLUTE_CONFIG,
+    "timeout",
+    "game_id",
+  );
+  const playerData: IPerPlayerTimeControlBase = {
+    remainingTimeMS: 600000,
+    onThePlaySince: null,
+  };
+  transition(playerData);
+  expect(playerData.remainingTimeMS).toBe(0);
+});
+
+test("makeTransition: timeout (Fischer)", () => {
+  const fischerConfig = {
+    ...new Baduk().defaultConfig(),
+    time_control: {
+      type: TimeControlType.Fischer,
+      mainTimeMS: 600_000,
+      maxTimeMS: null,
+      incrementMS: 5000,
+    } as IFischerConfig,
+  };
+  const transition = makeTransition(
+    () => 600005, // Timeout plus a bit
+    fischerConfig,
+    "timeout",
+    "game_id",
+  );
+  const playerData: IPerPlayerTimeControlBase = {
+    remainingTimeMS: 600000,
+    onThePlaySince: null,
+  };
+  transition(playerData);
+  expect(playerData.remainingTimeMS).toBe(0);
+});
+
+test("makeTransition: (Uncapped Fischer)", () => {
+  const fischerConfig = {
+    ...new Baduk().defaultConfig(),
+    time_control: {
+      type: TimeControlType.Fischer,
+      mainTimeMS: 600_000,
+      maxTimeMS: null,
+      incrementMS: 5000,
+    } as IFischerConfig,
+  };
+  const transition = makeTransition(
+    () => 2000, // Timeout plus a bit
+    fischerConfig,
+    "aa",
+    "game_id",
+  );
+  const playerData: IPerPlayerTimeControlBase = {
+    remainingTimeMS: 600_000,
+    onThePlaySince: null,
+  };
+  transition(playerData);
+  expect(playerData.remainingTimeMS).toBe(603_000);
+});
+
+test("makeTransition (Invalid)", () => {
+  const invalidConfig = {
+    ...new Baduk().defaultConfig(),
+    time_control: { type: TimeControlType.Invalid, mainTimeMS: 600_000 },
+  };
+  expect(() =>
+    makeTransition(() => 5000, invalidConfig, "aa", "game_id"),
+  ).toThrow("invalid");
+});
+
+test("msUntilTimeout (Absolute)", () => {
+  const playerData: IPerPlayerTimeControlBase = {
+    remainingTimeMS: 600000,
+    // player has not played a move yet
+    // or player is not on the play
+    onThePlaySince: null,
+  };
+  const ms = getMsUntilTimeout(
+    {
+      id: "",
+      variant: "",
+      moves: [],
+      config: ABSOLUTE_CONFIG,
+      time_control: {
+        moveTimestamps: [],
+        forPlayer: { "0": playerData, "1": playerData },
+      },
+    },
+    0,
+    17_000_000_000,
+  );
+  expect(ms).toBe(null); // no time removed
+});
+
+test("msUntilTimeout (Absolute)", () => {
+  const ms = getMsUntilTimeout(
+    {
+      id: "",
+      variant: "",
+      moves: [],
+      config: ABSOLUTE_CONFIG,
+      // oops no time control
+    },
+    0,
+    17_000_000_000,
+  );
+  expect(ms).toBe(null); // no time removed
+});


### PR DESCRIPTION
In #223 , there will be many code changes to the time handlers in order to use the `TimeControl` classes. Hopefully, there will be no functional changes for existing time control types `Fischer` and `Absolute`. Additional test coverage will increase my confidence with these modifications.

---

Testing:

```
$ cd packages/server
$ yarn test --coverage
 PASS  src/time-control/__tests__/time-handler-utils.test.ts
  ✓ initialState (Absolute) (5 ms)
  ✓ makeTransition (Absolute) (2 ms)
  ✓ makeTransition: timeout (Absolute) (3 ms)
  ✓ makeTransition: timeout (Fischer) (3 ms)
  ✓ makeTransition: (Uncapped Fischer) (3 ms)
  ✓ makeTransition (Invalid) (6 ms)
  ✓ msUntilTimeout (Absolute) (2 ms)
  ✓ msUntilTimeout (Absolute) (2 ms)

 PASS  src/time-control/__tests__/parallel.test.ts
  ✓ initialState (Fischer) (4 ms)
  ✓ handleMove - staged move (Fischer) (3 ms)
  ✓ handleMove - round transition (Fischer) (3 ms)
  ✓ getMSUntilTimeout (Fischer) (2 ms)
  ✓ handleMove - missing time_control will be treated as initialState (3 ms)
  ✓ handleMove - timeout sets the clock to zero (Fischer) (3 ms)
  ✓ handleMove - re-stage move not allowed if it will cause timeout (5 ms)

 PASS  src/time-control/__tests__/sequential.test.ts
  Sequential Time Control Tests
    ✓ Capped Fischer (6 ms)

-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |   95.76 |    91.48 |   93.93 |   95.61 |                   
 time-control                |   95.72 |    91.48 |   96.66 |   95.57 |                   
  clock.ts                   |   83.33 |      100 |      75 |   83.33 | 7                 
  time-handler-parallel.ts   |     100 |    95.65 |     100 |     100 | 148               
  time-handler-sequential.ts |   96.29 |       75 |     100 |   96.15 | 45                
  time-handler-utils.ts      |   92.68 |       90 |     100 |    92.5 | 54,135-136        
 time-control/mocks          |     100 |      100 |   66.66 |     100 |                   
  timeout-service.mock.ts    |     100 |      100 |   66.66 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
Test Suites: 3 passed, 3 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        0.652 s, estimated 1 s
Ran all test suites.
```