### PR TITLE
Fix some reactivity issues in Grid boards.

### DIFF
--- a/packages/vue-client/src/components/boards/BadukBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukBoard.vue
@@ -6,23 +6,17 @@ import {
   type BadukState,
   getHoshi,
 } from "@ogfcommunity/variants-shared";
-import { toRefs } from "vue";
+import { computed } from "vue";
+import { positionsGetter } from "./board_utils";
 
 const props = defineProps<{
   gamestate: BadukState;
   config: BadukConfig;
 }>();
 
-props.config;
-
-const { width, height } = toRefs(props.config);
-
-const positions = new Array(height.value * width.value)
-  .fill(null)
-  .map(
-    (_, index) =>
-      new Coordinate(index % width.value, Math.floor(index / width.value)),
-  );
+const width = computed(() => props.config.width);
+const height = computed(() => props.config.height);
+const positions = computed(positionsGetter(width, height));
 
 function colorToClassString(color: Color): string {
   return color === Color.EMPTY

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -6,10 +6,11 @@ interface MulticolorStone {
 </script>
 
 <script setup lang="ts">
-import { ref, toRefs, type Ref } from "vue";
+import { computed, ref, type Ref } from "vue";
 import TaegeukStone from "../TaegeukStone.vue";
 import IntersectionAnnotation from "../IntersectionAnnotation.vue";
 import { Coordinate } from "@ogfcommunity/variants-shared";
+import { positionsGetter } from "./board_utils";
 
 const props = defineProps<{
   board: (MulticolorStone | null)[][];
@@ -17,13 +18,9 @@ const props = defineProps<{
   config: { height: number; width: number };
 }>();
 
-const { width, height } = toRefs(props.config);
-
-const positions = new Array(height.value * width.value)
-  .fill(null)
-  .map((_, index) => {
-    return new Coordinate(index % width.value, Math.floor(index / width.value));
-  });
+const width = computed(() => props.config.width);
+const height = computed(() => props.config.height);
+const positions = computed(positionsGetter(width, height));
 
 const hovered: Ref<Coordinate> = ref(new Coordinate(-1, -1));
 

--- a/packages/vue-client/src/components/boards/board_utils.ts
+++ b/packages/vue-client/src/components/boards/board_utils.ts
@@ -1,6 +1,8 @@
 import { Coordinate } from "@ogfcommunity/variants-shared";
 import type { Ref } from "vue";
 
+/** Given Refs for width and height, return a flat array of coordinates containing
+ * all coordinates in a grid */
 export function positionsGetter(width: Ref<number>, height: Ref<number>) {
   return () =>
     new Array(height.value * width.value)

--- a/packages/vue-client/src/components/boards/board_utils.ts
+++ b/packages/vue-client/src/components/boards/board_utils.ts
@@ -1,0 +1,12 @@
+import { Coordinate } from "@ogfcommunity/variants-shared";
+import type { Ref } from "vue";
+
+export function positionsGetter(width: Ref<number>, height: Ref<number>) {
+  return () =>
+    new Array(height.value * width.value)
+      .fill(null)
+      .map(
+        (_, index) =>
+          new Coordinate(index % width.value, Math.floor(index / width.value)),
+      );
+}


### PR DESCRIPTION
The specific error was: `toRefs() expects a reactive object but received a plain one`. I believe it's because props.config is not reactive even though props is reactive.  I also made `positions` a computed property.

<img width="636" alt="Screenshot 2024-04-20 at 8 58 25 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/68987d4a-3d8c-4584-be3c-be66550e133a">
