### PR TITLE
Delay nodemon reloads

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,6 +40,7 @@
     "ts-jest": "^29.1.1"
   },
   "nodemonConfig": {
-    "watch": ["./src", "../shared/dist"]
+    "watch": ["./src", "../shared/dist"],
+    "delay": 500
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,7 +2,7 @@
   "name": "@ogfcommunity/variants-server",
   "main": "dist/index.js",
   "scripts": {
-    "start": "nodemon ./src/index.ts -w ./src -w ../shared/dist",
+    "start": "nodemon ./src/index.ts",
     "build": "tsc",
     "launch": "node ./dist/index.js",
     "test": "jest",
@@ -38,5 +38,8 @@
     "jest": "^29.6.0",
     "prettier": "^3.0.0",
     "ts-jest": "^29.1.1"
+  },
+  "nodemonConfig": {
+    "watch": ["./src", "../shared/dist"]
   }
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,7 +14,7 @@ import { connectToDb, getDb } from "./db";
 import passport from "passport";
 import { Strategy as CustomStrategy } from "passport-custom";
 import { Strategy as LocalStrategy } from "passport-local";
-import { UserResponse } from "@ogfcommunity/variants-shared";
+import { SITE_NAME, UserResponse } from "@ogfcommunity/variants-shared";
 import { router as apiRouter } from "./api";
 import * as socket_io from "./socket_io";
 import { ITimeoutService, TimeoutService } from "./time-control/timeout";
@@ -139,5 +139,6 @@ if (isProd) {
 
 const PORT = process.env.PORT || 3001;
 server.listen(PORT, () => {
+  console.log(`${SITE_NAME} server started`);
   console.log(`listening on *:${PORT}`);
 });


### PR DESCRIPTION
Noticed some log spam following #244:

<img width="440" alt="Screenshot 2024-04-27 at 11 07 28 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/5c2006cd-3159-475f-a291-e22e3a3c7e13">

While there may be some way to synchronize the shared and server reload scripts, I think the easiest is to put a small delay (500 ms) on server reloads.