### PR TITLE
[server] Watch shared/ for changes in start script.

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,7 +2,7 @@
   "name": "@ogfcommunity/variants-server",
   "main": "dist/index.js",
   "scripts": {
-    "start": "nodemon ./src/index.ts",
+    "start": "nodemon ./src/index.ts -w ./src -w ../shared/dist",
     "launch": "tsc && node ./dist/index.js",
     "test": "jest",
     "lint": "eslint --fix ./src && prettier --write ./src",


### PR DESCRIPTION
Piece of cake compared to Vite configs haha...  From the [nodemon docs](https://github.com/remy/nodemon#monitoring-multiple-directories):

> By default nodemon monitors the current working directory. If you want to take control of that option, use the --watch option to add specific paths:
>
> ```
> nodemon --watch app --watch libs app/server.js
>```
>
> Now nodemon will only restart if there are changes in the ./app or ./libs directory. By default nodemon will traverse sub-directories, so there's no need in explicitly including sub-directories.

With #240, should fix #28 