### PR TITLE
add components for new board patterns that work with baduk

### DIFF
--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -1,4 +1,3 @@
-import { GridBaduk } from "./variants/baduk";
 import { AbstractGame } from "./abstract_game";
 import { BadukWithAbstractBoard } from "./variants/badukWithAbstractBoard";
 import { Phantom } from "./variants/phantom";
@@ -14,12 +13,13 @@ import { Keima } from "./variants/keima";
 import { OneColorGo } from "./variants/one_color";
 import { DriftGo } from "./variants/drift";
 import { QuantumGo } from "./variants/quantum";
+import { Baduk } from "./variants/baduk";
 
 export const game_map: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [variant: string]: new (config?: any) => AbstractGame;
 } = {
-  baduk: GridBaduk,
+  baduk: Baduk,
   badukWithAbstractBoard: BadukWithAbstractBoard,
   phantom: Phantom,
   parallel: ParallelGo,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,5 +21,7 @@ export {
 export { type KeimaState } from "./variants/keima";
 export * from "./variants/drift";
 export * from "./variants/baduk_utils";
+export * from "./lib/abstractBoard/boardFactory";
+export * from "./lib/abstractBoard/intersection";
 
 export const SITE_NAME = "Go Variants";

--- a/packages/shared/src/lib/__tests__/board.test.ts
+++ b/packages/shared/src/lib/__tests__/board.test.ts
@@ -1,0 +1,22 @@
+import { Color } from "../../variants/badukWithAbstractBoard";
+import {
+  BoardPattern,
+  createBoard,
+  createGraph,
+} from "../abstractBoard/boardFactory";
+import { Intersection } from "../abstractBoard/intersection";
+
+test("create rhombitrihexagonal board", () => {
+  const intersections = createBoard(
+    {
+      type: BoardPattern.Polygonal,
+      size: 2,
+    },
+    Intersection,
+  );
+  const graph = createGraph(intersections, Color.EMPTY);
+
+  // Remark: This test case is not independent of implementation
+  // Also see PolygonalBoardHelper lines 4 - 28
+  expect(graph.neighbors(0)).toEqual([1, 5, 6, 17]);
+});

--- a/packages/shared/src/lib/__tests__/board.test.ts
+++ b/packages/shared/src/lib/__tests__/board.test.ts
@@ -16,7 +16,14 @@ test("create rhombitrihexagonal board", () => {
   );
   const graph = createGraph(intersections, Color.EMPTY);
 
-  // Remark: This test case is not independent of implementation
+  expect(
+    graph.reduce<number>(
+      (prev, _, index, g) => prev + g.neighbors(index).length,
+      0,
+    ),
+  ).toEqual(6 * 4 + 12 * 3);
+
+  // Remark: This assertion is not independent of implementation
   // Also see PolygonalBoardHelper lines 4 - 28
   expect(graph.neighbors(0)).toEqual([1, 5, 6, 17]);
 });

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -130,8 +130,7 @@ export function createGraph<TIntersection extends Intersection, TColor>(
       intersections.indexOf(neighbour),
     ),
   );
-  const graph = new Graph<TColor>(adjacencyMatrix).fill(startColor);
-  return graph;
+  return new Graph<TColor>(adjacencyMatrix).fill(startColor);
 }
 
 function createRthBoard<TIntersection extends Intersection>(

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -130,10 +130,7 @@ export function createGraph<TIntersection extends Intersection, TColor>(
       intersections.indexOf(neighbour),
     ),
   );
