### PR TITLE
CORS stuff

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,12 +13,12 @@
     "@types/bcrypt": "^5.0.0",
     "@types/express": "^4.17.17",
     "@types/express-session": "^1.17.7",
+    "@types/jest": "^29.5.12",
     "@types/jsdom": "^21.1.1",
     "@types/passport": "^1.0.12",
     "@types/passport-local": "^1.0.35",
     "body-parser": "^1.20.2",
     "connect-mongo": "^5.0.0",
-    "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "mongodb": "^5.6.0",
@@ -28,8 +28,7 @@
     "passport-local": "^1.0.0",
     "socket.io": "^4.7.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.1.6",
-    "@types/jest": "^29.5.12"
+    "typescript": "^5.1.6"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.1.0",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,6 @@ import {
   getUserBySessionId,
 } from "./users";
 import bodyParser from "body-parser";
-import cors from "cors";
 import path from "path";
 import { connectToDb, getDb } from "./db";
 import passport from "passport";
@@ -92,7 +91,6 @@ app.use(
   }),
 );
 app.use(bodyParser.json()); // TODO: app.use(express.json()) instead? Difference?
-app.use(cors({ origin: LOCAL_ORIGIN, credentials: true })); // TODO: Is this still necessary with dev proxy?
 app.use(
   session({
     // TODO: Cookie banner or permission necessary?

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,7 +20,11 @@ import { router as apiRouter } from "./api";
 import * as socket_io from "./socket_io";
 import { ITimeoutService, TimeoutService } from "./time-control/timeout";
 
-const LOCAL_ORIGIN = "http://127.0.0.1:5173";
+const LOCAL_ORIGIN = [
+  "http://127.0.0.1:5173",
+  "http://localhost:5173",
+  "http://[::1]:5173",
+];
 
 const timeoutService = new TimeoutService();
 export function getTimeoutService(): ITimeoutService {

--- a/packages/server/src/socket_io.ts
+++ b/packages/server/src/socket_io.ts
@@ -2,7 +2,7 @@ import http from "http";
 import { Server } from "socket.io";
 
 let _io: Server | null = null;
-export function init(server: http.Server, origin: string) {
+export function init(server: http.Server, origin: string | string[]) {
   _io = new Server(server, {
     cors: {
       origin,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,7 +1461,6 @@ __metadata:
     "@typescript-eslint/parser": ^6.1.0
     body-parser: ^1.20.2
     connect-mongo: ^5.0.0
-    cors: ^2.8.5
     eslint: ^8.44.0
     express: ^4.18.2
     express-session: ^1.17.3
@@ -3777,7 +3776,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cors@npm:^2.8.5, cors@npm:~2.8.5":
+"cors@npm:~2.8.5":
   version: 2.8.5
   resolution: "cors@npm:2.8.5"
   dependencies:


### PR DESCRIPTION
## Motivation

I wasn't getting socket messages in my dev environment, and it's because of a CORS mismatch.  I only recently noticed because I was looking at time control, where socket is necessary to receive the timeout event on the client.  The current value is IPv4 `127.0.0.1:5173`, but on my machine (Mac), it's the IPv6 `[::1]:5173`.

<img width="609" alt="Screenshot 2024-04-14 at 8 17 50 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/a010f21e-e20f-4ce4-8967-1ff259101353">


## Summary of Changes

1) Sets multiple CORS origins so that development works okay in all environments, regardless of whether a user visits `localhost:5173`, `127.0.0.1:5173`, or `[::1]:5173`.
    - @merowin fyi - this PR shouldn't break your dev environment, but just in case.  I know `"127.0.0.1:5173"` has been working best for you
2) Remove `app.use(cors({ origin: LOCAL_ORIGIN, ...))`
    - Since `LOCAL_ORIGIN` has been "wrong" this whole time, it seems clear this line isn't needed
    - @JonKo314 let me know if you had any other concerns about removing the `cors` line.  I think you wrote the `TODO: Is this still necessary with the dev proxy?`

## Testing

I ran `yarn start`, visit `localhost:5173` and `[::1]:5173`and no longer get the CORS errors in my console and socket stuff like timers works.  Vite is not serving on `127.0.0.1:5173` on my machine, so I couldn't test that.