### PR TITLE
add new board patterns in abstract baduk, use enum

### DIFF
--- a/packages/shared/src/lib/abstractBaduk/abstractBaduk.test.ts
+++ b/packages/shared/src/lib/abstractBaduk/abstractBaduk.test.ts
@@ -1,3 +1,4 @@
+import { BoardPattern } from "../abstractBoard/boardFactory";
 import { AbstractBaduk, AbstractBadukConfig } from "./abstractBaduk";
 import { BadukIntersection, AbstractBadukStone } from "./badukIntersection";
 
@@ -32,7 +33,7 @@ class AbstractBadukTestGame extends AbstractBaduk<
   center: TestIntersection;
 
   constructor() {
-    super({ board: { type: "grid", height: 3, width: 3 } });
+    super({ board: { type: BoardPattern.Grid, height: 3, width: 3 } });
 
     this.center = this.intersections.find(
       (intersection) => intersection.neighbours.length === 4,
@@ -68,7 +69,7 @@ class AbstractBadukTestGame extends AbstractBaduk<
   }
 
   defaultConfig(): AbstractBadukConfig {
-    return { board: { type: "grid", height: 19, width: 19 } };
+    return { board: { type: BoardPattern.Grid, height: 19, width: 19 } };
   }
 
   exportState(_player?: number): TestState {

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -2,17 +2,49 @@ import { Intersection } from "./intersection";
 import { Intersection as IntersectionOld } from "../../variants/badukWithAbstractBoard/abstractBoard/intersection";
 import { Vector2D } from "../../variants/badukWithAbstractBoard/abstractBoard/Vector2D";
 import { CreatePolygonalBoard as createPolygonalBoard } from "../../variants/badukWithAbstractBoard/abstractBoard/PolygonalBoardHelper";
+import { CreateCircularBoard } from "../../variants/badukWithAbstractBoard/abstractBoard/CircularBoardHelper";
+import { TrihexagonalBoardHelper } from "../../variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper";
+import { createSierpinskyBoard } from "../../variants/badukWithAbstractBoard/abstractBoard/SierpinskyBoard";
 
-export type BoardConfig = GridBoardConfig | RhombitrihexagonalBoardConfig;
+export enum BoardPattern {
+  Grid = "grid",
+  Polygonal = "polygonal",
+  Circular = "circular",
+  Trihexagonal = "trihexagonal",
+  Sierplinsky = "sierplinsky",
+}
+
+export type BoardConfig =
+  | GridBoardConfig
+  | RhombitrihexagonalBoardConfig
+  | CircularBoardConfig
+  | TrihexagonalBoardConfig
+  | SierplinskyBoardConfig;
 
 export interface GridBoardConfig {
-  type: "grid";
+  type: BoardPattern.Grid;
   width: number;
   height: number;
 }
 
 export interface RhombitrihexagonalBoardConfig {
-  type: "polygonal"; // Is this rhombitrihexagonal?
+  type: BoardPattern.Polygonal; // Is this rhombitrihexagonal?
+  size: number;
+}
+
+export interface CircularBoardConfig {
+  type: BoardPattern.Circular;
+  rings: number;
+  nodesPerRing: number;
+}
+
+export interface TrihexagonalBoardConfig {
+  type: BoardPattern.Trihexagonal;
+  size: number;
+}
+
+export interface SierplinskyBoardConfig {
+  type: BoardPattern.Sierplinsky;
   size: number;
 }
 
@@ -26,14 +58,32 @@ export function createBoard<TIntersection extends Intersection>(
 ): TIntersection[] {
   let intersections: TIntersection[];
   switch (config.type) {
-    case "grid":
+    case BoardPattern.Grid:
       intersections = createGridBoard<TIntersection>(
         config,
         intersectionConstructor,
       );
       break;
-    case "polygonal":
+    case BoardPattern.Polygonal:
       intersections = createRthBoard<TIntersection>(
+        config,
+        intersectionConstructor,
+      );
+      break;
+    case BoardPattern.Circular:
+      intersections = createCircularBoard<TIntersection>(
+        config,
+        intersectionConstructor,
+      );
+      break;
+    case BoardPattern.Trihexagonal:
+      intersections = createTrihexagonalBoard<TIntersection>(
+        config,
+        intersectionConstructor,
+      );
+      break;
+    case BoardPattern.Sierplinsky:
+      intersections = createSierplinskyBoard<TIntersection>(
         config,
         intersectionConstructor,
       );
@@ -76,6 +126,36 @@ function createRthBoard<TIntersection extends Intersection>(
 ): TIntersection[] {
   return convertIntersections<TIntersection>(
     createPolygonalBoard(config.size),
+    intersectionConstructor,
+  );
+}
+
+function createCircularBoard<TIntersection extends Intersection>(
+  config: CircularBoardConfig,
+  intersectionConstructor: IntersectionConstructor<TIntersection>,
+): TIntersection[] {
+  return convertIntersections<TIntersection>(
+    CreateCircularBoard(config.rings, config.nodesPerRing),
+    intersectionConstructor,
+  );
+}
+
+function createTrihexagonalBoard<TIntersection extends Intersection>(
+  config: TrihexagonalBoardConfig,
+  intersectionConstructor: IntersectionConstructor<TIntersection>,
+): TIntersection[] {
+  return convertIntersections<TIntersection>(
+    new TrihexagonalBoardHelper().CreateTrihexagonalBoard(config.size),
+    intersectionConstructor,
+  );
+}
+
+function createSierplinskyBoard<TIntersection extends Intersection>(
+  config: SierplinskyBoardConfig,
+  intersectionConstructor: IntersectionConstructor<TIntersection>,
+): TIntersection[] {
+  return convertIntersections<TIntersection>(
+    createSierpinskyBoard(config.size),
     intersectionConstructor,
   );
 }

--- a/packages/shared/src/variants/fractional/fractional.test.ts
+++ b/packages/shared/src/variants/fractional/fractional.test.ts
@@ -1,3 +1,4 @@
+import { BoardPattern } from "../../lib/abstractBoard/boardFactory";
 import {
   Fractional,
   FractionalConfig,
@@ -8,7 +9,10 @@ class FractionalTestGame extends Fractional {
   readonly firstCorner: FractionalIntersection | undefined;
 
   constructor(config: Pick<FractionalConfig, "players">) {
-    super({ ...config, board: { type: "grid", width: 9, height: 9 } });
+    super({
+      ...config,
+      board: { type: BoardPattern.Grid, width: 9, height: 9 },
+    });
 
     this.firstCorner = this.intersections.find(
       (i) => i.neighbours.length === 2,

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -4,6 +4,7 @@ import {
   AbstractBadukConfig,
 } from "../../lib/abstractBaduk/abstractBaduk";
 import { FractionalStone } from "./fractionalStone";
+import { BoardPattern } from "../../lib/abstractBoard/boardFactory";
 
 export type Color =
   | "black"
@@ -137,7 +138,7 @@ export class Fractional extends AbstractBaduk<
         { primaryColor: "white", secondaryColor: "green" },
         { primaryColor: "white", secondaryColor: "blue" },
       ],
-      board: { type: "grid", width: 19, height: 19 },
+      board: { type: BoardPattern.Grid, width: 19, height: 19 },
     };
   }
 


### PR DESCRIPTION
Adds the new board patterns to the board factory (circular, trihexagonal, sierplinsky).

Also adds the BoardPattern enum. I think that working with enums is nicer than working with strings (auto-completion by the IDE, no typos possible).