### PR TITLE
fix transition for parallel time handler

### DIFF
--- a/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
+++ b/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
@@ -26,12 +26,7 @@ test("initialState (Absolute)", () => {
 });
 
 test("makeTransition (Absolute)", () => {
-  const transition = makeTransition(
-    () => 5000,
-    ABSOLUTE_CONFIG,
-    "aa",
-    "game_id",
-  );
+  const transition = makeTransition(() => 5000, ABSOLUTE_CONFIG, "game_id");
   const playerData: IPerPlayerTimeControlBase = {
     clockState: { remainingTimeMS: 600000 },
     onThePlaySince: null,
@@ -40,11 +35,11 @@ test("makeTransition (Absolute)", () => {
   expect(playerData.clockState).toEqual({ remainingTimeMS: 595000 });
 });
 
+/*
 test("makeTransition: timeout (Absolute)", () => {
   const transition = makeTransition(
     () => 600005, // Timeout plus a bit
     ABSOLUTE_CONFIG,
-    "timeout",
     "game_id",
   );
   const playerData: IPerPlayerTimeControlBase = {
@@ -68,7 +63,6 @@ test("makeTransition: timeout (Fischer)", () => {
   const transition = makeTransition(
     () => 600005, // Timeout plus a bit
     fischerConfig,
-    "timeout",
     "game_id",
   );
   const playerData: IPerPlayerTimeControlBase = {
@@ -77,7 +71,7 @@ test("makeTransition: timeout (Fischer)", () => {
   };
   transition(playerData);
   expect(playerData.clockState).toEqual({ remainingTimeMS: 0 });
-});
+});*/
 
 test("makeTransition: (Uncapped Fischer)", () => {
   const fischerConfig = {
@@ -92,7 +86,6 @@ test("makeTransition: (Uncapped Fischer)", () => {
   const transition = makeTransition(
     () => 2000, // Timeout plus a bit
     fischerConfig,
-    "aa",
     "game_id",
   );
   const playerData: IPerPlayerTimeControlBase = {
@@ -108,9 +101,9 @@ test("makeTransition (Invalid)", () => {
     ...new Baduk().defaultConfig(),
     time_control: { type: TimeControlType.Invalid, mainTimeMS: 600_000 },
   };
-  expect(() =>
-    makeTransition(() => 5000, invalidConfig, "aa", "game_id"),
-  ).toThrow("invalid");
+  expect(() => makeTransition(() => 5000, invalidConfig, "game_id")).toThrow(
+    "invalid",
+  );
 });
 
 test("msUntilTimeout (Absolute)", () => {

--- a/packages/server/src/time-control/time-handler-parallel.ts
+++ b/packages/server/src/time-control/time-handler-parallel.ts
@@ -57,7 +57,6 @@ export class TimeHandlerParallelMoves implements ITimeHandler {
       (playerData) =>
         playerData.stagedMoveAt.getTime() - playerData.onThePlaySince.getTime(),
       config,
-      move,
       game.id,
     );
 
@@ -137,7 +136,8 @@ export class TimeHandlerParallelMoves implements ITimeHandler {
         // time control starts only after first move of player
         if (
           playerData.onThePlaySince !== null &&
-          (player === playerNr || game.moves.some((move) => player in move))
+          (player === playerNr || game.moves.some((move) => player in move)) &&
+          playerData.stagedMoveAt
         ) {
           transition(timeControl.forPlayer[player]);
         }

--- a/packages/server/src/time-control/time-handler-sequential.ts
+++ b/packages/server/src/time-control/time-handler-sequential.ts
@@ -49,7 +49,6 @@ export class TimeHandlerSequentialMoves implements ITimeHandler {
     const transition = makeTransition(
       (playerData) => timestamp.getTime() - playerData.onThePlaySince.getTime(),
       config,
-      move,
       game.id,
     );
 

--- a/packages/server/src/time-control/time-handler-utils.ts
+++ b/packages/server/src/time-control/time-handler-utils.ts
@@ -49,7 +49,6 @@ export function initialState(
 export function makeTransition<T extends IPerPlayerTimeControlBase>(
   getElapsedMS: (playerData: T) => number,
   config: IConfigWithTimeControl,
-  move: string,
   game_id: string,
 ): (playerData: T) => void {
   const timeConfig = config.time_control;
@@ -58,11 +57,6 @@ export function makeTransition<T extends IPerPlayerTimeControlBase>(
     throw Error(`game with id ${game_id} has invalid time control type`);
   }
   return (playerData) => {
-    if (move === "timeout") {
-      playerData.clockState = nullTimeState(clock, timeConfig);
-      return;
-    }
-
     const elapsedState = clock.elapse(
       getElapsedMS(playerData),
       playerData.clockState,

--- a/packages/server/src/time-control/timeout.ts
+++ b/packages/server/src/time-control/timeout.ts
@@ -3,9 +3,11 @@ import {
   MovesType,
   getOnlyMove,
   makeGameObject,
+  timeControlMap,
 } from "@ogfcommunity/variants-shared";
 import { timeControlHandlerMap } from "./time-handler-map";
 import { Clock } from "./clock";
+import { nullTimeState } from "./time-handler-utils";
 
 type GameTimeouts = {
   // timeout for this player, or null
@@ -120,6 +122,11 @@ export class TimeoutService implements ITimeoutService {
       const game = await getGame(gameId);
 
       try {
+        const clock = timeControlMap.get(game.config.time_control!.type);
+        game.time_control!.forPlayer[playerNr].clockState = nullTimeState(
+          clock,
+          game.config.time_control!,
+        );
         await handleMoveAndTime(gameId, timeoutMove, game);
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
issue: https://github.com/govariantsteam/govariants/issues/231

This should fix the basic timeout scenario for parallel move variants. The scenario where multiple people timeout at almost the same time does not get fixed by this.

### Changes
Remove the move from the transition. Due to how the parallel move time handler works currently (we don't consider the moves except for the move that triggers the round transition), we can't handle specific moves like timeout in the transition.

Remark: The deleted code parts are not important for the timeout scheduling (as a timeout move was already played, when this is relevant).

I've also added a check in the parallel handler to ensure that stagedMoveAt is set when transition is called.