### PR TITLE
[server] Separate "build" and "launch" scripts.

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,8 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "nodemon ./src/index.ts",
-    "launch": "tsc && node ./dist/index.js",
+    "build": "tsc",
+    "launch": "node ./dist/index.js",
     "test": "jest",
     "lint": "eslint --fix ./src && prettier --write ./src",
     "lint:check": "eslint ./src && prettier --check ./src"


### PR DESCRIPTION
Semantically, `tsc` is definitely the "build" command for the server.  The motivation for splitting this out is #97 - it makes sense to run "yarn build" as part of PR checks, but doesn't make as much sense to run "launch".

If you're wondering why I didn't update the Heroku config, it's because [Heroku runs `yarn build` automatically](https://devcenter.heroku.com/changelog-items/1573) 🤞