### PR TITLE
Copy Procfile into the root directory.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn workspace @ogfcommunity/variants-server launch


### PR DESCRIPTION
In attempt to address #37, I will do the following in order:

1) Copy the procfile into root (this PR)
2) Remove the [Multi Procfile buildpack](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-multi-procfile)
3) Delete `server/Procfile`

---

From Heroku docs:

> The Procfile must live in your app’s root directory. It does not function if placed anywhere else.

The only reason it's working currently is the Multiprocfile buildpack looks at a `PROCFILE` environment variable. However, we aren't using multiple Procfiles anymore, so this is superfluous.