### PR TITLE
Variant templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "yarn workspaces foreach -pti run lint",
     "start:server": "yarn workspace @ogfcommunity/variants-server run start",
     "start:client": "yarn workspace @ogfcommunity/variants-vue-client run start",
-    "start:shared": "yarn workspace @ogfcommunity/variants-shared run start"
+    "start:shared": "yarn workspace @ogfcommunity/variants-shared run start",
+    "new-variant": "node  ./scripts/create-new-app.js"
   },
   "workspaces": {
     "packages": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,7 @@
     "@typescript-eslint/parser": "^6.1.0",
     "eslint": "^8.44.0",
     "jest": "^29.6.0",
+    "nunjucks": "^3.2.4",
     "prettier": "^3.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1"
@@ -17,7 +18,8 @@
     "start": "tsc --watch",
     "test": "jest",
     "lint:check": "eslint ./src && prettier --check ./src",
-    "lint": "eslint --fix ./src && prettier --write ./src"
+    "lint": "eslint --fix ./src && prettier --write ./src",
+    "new-variant": "node scripts/create-new-variant.mjs"
   },
   "dependencies": {
     "chess.js": "^1.0.0-beta.6",

--- a/packages/shared/scripts/create-new-variant.mjs
+++ b/packages/shared/scripts/create-new-variant.mjs
@@ -6,17 +6,32 @@ import path from "path";
 /* global process */
 
 // Function to replace templates
-function replaceTemplates(sourcePath, targetPath) {
+function replaceTemplates(sourcePath, targetPath, variantName) {
   // Read the source file
   let content = readFileSync(sourcePath, "utf-8");
 
   // Use Nunjucks to render the template
   content = nunjucks.renderString(content, {
-    /* your variables here */
+    namePascal: snakeToPascal(variantName),
+    nameSnake: variantName,
   });
 
   // Write the rendered content to the target file
   writeFileSync(targetPath, content);
+}
+
+// convert snake_case string to PascalCase
+function snakeToPascal(snakeCase) {
+  // Split the string into an array of words
+  const words = snakeCase.split("_");
+
+  // Capitalize the first letter of each word
+  const pascalWords = words.map(
+    (word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase(),
+  );
+
+  // Join the words back together
+  return pascalWords.join("");
 }
 
 // Get the variant name
@@ -43,7 +58,7 @@ const testFileOutput = path.join(
 );
 
 // Call the copy directory function
-replaceTemplates(sourceFileTemplate, sourceFileOutput);
-replaceTemplates(testFileTemplate, testFileOutput);
+replaceTemplates(sourceFileTemplate, sourceFileOutput, variantName);
+replaceTemplates(testFileTemplate, testFileOutput, variantName);
 
 console.log("Directory copied and templates replaced successfully.");

--- a/packages/shared/scripts/create-new-variant.mjs
+++ b/packages/shared/scripts/create-new-variant.mjs
@@ -1,0 +1,49 @@
+import { readFileSync, writeFileSync } from "fs";
+import nunjucks from "nunjucks";
+import path from "path";
+
+/* global console */
+/* global process */
+
+// Function to replace templates
+function replaceTemplates(sourcePath, targetPath) {
+  // Read the source file
+  let content = readFileSync(sourcePath, "utf-8");
+
+  // Use Nunjucks to render the template
+  content = nunjucks.renderString(content, {
+    /* your variables here */
+  });
+
+  // Write the rendered content to the target file
+  writeFileSync(targetPath, content);
+}
+
+// Get the variant name
+if (process.argv.length !== 3) {
+  console.log("Usage: node create-new-variant.mjs [variant name]");
+  process.exit(1);
+}
+const variantName = process.argv[2];
+if (!/^[a-z_]*$/.test(variantName)) {
+  console.error(
+    "Please use snake_case (only lower case letters and underscores)",
+  );
+  process.exit(1);
+}
+
+// Define source and target directories
+const variantsDir = path.join(process.cwd(), "src/variants");
+const sourceFileTemplate = path.join(variantsDir, "template/variant.ts.njk");
+const sourceFileOutput = path.join(variantsDir, `${variantName}.ts`);
+const testFileTemplate = path.join(variantsDir, "template/variant.test.ts.njk");
+const testFileOutput = path.join(
+  variantsDir,
+  `__tests__/${variantName}.test.ts`,
+);
+
+// Call the copy directory function
+replaceTemplates(sourceFileTemplate, sourceFileOutput);
+replaceTemplates(testFileTemplate, testFileOutput);
+
+console.log("Directory copied and templates replaced successfully.");

--- a/packages/shared/src/variants/template/variant.test.ts.njk
+++ b/packages/shared/src/variants/template/variant.test.ts.njk
@@ -1,8 +1,9 @@
-import { {{ namePascal }}, Color } from "../{{ nameSnake }}";
+import { {{ namePascal }} } from "../{{ nameSnake }}";
 
-const B = Color.BLACK;
-const _ = Color.EMPTY;
-const W = Color.WHITE;
+// These variables just make the boards a little prettier
+const B = 0;
+const _ = null;
+const W = 1;
 
 test("Play a game", () => {
   const game = new {{ namePascal }}({ width: 4, height: 4 });

--- a/packages/shared/src/variants/template/variant.test.ts.njk
+++ b/packages/shared/src/variants/template/variant.test.ts.njk
@@ -1,0 +1,3 @@
+/* global console */
+
+console.log("hello, world");

--- a/packages/shared/src/variants/template/variant.test.ts.njk
+++ b/packages/shared/src/variants/template/variant.test.ts.njk
@@ -1,3 +1,26 @@
-/* global console */
+import { {{ namePascal }}, Color } from "../{{ nameSnake }}";
 
-console.log("hello, world");
+const B = Color.BLACK;
+const _ = Color.EMPTY;
+const W = Color.WHITE;
+
+test("Play a game", () => {
+  const game = new {{ namePascal }}({ width: 4, height: 4 });
+  // Tiny board:
+  // B - - -
+  // - W - -
+  // - - B -
+  // - - - W
+
+  game.playMove(0, "aa");
+  game.playMove(1, "bb");
+  game.playMove(0, "cc");
+  game.playMove(1, "dd");
+
+  expect(game.exportState().board).toEqual([
+    [B, _, _, _],
+    [_, W, _, _],
+    [_, _, B, _],
+    [_, _, _, W],
+  ]);
+});

--- a/packages/shared/src/variants/template/variant.ts.njk
+++ b/packages/shared/src/variants/template/variant.ts.njk
@@ -2,11 +2,7 @@ import { Coordinate } from "../lib/coordinate";
 import { Grid } from "../lib/grid";
 import { AbstractGame } from "../abstract_game";
 
-export enum Color {
-  EMPTY = 0,
-  BLACK = 1,
-  WHITE = 2,
-}
+type Color = number | null;
 
 export interface {{ namePascal }}Config {
   width: number;
@@ -17,70 +13,103 @@ export interface {{ namePascal }}State {
   board: Color[][];
 }
 
-export type {{ namePascal }}Move = { 0: string } | { 1: string };
-
 export class {{ namePascal }} extends AbstractGame<
   {{ namePascal }}Config,
   {{ namePascal }}State
 > {
-  public board: Grid<Color>;
+  public board: Grid<number | null>;
   protected next_to_play: 0 | 1 = 0;
 
+  // Initialize state of the game for a given config
   constructor(config?: {{ namePascal }}Config) {
+    // AbstractGame will set this.config to the defaultConfig() if config is undefined.
+    // Therefore, we access config through this.config in the rest of this function
     super(config);
 
+    if (this.config.width >= 25 || this.config.height >= 25) {
+        // You can throw from this function to signify an invalid config
+        // It is highly recommended to put a cap on board size to prevent
+        // overloading the CPU
+        throw new Error("Board too big!");
+    }
+
     this.board = new Grid<Color>(this.config.width, this.config.height).fill(
-      Color.EMPTY,
+      null,
     );
   }
 
-  override exportState(): {{ namePascal }}State {
+  // Return an object that represents the state of the game as it should be displayed to
+  // the user.  The player parameter can be used to determine which parts of the state
+  // should not be shown.
+  override exportState(/* player?: number */): {{ namePascal }}State {
     return {
       board: this.board.to2DArray(),
     };
   }
 
+  // Return an array of the players who can place a stone in this round
   override nextToPlay(): number[] {
-    // This just means either player can play as long as the game hasn't ended
-    // you will likely want to change this.
-    return this.phase === "gameover" ? [] : [0, 1];
+    // Return empty array if game is over.
+    // You can check the phase property of AbstractGame
+    if (this.phase === "gameover") {
+      return [];
+    }
+
+    // Return a list of the players who may submit a move
+    // [0, 1] means either player can make a move - you will likely want to change this
+    return [0, 1]
   }
 
+  // Validate move and update the state accordingly
   override playMove(player: number, move: string): void {
     if (move === "resign") {
-      // Set this.phase to "gameover" to end the game
+      // Set phase to "gameover" to end the game
+      // phase is a property of the AbstractGame class
       this.phase = "gameover";
+      // result is also a property of the AbstractGame class, and is displayed to the user
       this.result = this.next_to_play === 0 ? "W+R" : "B+R";
       return;
     }
 
     if (move === "timeout") {
+      // "timeout" is a special move sent by the system, and is handled similar
+      // "resign"
       this.phase = "gameover";
       this.result = player === 0 ? "W+T" : "B+T";
       return;
     }
 
     if (move == "pass") {
+      // It is important to increase the round in order for game playback
+      // and timers to work
+      super.increaseRound();
       return;
     }
 
     const decoded_move = Coordinate.fromSgfRepr(move);
     if (!this.board.isInBounds(decoded_move)) {
-      // You can throw from this function to signify invalid moves
+      // You can throw from the playMove() function to signify invalid moves
       throw Error(
         `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`,
       );
     }
 
-    this.board.set(decoded_move, player === 0 ? Color.BLACK : Color.WHITE);
+    // After checking the move is valid
+    this.board.set(decoded_move, player);
 
+    // It is important to increase the round in order for game playback
+    // and timers to work
     super.increaseRound();
   }
+
 
   override numPlayers(): number {
     return 2;
   }
 
+  // These show up as buttons in the UI
+  // The key is the string that is passed to playMove(), and the value is
+  // the string that is displayed on the button
   override specialMoves(): { [key: string]: string } {
     return { pass: "Pass", resign: "Resign" };
   }

--- a/packages/shared/src/variants/template/variant.ts.njk
+++ b/packages/shared/src/variants/template/variant.ts.njk
@@ -1,0 +1,3 @@
+/* global console */
+
+console.log("hello, world");

--- a/packages/shared/src/variants/template/variant.ts.njk
+++ b/packages/shared/src/variants/template/variant.ts.njk
@@ -1,3 +1,91 @@
-/* global console */
+import { Coordinate } from "../lib/coordinate";
+import { Grid } from "../lib/grid";
+import { AbstractGame } from "../abstract_game";
 
-console.log("hello, world");
+export enum Color {
+  EMPTY = 0,
+  BLACK = 1,
+  WHITE = 2,
+}
+
+export interface {{ namePascal }}Config {
+  width: number;
+  height: number;
+}
+
+export interface {{ namePascal }}State {
+  board: Color[][];
+}
+
+export type {{ namePascal }}Move = { 0: string } | { 1: string };
+
+export class {{ namePascal }} extends AbstractGame<
+  {{ namePascal }}Config,
+  {{ namePascal }}State
+> {
+  public board: Grid<Color>;
+  protected next_to_play: 0 | 1 = 0;
+
+  constructor(config?: {{ namePascal }}Config) {
+    super(config);
+
+    this.board = new Grid<Color>(this.config.width, this.config.height).fill(
+      Color.EMPTY,
+    );
+  }
+
+  override exportState(): {{ namePascal }}State {
+    return {
+      board: this.board.to2DArray(),
+    };
+  }
+
+  override nextToPlay(): number[] {
+    // This just means either player can play as long as the game hasn't ended
+    // you will likely want to change this.
+    return this.phase === "gameover" ? [] : [0, 1];
+  }
+
+  override playMove(player: number, move: string): void {
+    if (move === "resign") {
+      // Set this.phase to "gameover" to end the game
+      this.phase = "gameover";
+      this.result = this.next_to_play === 0 ? "W+R" : "B+R";
+      return;
+    }
+
+    if (move === "timeout") {
+      this.phase = "gameover";
+      this.result = player === 0 ? "W+T" : "B+T";
+      return;
+    }
+
+    if (move == "pass") {
+      return;
+    }
+
+    const decoded_move = Coordinate.fromSgfRepr(move);
+    if (!this.board.isInBounds(decoded_move)) {
+      // You can throw from this function to signify invalid moves
+      throw Error(
+        `Move out of bounds. (move: ${decoded_move}, board dimensions: ${this.config.width}x${this.config.height}`,
+      );
+    }
+
+    this.board.set(decoded_move, player === 0 ? Color.BLACK : Color.WHITE);
+
+    super.increaseRound();
+  }
+
+  override numPlayers(): number {
+    return 2;
+  }
+
+  override specialMoves(): { [key: string]: string } {
+    return { pass: "Pass", resign: "Resign" };
+  }
+
+  defaultConfig(): {{ namePascal }}Config {
+    return { width: 19, height: 19 };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,6 +1489,7 @@ __metadata:
     chess.js: ^1.0.0-beta.6
     eslint: ^8.44.0
     jest: ^29.6.0
+    nunjucks: ^3.2.4
     prettier: ^3.0.0
     ts-jest: ^29.1.1
     ts-node: ^10.9.1
@@ -2627,6 +2628,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"a-sync-waterfall@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "a-sync-waterfall@npm:1.0.1"
+  checksum: 534948b50d6787c2dd5b7e89179b30c0fd96ac80a662d0f92eaa568cfffb36f1eea4aa720e3a21572d8b5f8686940954ac9d8c7667bcc719c1317ae3bdf86fe0
+  languageName: node
+  linkType: hard
+
 "abab@npm:^2.0.6":
   version: 2.0.6
   resolution: "abab@npm:2.0.6"
@@ -2874,6 +2882,13 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
+  languageName: node
+  linkType: hard
+
+"asap@npm:^2.0.3":
+  version: 2.0.6
+  resolution: "asap@npm:2.0.6"
+  checksum: b296c92c4b969e973260e47523207cd5769abd27c245a68c26dc7a0fe8053c55bb04360237cb51cab1df52be939da77150ace99ad331fb7fb13b3423ed73ff3d
   languageName: node
   linkType: hard
 
@@ -3658,6 +3673,13 @@ __metadata:
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
+"commander@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "commander@npm:5.1.0"
+  checksum: 0b7fec1712fbcc6230fcb161d8d73b4730fa91a21dc089515489402ad78810547683f058e2a9835929c212fead1d6a6ade70db28bbb03edbc2829a9ab7d69447
   languageName: node
   linkType: hard
 
@@ -7607,6 +7629,24 @@ __metadata:
   dependencies:
     boolbase: ^1.0.0
   checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
+  languageName: node
+  linkType: hard
+
+"nunjucks@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "nunjucks@npm:3.2.4"
+  dependencies:
+    a-sync-waterfall: ^1.0.0
+    asap: ^2.0.3
+    commander: ^5.1.0
+  peerDependencies:
+    chokidar: ^3.3.0
+  peerDependenciesMeta:
+    chokidar:
+      optional: true
+  bin:
+    nunjucks-precompile: bin/precompile
+  checksum: 8b902a9deb9ff0f5c9ebbd2c7f96dfe5800bf42bdfc91d8f829fc0440ec1f87901593e20479f5ba1bddcc9f2472b16a5e932be5863dcdec0899a27c01a03df32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a bit experimental - I think it could be nice to have a way to generate boilerplate for new variants.  I don't know if this offers a ton of value on top over just copy+paste, but I'd like to try it out in case it's useful.

How to use:

- From the packages/shared directory, run `yarn new-variant variant_name` to generate code.
- A simple test is also generated, which can be run with `yarn test variant_name`

```
$ cd packages/shared
$ yarn new-variant my_new_variant                   
Directory copied and templates replaced successfully.
$ yarn test my_new_variant
 PASS  src/variants/__tests__/my_new_variant.test.ts
  ✓ Play a game (5 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        0.48 s, estimated 1 s
Ran all test suites matching /my_new_variant/i.
```

## Technical summary

I use [Nunjucks](https://mozilla.github.io/nunjucks/) to fill in templates from the shared/variants/templates directory.  Then copy them over to their proper places.

## Future improvements

Not in this PR, but it would be good to:

- Add `yarn new-variant dummy_variant && yarn test dummy_variant` to CI.
- Add variant to the various "maps" in the generation script.

