### PR TITLE
Allow variants to signal bad configs by throwing from the constructor

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -53,11 +53,13 @@ router.get("/games", async (req, res) => {
 router.post("/games", async (req, res) => {
   const data = req.body;
 
-  const game: GameResponse = await createGame(data.variant, data.config);
-
-  res.send(game);
-
-  return;
+  try {
+    const game: GameResponse = await createGame(data.variant, data.config);
+    res.send(game);
+  } catch (e) {
+    res.status(500);
+    res.json(e.message);
+  }
 });
 
 router.post("/games/:gameId/move", async (req, res) => {

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -6,6 +6,7 @@ import {
   getOnlyMove,
   HasTimeControlConfig,
   GamesFilter,
+  game_map,
 } from "@ogfcommunity/variants-shared";
 import { ObjectId, WithId, Document, Filter } from "mongodb";
 import { getDb } from "./db";
@@ -93,6 +94,9 @@ export async function createGame(
   variant: string,
   config: object,
 ): Promise<GameResponse> {
+  // Construct a game from the config to ensure the config is valid
+  new game_map[variant](config);
+
   const game = {
     variant: variant,
     moves: [] as MovesType[],

--- a/packages/shared/src/variants/__tests__/baduk.test.ts
+++ b/packages/shared/src/variants/__tests__/baduk.test.ts
@@ -195,3 +195,8 @@ test("Capture test", () => {
     [W, W, W],
   ]);
 });
+
+test("Board too big", () => {
+  // SGF encoding only supports up to 52
+  expect(() => new Baduk({ width: 500, height: 500, komi: 0 })).toThrow();
+});

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -38,6 +38,11 @@ export class Baduk extends AbstractGame<BadukConfig, BadukState> {
 
   constructor(config?: BadukConfig) {
     super(config);
+
+    if (this.config.width >= 52 || this.config.height >= 52) {
+      throw new Error("Baduk does not support sizes greater than 52");
+    }
+
     this.board = new Grid<Color>(this.config.width, this.config.height).fill(
       Color.EMPTY,
     );

--- a/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
+++ b/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
@@ -54,11 +54,15 @@ const createGame = async () => {
     return;
   }
 
-  const game = await requests.post("/games", {
-    variant: variant.value,
-    config: { ...config, time_control: timeControlConfig },
-  });
-  router.push({ name: "game", params: { gameId: game.id } });
+  try {
+    const game = await requests.post("/games", {
+      variant: variant.value,
+      config: { ...config, time_control: timeControlConfig },
+    });
+    router.push({ name: "game", params: { gameId: game.id } });
+  } catch (e) {
+    alert(e);
+  }
 };
 
 const parseConfigThenCreateGame = async () => {


### PR DESCRIPTION
Fixes #23 

## Summary

- In Baduk, add a simple check: `height, width < 52`.
- Propagate config errors from variant constructors through the server to the UI

## Screenshot

<img width="631" alt="Screenshot 2024-04-14 at 10 26 29 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/067b8677-e15c-493b-8c2c-32e7fd896e9c">


