### PR TITLE
graph boards for quantum

### DIFF
--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -4,28 +4,40 @@ import { Color, type CoordinateLike } from "@ogfcommunity/variants-shared";
 
 <script setup lang="ts">
 import MulticolorGridBoard from "./MulticolorGridBoard.vue";
+import MulticolorGraphBoard from "./MulticolorGraphBoard.vue";
 import {
   Coordinate,
   type QuantumGoState,
-  GridBadukConfig,
   getWidthAndHeight,
+  BadukConfig,
+  isGridBadukConfig,
 } from "@ogfcommunity/variants-shared";
 import { Grid } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 
 const props = defineProps<{
-  config: GridBadukConfig;
+  config: BadukConfig;
   gamestate: QuantumGoState;
 }>();
 
-const board_dimensions = computed(() => getWidthAndHeight(props.config));
+const gridConfig = computed(() =>
+  isGridBadukConfig(props.config) ? props.config : undefined,
+);
+
+const graphConfig = computed(() =>
+  !isGridBadukConfig(props.config) ? props.config : undefined,
+);
+
+const board_dimensions = computed(() =>
+  gridConfig.value ? getWidthAndHeight(gridConfig.value) : undefined,
+);
 
 const emit = defineEmits<{
-  (e: "move", pos: string): void;
+  (e: "move", move: string): void;
 }>();
 
-function positionClicked(pos: Coordinate) {
-  emit("move", pos.toSgfRepr());
+function emitMove(move: string) {
+  emit("move", move);
 }
 
 function board_with_quantum_stones(
@@ -65,21 +77,78 @@ const board_1 = computed(() => {
     props.gamestate.quantum_stones.map((pos) => Coordinate.fromSgfRepr(pos)),
   );
 });
+
+function graph_board_with_quantum_stones(
+  board: Color[],
+  quantum_stones: Array<CoordinateLike>,
+) {
+  const ret_board = board.map((color) => {
+    switch (color) {
+      case Color.BLACK:
+        return { colors: ["black"], annotation: undefined };
+      case Color.WHITE:
+        return { colors: ["white"], annotation: undefined };
+      case Color.EMPTY:
+        return null;
+    }
+  });
+
+  quantum_stones.forEach((stone) => {
+    ret_board.at(stone.x)?.colors.push("green");
+  });
+
+  return ret_board;
+}
+
+const graph_boards = computed(() => {
+  const sequence_0 = props.gamestate.boards.at(0)?.at(0) ?? [];
+  const sequence_1 = props.gamestate.boards.at(1)?.at(0) ?? [];
+
+  return {
+    board_0: graph_board_with_quantum_stones(
+      sequence_0,
+      props.gamestate.quantum_stones.map((pos) => Coordinate.fromSgfRepr(pos)),
+    ),
+    board_1: graph_board_with_quantum_stones(
+      sequence_1,
+      props.gamestate.quantum_stones.map((pos) => Coordinate.fromSgfRepr(pos)),
+    ),
+  };
+});
 </script>
 
 <template>
-  <div style="width: 50%; height: 100%; display: inline-block">
-    <MulticolorGridBoard
-      :board="board_0"
-      :board_dimensions="board_dimensions"
-      @click="positionClicked"
-    />
-  </div>
-  <div style="width: 50%; height: 100%; display: inline-block">
-    <MulticolorGridBoard
-      :board="board_1"
-      :board_dimensions="board_dimensions"
-      @click="positionClicked"
-    />
-  </div>
+  <template v-if="gridConfig">
+    <div style="width: 50%; height: 100%; display: inline-block">
+      <MulticolorGridBoard
+        :board="board_0"
+        :board_dimensions="board_dimensions!"
+        @click="emitMove($event.toSgfRepr())"
+      />
+    </div>
+    <div style="width: 50%; height: 100%; display: inline-block">
+      <MulticolorGridBoard
+        :board="board_1"
+        :board_dimensions="board_dimensions!"
+        @click="emitMove($event.toSgfRepr())"
+      />
+    </div>
+  </template>
+
+  <template v-if="graphConfig">
+    <div style="width: 50%; height: 100%; display: inline-block">
+      <MulticolorGraphBoard
+        :board="graph_boards.board_0"
+        :board_config="graphConfig!.board"
+        @click="emitMove($event.toString())"
+      />
+    </div>
+    <div style="width: 50%; height: 100%; display: inline-block">
+      <MulticolorGraphBoard
+        :board="graph_boards.board_1"
+        :board_config="graphConfig!.board"
+        @click="emitMove($event.toString())"
+      />
+    </div>
+  </template>
 </template>

--- a/packages/vue-client/src/config_form_map.ts
+++ b/packages/vue-client/src/config_form_map.ts
@@ -20,5 +20,5 @@ export const config_form_map: {
   keima: GridBadukConfigForm,
   "one color": BadukConfigForm,
   drift: DriftGoConfigFormVue,
-  quantum: GridBadukConfigForm,
+  quantum: BadukConfigForm,
 };


### PR DESCRIPTION
This adds the graph boards to quantum go.

I thought about the possibility of storing the moves for graph boards also in SGF format, to simplify the logic here. But I decided against it, one reason being that we should stay consistent (in my opinion).