-  const graph = new Graph<TColor>(adjacencyMatrix);
-  intersections.forEach((intersection) =>
-    graph.set(intersection.id, startColor),
-  );
+  const graph = new Graph<TColor>(adjacencyMatrix).fill(startColor);
   return graph;
 }
 

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -123,11 +123,18 @@ function createGridBoard<TIntersection extends Intersection>(
 
 export function createGraph<TIntersection extends Intersection, TColor>(
   intersections: TIntersection[],
+  startColor: TColor,
 ): Graph<TColor> {
   const adjacencyMatrix = intersections.map((intersection) =>
-    intersection.neighbours.map((_neighbour, index) => index),
+    intersection.neighbours.map((neighbour) =>
+      intersections.indexOf(neighbour),
+    ),
   );
-  return new Graph<TColor>(adjacencyMatrix);
+  const graph = new Graph<TColor>(adjacencyMatrix);
+  intersections.forEach((intersection) =>
+    graph.set(intersection.id, startColor),
+  );
+  return graph;
 }
 
 function createRthBoard<TIntersection extends Intersection>(

--- a/packages/shared/src/variants/__tests__/quantum.test.ts
+++ b/packages/shared/src/variants/__tests__/quantum.test.ts
@@ -7,7 +7,10 @@ const B = Color.BLACK;
 const _ = Color.EMPTY;
 
 test("Quantum stone placement", () => {
-  const game = new QuantumGo({ width: 2, height: 2, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 2, height: 2 },
+    komi: 0.5,
+  });
 
   game.playMove(0, "aa");
   expect(game.exportState().boards).toEqual([
@@ -37,7 +40,10 @@ test("Quantum stone placement", () => {
 });
 
 test("Test throws if incorrect player in the quantum stone phase", () => {
-  const game = new QuantumGo({ width: 2, height: 2, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 2, height: 2 },
+    komi: 0.5,
+  });
 
   expect(() => game.playMove(1, "aa")).toThrow();
   game.playMove(0, "aa");
@@ -45,14 +51,20 @@ test("Test throws if incorrect player in the quantum stone phase", () => {
 });
 
 test("Test throws stone played on top of stone in quantum phase", () => {
-  const game = new QuantumGo({ width: 2, height: 2, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 2, height: 2 },
+    komi: 0.5,
+  });
 
   game.playMove(0, "aa");
   expect(() => game.playMove(1, "aa")).toThrow();
 });
 
 test("Capture quantum stone", () => {
-  const game = new QuantumGo({ width: 5, height: 3, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 5, height: 3 },
+    komi: 0.5,
+  });
 
   // .{B}. . W
   // B{W}B . W
@@ -102,7 +114,10 @@ test("Capture quantum stone", () => {
 });
 
 test("Capture non-quantum stone", () => {
-  const game = new QuantumGo({ width: 5, height: 3, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 5, height: 3 },
+    komi: 0.5,
+  });
 
   // .{B}. . W
   // B W B .{W}
@@ -152,7 +167,10 @@ test("Capture non-quantum stone", () => {
 });
 
 test("Two passes ends the game", () => {
-  const game = new QuantumGo({ width: 4, height: 2, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 4, height: 2 },
+    komi: 0.5,
+  });
 
   game.playMove(0, "ba");
   game.playMove(1, "ca");
@@ -195,7 +213,10 @@ test("Two passes ends the game", () => {
 });
 
 test("Placing a stone in a captured quantum position", () => {
-  const game = new QuantumGo({ width: 9, height: 9, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 9, height: 9 },
+    komi: 0.5,
+  });
 
   // https://www.govariants.com/game/660248dd5e01aefcbd63df6a
 
@@ -238,7 +259,10 @@ test("Placing a stone in a captured quantum position", () => {
 });
 
 test("Placing a white stone in a captured quantum position", () => {
-  const game = new QuantumGo({ width: 9, height: 9, komi: 0.5 });
+  const game = new QuantumGo({
+    board: { type: "grid", width: 9, height: 9 },
+    komi: 0.5,
+  });
 
   // https://www.govariants.com/game/660248dd5e01aefcbd63df6a
 

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -4,7 +4,6 @@ import { getGroup, getOuterBorder } from "../lib/group_utils";
 import { SuperKoDetector } from "../lib/ko_detector";
 import { AbstractGame } from "../abstract_game";
 import {
-  BoardConfig,
   BoardPattern,
   createBoard,
   createGraph,
@@ -12,9 +11,9 @@ import {
 import { Intersection } from "../lib/abstractBoard/intersection";
 import { GraphWrapper } from "../lib/graph";
 import {
-  GridBadukConfig,
   LegacyBadukConfig,
   NewBadukConfig,
+  NewGridBadukConfig,
   isGridBadukConfig,
   isLegacyBadukConfig,
   mapToNewConfig,
@@ -51,7 +50,7 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
   /** after game ends, this is black points - white points */
   public numeric_result?: number;
 
-  constructor(config?: LegacyBadukConfig | BadukConfig) {
+  constructor(config?: BadukConfig) {
     super(isLegacyBadukConfig(config) ? mapToNewConfig(config) : config);
 
     if (isGridBadukConfig(this.config)) {
@@ -246,4 +245,28 @@ export function groupHasLiberties(
 /** Returns a reducer that will count occurences of a given number **/
 function count_color<T>(value: T) {
   return (total: number, color: T) => total + (color === value ? 1 : 0);
+}
+
+export class GridBaduk extends Baduk {
+  // ! isn't typesafe, but we know board will be assigned in super()
+  declare board: Grid<Color>;
+  protected declare score_board?: Grid<Color>;
+  declare config: NewGridBadukConfig;
+  constructor(config?: BadukConfig) {
+    if (config && !isGridBadukConfig(config)) {
+      throw "GridBaduk requires a GridBadukConfig";
+    }
+    super(config);
+  }
+
+  override defaultConfig(): NewGridBadukConfig {
+    return {
+      komi: 6.5,
+      board: {
+        type: BoardPattern.Grid,
+        width: 19,
+        height: 19,
+      },
+    };
+  }
 }

--- a/packages/shared/src/variants/baduk_utils.ts
+++ b/packages/shared/src/variants/baduk_utils.ts
@@ -1,4 +1,5 @@
 import {
+  BoardConfig,
   BoardPattern,
   GridBoardConfig,
 } from "../lib/abstractBoard/boardFactory";
@@ -8,6 +9,11 @@ export type LegacyBadukConfig = {
   width: number;
   height: number;
   komi: number;
+};
+
+export type NewBadukConfig = {
+  komi: number;
+  board: BoardConfig;
 };
 
 export type GridBadukConfig =
@@ -30,4 +36,26 @@ export function getWidthAndHeight(config: GridBadukConfig): {
   const width = "board" in config ? config.board.width : config.width;
   const height = "board" in config ? config.board.height : config.height;
   return { width: width, height: height };
+}
+
+export function isLegacyBadukConfig(
+  config: object | undefined,
+): config is LegacyBadukConfig {
+  return (
+    config !== undefined &&
+    "width" in config &&
+    "height" in config &&
+    "komi" in config
+  );
+}
+
+export function mapToNewConfig(config: LegacyBadukConfig): NewBadukConfig {
+  return {
+    ...config,
+    board: {
+      type: BoardPattern.Grid,
+      width: config.width,
+      height: config.height,
+    },
+  };
 }

--- a/packages/shared/src/variants/baduk_utils.ts
+++ b/packages/shared/src/variants/baduk_utils.ts
@@ -16,12 +16,12 @@ export type NewBadukConfig = {
   board: BoardConfig;
 };
 
-export type GridBadukConfig =
-  | LegacyBadukConfig
-  | {
-      komi: number;
-      board: GridBoardConfig;
-    };
+export type NewGridBadukConfig = {
+  komi: number;
+  board: GridBoardConfig;
+};
+
+export type GridBadukConfig = LegacyBadukConfig | NewGridBadukConfig;
 
 export function isGridBadukConfig(
   config: BadukConfig,

--- a/packages/shared/src/variants/drift.ts
+++ b/packages/shared/src/variants/drift.ts
@@ -1,23 +1,50 @@
+import { GridBoardConfig } from "../lib/abstractBoard/boardFactory";
 import { Coordinate } from "../lib/coordinate";
+import { Grid } from "../lib/grid";
 import { getGroup } from "../lib/group_utils";
-import { Color, GridBaduk, groupHasLiberties } from "./baduk";
-import { GridBadukConfig } from "./baduk_utils";
+import { Baduk, Color, groupHasLiberties } from "./baduk";
+import { LegacyBadukConfig, NewBadukConfig } from "./baduk_utils";
 
-export type DriftGoConfig = GridBadukConfig & {
+export type DriftGoConfig = { komi: number; board: GridBoardConfig } & {
   yShift: number;
   xShift: number;
 };
 
-export class DriftGo extends GridBaduk {
-  private typedConfig: DriftGoConfig;
+export type LegacyDriftGoConfig = LegacyBadukConfig & {
+  yShift: number;
+  xShift: number;
+};
 
-  constructor(config?: DriftGoConfig) {
+function isDriftGoConfig(config: object): config is DriftGoConfig {
+  return (
+    "komi" in config &&
+    "board" in config &&
+    "xShift" in config &&
+    "yShift" in config
+  );
+}
+
+export class DriftGo extends Baduk {
+  private typedConfig: DriftGoConfig;
+  declare board: Grid<Color>;
+
+  constructor(config?: DriftGoConfig | LegacyDriftGoConfig) {
     super(config);
-    this.typedConfig = config ?? this.defaultConfig();
+    if (!isDriftGoConfig(this.config)) {
+      throw Error(
+        `Drift accepts only grid board config. Received config: ${JSON.stringify(config)}`,
+      );
+    }
+    this.typedConfig = this.config ?? this.defaultConfig();
   }
 
   defaultConfig(): DriftGoConfig {
-    return { ...super.defaultConfig(), xShift: 0, yShift: 1 };
+    return {
+      komi: 6.5,
+      board: { type: "grid", width: 19, height: 19 },
+      xShift: 0,
+      yShift: 1,
+    };
   }
 
   protected prepareForNextMove(move: string): void {

--- a/packages/shared/src/variants/drift.ts
+++ b/packages/shared/src/variants/drift.ts
@@ -1,42 +1,17 @@
-import { GridBoardConfig } from "../lib/abstractBoard/boardFactory";
 import { Coordinate } from "../lib/coordinate";
 import { Grid } from "../lib/grid";
 import { getGroup } from "../lib/group_utils";
-import { Baduk, Color, groupHasLiberties } from "./baduk";
-import { LegacyBadukConfig, NewBadukConfig } from "./baduk_utils";
+import { Color, GridBaduk, groupHasLiberties } from "./baduk";
+import { NewGridBadukConfig } from "./baduk_utils";
 
-export type DriftGoConfig = { komi: number; board: GridBoardConfig } & {
+export type DriftGoConfig = NewGridBadukConfig & {
   yShift: number;
   xShift: number;
 };
 
-export type LegacyDriftGoConfig = LegacyBadukConfig & {
-  yShift: number;
-  xShift: number;
-};
-
-function isDriftGoConfig(config: object): config is DriftGoConfig {
-  return (
-    "komi" in config &&
-    "board" in config &&
-    "xShift" in config &&
-    "yShift" in config
-  );
-}
-
-export class DriftGo extends Baduk {
-  private typedConfig: DriftGoConfig;
+export class DriftGo extends GridBaduk {
+  declare config: DriftGoConfig;
   declare board: Grid<Color>;
-
-  constructor(config?: DriftGoConfig | LegacyDriftGoConfig) {
-    super(config);
-    if (!isDriftGoConfig(this.config)) {
-      throw Error(
-        `Drift accepts only grid board config. Received config: ${JSON.stringify(config)}`,
-      );
-    }
-    this.typedConfig = this.config ?? this.defaultConfig();
-  }
 
   defaultConfig(): DriftGoConfig {
     return {
@@ -81,8 +56,8 @@ export class DriftGo extends Baduk {
 
   private shift(coord: Coordinate): Coordinate {
     return new Coordinate(
-      (coord.x - this.typedConfig.xShift) % this.board.width,
-      (coord.y - this.typedConfig.yShift) % this.board.height,
+      (coord.x - this.config.xShift) % this.board.width,
+      (coord.y - this.config.yShift) % this.board.height,
     );
   }
 

--- a/packages/shared/src/variants/keima.ts
+++ b/packages/shared/src/variants/keima.ts
@@ -1,12 +1,26 @@
 import { Coordinate } from "../lib/coordinate";
-import { BadukState, GridBaduk } from "./baduk";
+import { Baduk, BadukState } from "./baduk";
+import {
+  GridBadukConfig,
+  LegacyBadukConfig,
+  isGridBadukConfig,
+} from "./baduk_utils";
 
 export interface KeimaState extends BadukState {
   keima?: string;
 }
 
-export class Keima extends GridBaduk {
+export class Keima extends Baduk {
   private move_number = 0;
+
+  constructor(config?: GridBadukConfig | LegacyBadukConfig) {
+    super(config);
+    if (!isGridBadukConfig(this.config)) {
+      throw Error(
+        `Keima accepts only grid board config. Received config: ${JSON.stringify(config)}`,
+      );
+    }
+  }
 
   playMove(player: number, move: string): void {
     super.playMove(player, move);

--- a/packages/shared/src/variants/keima.ts
+++ b/packages/shared/src/variants/keima.ts
@@ -1,26 +1,12 @@
 import { Coordinate } from "../lib/coordinate";
-import { Baduk, BadukState } from "./baduk";
-import {
-  GridBadukConfig,
-  LegacyBadukConfig,
-  isGridBadukConfig,
-} from "./baduk_utils";
+import { BadukState, GridBaduk } from "./baduk";
 
 export interface KeimaState extends BadukState {
   keima?: string;
 }
 
-export class Keima extends Baduk {
+export class Keima extends GridBaduk {
   private move_number = 0;
-
-  constructor(config?: GridBadukConfig | LegacyBadukConfig) {
-    super(config);
-    if (!isGridBadukConfig(this.config)) {
-      throw Error(
-        `Keima accepts only grid board config. Received config: ${JSON.stringify(config)}`,
-      );
-    }
-  }
 
   playMove(player: number, move: string): void {
     super.playMove(player, move);

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -1,15 +1,27 @@
-import { Color, GridBaduk } from "./baduk";
+import { Baduk, Color } from "./baduk";
 import { Grid } from "../lib/grid";
-import { GridBadukConfig, getWidthAndHeight } from "./baduk_utils";
+import {
+  GridBadukConfig,
+  LegacyBadukConfig,
+  isGridBadukConfig,
+} from "./baduk_utils";
 
-export class PyramidGo extends GridBaduk {
+export class PyramidGo extends Baduk {
   private weights: Grid<number>;
-  constructor(config?: GridBadukConfig) {
+  declare board: Grid<Color>;
+  declare score_board?: Grid<Color>;
+
+  constructor(config?: GridBadukConfig | LegacyBadukConfig) {
     super(config);
+    if (!isGridBadukConfig(this.config)) {
+      throw Error(
+        `Pyramid accepts only grid board config. Received config: ${JSON.stringify(config)}`,
+      );
+    }
 
     // Note: config may be undefined, but this.config is
     // defined after the AbstractGame constructor is called.
-    const { width, height } = getWidthAndHeight(this.config);
+    const { width, height } = this.config.board;
 
     this.weights = new Grid(width, height)
       .fill(0)

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -1,23 +1,14 @@
-import { Baduk, Color } from "./baduk";
+import { Color, GridBaduk } from "./baduk";
 import { Grid } from "../lib/grid";
-import {
-  GridBadukConfig,
-  LegacyBadukConfig,
-  isGridBadukConfig,
-} from "./baduk_utils";
+import { GridBadukConfig } from "./baduk_utils";
 
-export class PyramidGo extends Baduk {
+export class PyramidGo extends GridBaduk {
   private weights: Grid<number>;
   declare board: Grid<Color>;
   declare score_board?: Grid<Color>;
 
-  constructor(config?: GridBadukConfig | LegacyBadukConfig) {
+  constructor(config?: GridBadukConfig) {
     super(config);
-    if (!isGridBadukConfig(this.config)) {
-      throw Error(
-        `Pyramid accepts only grid board config. Received config: ${JSON.stringify(config)}`,
-      );
-    }
 
     // Note: config may be undefined, but this.config is
     // defined after the AbstractGame constructor is called.

--- a/packages/shared/src/variants/quantum.ts
+++ b/packages/shared/src/variants/quantum.ts
@@ -1,12 +1,10 @@
 import { AbstractGame } from "../abstract_game";
 import { BoardPattern } from "../lib/abstractBoard/boardFactory";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";
-import { Grid } from "../lib/grid";
 import { Baduk, BadukBoard, BadukConfig, Color } from "./baduk";
 import {
-  GridBadukConfig,
-  LegacyBadukConfig,
-  isGridBadukConfig,
+  NewBadukConfig,
+  NewGridBadukConfig,
   isLegacyBadukConfig,
   mapToNewConfig,
 } from "./baduk_utils";
@@ -47,18 +45,12 @@ class BadukHelper {
   }
 }
 
-export class QuantumGo extends AbstractGame<BadukConfig, QuantumGoState> {
+export class QuantumGo extends AbstractGame<NewBadukConfig, QuantumGoState> {
   subgames: BadukHelper[] = [];
   quantum_stones: Coordinate[] = [];
 
-  constructor(config: BadukConfig | LegacyBadukConfig) {
+  constructor(config: BadukConfig) {
     super(isLegacyBadukConfig(config) ? mapToNewConfig(config) : config);
-
-    if (config && !isGridBadukConfig(this.config)) {
-      throw Error(
-        `Drift accepty only grid board config. Received config: ${JSON.stringify(config)}`,
-      );
-    }
   }
 
   playMove(player: number, move: string): void {
@@ -201,7 +193,7 @@ export class QuantumGo extends AbstractGame<BadukConfig, QuantumGoState> {
   numPlayers(): number {
     return 2;
   }
-  defaultConfig(): GridBadukConfig {
+  defaultConfig(): NewGridBadukConfig {
     return {
       board: { type: BoardPattern.Grid, width: 9, height: 9 },
       komi: 7.5,

--- a/packages/vue-client/src/board_map.ts
+++ b/packages/vue-client/src/board_map.ts
@@ -1,4 +1,3 @@
-import Baduk from "@/components/boards/BadukBoard.vue";
 import BadukBoardAbstract from "@/components/boards/BadukBoardAbstract.vue";
 import ParallelGoBoard from "@/components/boards/ParallelGoBoard.vue";
 import FreezeGoBoard from "@/components/boards/FreezeGoBoard.vue";
@@ -7,23 +6,24 @@ import FractionalBoard from "@/components/boards/FractionalBoard.vue";
 import KeimaBoard from "@/components/boards/KeimaBoard.vue";
 import type { Component } from "vue";
 import QuantumBoard from "@/components/boards/QuantumBoard.vue";
+import BadukBoardSelector from "./components/boards/BadukBoardSelector.vue";
 
 export const board_map: {
   [variant: string]: Component<{ config: unknown; gamestate: unknown }>;
 } = {
-  baduk: Baduk,
-  phantom: Baduk,
+  baduk: BadukBoardSelector,
+  phantom: BadukBoardSelector,
   badukWithAbstractBoard: BadukBoardAbstract,
   parallel: ParallelGoBoard,
-  capture: Baduk,
+  capture: BadukBoardSelector,
   chess: ChessBoard,
-  tetris: Baduk,
-  pyramid: Baduk,
-  "thue-morse": Baduk,
+  tetris: BadukBoardSelector,
+  pyramid: BadukBoardSelector,
+  "thue-morse": BadukBoardSelector,
   freeze: FreezeGoBoard,
   fractional: FractionalBoard,
   keima: KeimaBoard,
-  "one color": Baduk,
-  drift: Baduk,
+  "one color": BadukBoardSelector,
+  drift: BadukBoardSelector,
   quantum: QuantumBoard,
 };

--- a/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
@@ -1,17 +1,20 @@
 import { Grid } from '../../../../shared/src/lib/grid';
 <script setup lang="ts">
-import {
-  getWidthAndHeight,
-  type GridBadukConfig,
-} from "@ogfcommunity/variants-shared";
+import { type GridBadukConfig } from "@ogfcommunity/variants-shared";
 
-const props = defineProps<{ initialConfig: GridBadukConfig }>();
+const props = defineProps<{
+  initialConfig: {
+    komi: number;
+    board: { type: "grid"; width: number; height: number };
+  };
+}>();
+// the type here is ugly atm, but I will fix this when I add input forms for the new board patterns
 const config: GridBadukConfig = {
   komi: props.initialConfig.komi,
   board: {
     type: "grid",
-    width: getWidthAndHeight(props.initialConfig).width,
-    height: getWidthAndHeight(props.initialConfig).height,
+    width: props.initialConfig.board.width,
+    height: props.initialConfig.board.height,
   },
 };
 

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
-import {
-  getWidthAndHeight,
-  type DriftGoConfig,
-} from "@ogfcommunity/variants-shared";
+import { type DriftGoConfig } from "@ogfcommunity/variants-shared";
 
 const props = defineProps<{ initialConfig: DriftGoConfig }>();
 const config: DriftGoConfig = {
@@ -11,8 +8,8 @@ const config: DriftGoConfig = {
   yShift: props.initialConfig.yShift,
   board: {
     type: "grid",
-    width: getWidthAndHeight(props.initialConfig).width,
-    height: getWidthAndHeight(props.initialConfig).height,
+    width: props.initialConfig.board.width,
+    height: props.initialConfig.board.height,
   },
 };
 

--- a/packages/vue-client/src/components/boards/BadukBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukBoard.vue
@@ -16,7 +16,7 @@ const props = defineProps<{
 }>();
 
 const width = computed(() => getWidthAndHeight(props.config).width);
-const height = computed(() => getWidthAndHeight(props.config).width);
+const height = computed(() => getWidthAndHeight(props.config).height);
 const positions = computed(positionsGetter(width, height));
 
 function colorToClassString(color: Color): string {

--- a/packages/vue-client/src/components/boards/BadukBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukBoard.vue
@@ -4,8 +4,8 @@ import {
   Coordinate,
   type BadukState,
   getHoshi,
-  GridBadukConfig,
   getWidthAndHeight,
+  GridBadukConfig,
 } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import { positionsGetter } from "./board_utils";
@@ -16,7 +16,7 @@ const props = defineProps<{
 }>();
 
 const width = computed(() => getWidthAndHeight(props.config).width);
-const height = computed(() => getWidthAndHeight(props.config).height);
+const height = computed(() => getWidthAndHeight(props.config).width);
 const positions = computed(positionsGetter(width, height));
 
 function colorToClassString(color: Color): string {

--- a/packages/vue-client/src/components/boards/BadukBoardSelector.vue
+++ b/packages/vue-client/src/components/boards/BadukBoardSelector.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import {
+  BadukConfig,
+  BadukState,
+  GridBadukConfig,
+  isGridBadukConfig,
+} from "@ogfcommunity/variants-shared";
+import { computed } from "vue";
+import BadukGraphBoard from "./BadukGraphBoard.vue";
+import BadukBoard from "./BadukBoard.vue";
+
+const props = defineProps<{
+  gamestate: BadukState;
+  config: BadukConfig;
+}>();
+
+const emit = defineEmits<{
+  (e: "move", move: string): void;
+}>();
+
+function move(move: string) {
+  emit("move", move);
+}
+
+const isGridBoard = computed(() => isGridBadukConfig(props.config));
+</script>
+
+<template>
+  <BadukGraphBoard
+    v-if="!isGridBoard"
+    :gamestate="$props.gamestate"
+    :config="$props.config"
+    @move="move"
+  />
+  <BadukBoard
+    v-if="isGridBoard"
+    :gamestate="$props.gamestate"
+    :config="$props.config as GridBadukConfig"
+    @move="move"
+  />
+</template>

--- a/packages/vue-client/src/components/boards/BadukBoardSelector.vue
+++ b/packages/vue-client/src/components/boards/BadukBoardSelector.vue
@@ -3,6 +3,7 @@ import {
   BadukConfig,
   BadukState,
   GridBadukConfig,
+  NewBadukConfig,
   isGridBadukConfig,
 } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
@@ -29,7 +30,7 @@ const isGridBoard = computed(() => isGridBadukConfig(props.config));
   <BadukGraphBoard
     v-if="!isGridBoard"
     :gamestate="$props.gamestate"
-    :config="$props.config"
+    :config="$props.config as NewBadukConfig"
     @move="move"
   />
   <BadukBoard

--- a/packages/vue-client/src/components/boards/BadukGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukGraphBoard.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import {
+  BadukState,
+  Color,
+  NewBadukConfig,
+} from "@ogfcommunity/variants-shared";
+import { computed } from "vue";
+import MulticolorGraphBoard from "./MulticolorGraphBoard.vue";
+
+const props = defineProps<{
+  gamestate: BadukState;
+  config: NewBadukConfig;
+}>();
+
+const board = computed(() => {
+  const sequence = props.gamestate.board.at(0) ?? [];
+
+  return sequence.map((color) => {
+    switch (color) {
+      case Color.BLACK:
+        return { colors: ["black"], annotation: undefined };
+      case Color.WHITE:
+        return { colors: ["white"], annotation: undefined };
+      case Color.EMPTY:
+        return null;
+    }
+  });
+});
+
+const emit = defineEmits<{
+  (e: "move", move: string): void;
+}>();
+
+function click(index: number) {
+  emit("move", index.toString());
+}
+</script>
+
+<template>
+  <MulticolorGraphBoard
+    :board="board"
+    :board_config="$props.config.board"
+    @click="click"
+  />
+</template>

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -1,0 +1,129 @@
+<script lang="ts">
+interface MulticolorStone {
+  colors: string[];
+  annotation?: "CR" | "MA";
+}
+</script>
+
+<script setup lang="ts">
+import { computed, ref, type Ref } from "vue";
+import TaegeukStone from "../TaegeukStone.vue";
+import IntersectionAnnotation from "../IntersectionAnnotation.vue";
+import {
+  BoardConfig,
+  createBoard,
+  Intersection,
+} from "@ogfcommunity/variants-shared";
+
+const props = defineProps<{
+  board: (MulticolorStone | null)[];
+  background_color?: string;
+  board_config: BoardConfig;
+}>();
+
+const intersections = createBoard(props.board_config, Intersection);
+const hovered: Ref<number> = ref(-1);
+
+const emit = defineEmits<{
+  (e: "click", index: number): void;
+  (e: "hover", index: number): void;
+}>();
+
+function positionClicked(index: number) {
+  emit("click", index);
+}
+
+function positionHovered(index: number) {
+  emit("hover", index);
+  hovered.value = index;
+}
+
+const viewBox = computed(() => {
+  const xPositions = intersections.map((i) => i.position.X);
+  const yPositions = intersections.map((i) => i.position.Y);
+  const minX = Math.min(...xPositions) - 1;
+  const minY = Math.min(...yPositions) - 1;
+  const width = Math.max(...xPositions) - Math.min(...xPositions) + 2;
+  const height = Math.max(...yPositions) - Math.min(...yPositions) + 2;
+  const vb = `${minX} ${minY} ${width} ${height}`;
+  return vb;
+});
+</script>
+
+<template>
+  <svg
+    class="board"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100%"
+    height="100%"
+    v-bind:viewBox="viewBox"
+  >
+    <rect
+      x="-0.5"
+      y="-0.5"
+      width="100%"
+      height="100%"
+      :fill="background_color ?? '#dcb35c'"
+    />
+
+    <g v-for="intersection in intersections" :key="intersection.id">
+      <line
+        v-for="neighbour in intersection.neighbours.filter(
+          (n) => n.id < intersection.id,
+        )"
+        :key="neighbour.id"
+        class="grid"
+        v-bind:x1="intersection.position.X"
+        v-bind:x2="neighbour.position.X"
+        v-bind:y1="intersection.position.Y"
+        v-bind:y2="neighbour.position.Y"
+      />
+    </g>
+    <g v-for="intersection in intersections" :key="intersection.id">
+      <TaegeukStone
+        :key="`${intersection.position.X},${intersection.position.Y}`"
+        :cx="intersection.position.X"
+        :cy="intersection.position.Y"
+        :r="0.48"
+        :colors="props.board?.at(intersection.id)?.colors ?? []"
+        @click="positionClicked(intersection.id)"
+        @mouseover="positionHovered(intersection.id)"
+      />
+    </g>
+    <g>
+      <IntersectionAnnotation
+        v-for="intersection in intersections.filter(
+          (x) => props.board.at(x.id)?.annotation,
+        )"
+        :key="intersection.id"
+        :cx="intersection.position.X"
+        :cy="intersection.position.Y"
+        :r="0.48"
+        :annotation="props.board.at(intersection.id)?.annotation!"
+      />
+    </g>
+    <g>
+      <rect
+        v-for="intersection in intersections"
+        :key="intersection.id"
+        @click="positionClicked(intersection.id)"
+        @mouseover="positionHovered(intersection.id)"
+        :x="intersection.position.X - 0.5"
+        :y="intersection.position.Y - 0.5"
+        width="1"
+        height="1"
+        :fill="hovered == intersection.id ? 'pink' : 'transparent'"
+        opacity="0.5"
+      />
+    </g>
+    <g></g>
+  </svg>
+</template>
+
+<style scoped>
+line {
+  stroke: black;
+  stroke-width: 0.02;
+  stroke-linecap: round;
+}
+</style>

--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -7,8 +7,8 @@ import MulticolorGridBoard from "./MulticolorGridBoard.vue";
 import {
   Coordinate,
   type QuantumGoState,
-  getWidthAndHeight,
   GridBadukConfig,
+  getWidthAndHeight,
 } from "@ogfcommunity/variants-shared";
 import { Grid } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";


### PR DESCRIPTION
### Changes
- take out the baduk adapter class
- some more refactoring so the variants can work with graph boards
- add components for graph boards in the vue-client that work with baduk and the board factory

### Not done yet:
- make it so Freeze, Quantum have boards that render the graph boards (they have their own components)
- add game config input forms for variants that now support the new patterns.
- Figure out what to do with Annotations on the board (I copied the Multicolored Grid board and made it work for the graphs).

### But
It's already working for the most part. Here is variant Tetris on a rhombitrihexagonal board:

![grafik](https://github.com/govariantsteam/govariants/assets/77507448/096c56ff-99eb-445f-92c0-9488bdc6647e)

I had some problems with backwards compatibility at first, but I think that I sorted those out.