### PR TITLE
Deprecate variant Baduk with abstract board

### DIFF
--- a/packages/shared/src/deprecated_variants.ts
+++ b/packages/shared/src/deprecated_variants.ts
@@ -1,0 +1,4 @@
+import { game_map } from "./game_map";
+export const deprecated_variants: (keyof typeof game_map)[] = [
+  "badukWithAbstractBoard",
+];

--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -1,5 +1,5 @@
 import { AbstractGame } from "./abstract_game";
-import { BadukWithAbstractBoardConstructor } from "./variants/badukWithAbstractBoard";
+import { BadukWithAbstractBoard } from "./variants/badukWithAbstractBoard";
 import { Phantom } from "./variants/phantom";
 import { ParallelGo } from "./variants/parallel";
 import { Capture } from "./variants/capture";
@@ -21,7 +21,7 @@ export const game_map: {
   [variant: string]: new (config?: any) => AbstractGame;
 } = {
   baduk: Baduk,
-  badukWithAbstractBoard: BadukWithAbstractBoardConstructor as any,
+  badukWithAbstractBoard: BadukWithAbstractBoard,
   phantom: Phantom,
   parallel: ParallelGo,
   capture: Capture,

--- a/packages/shared/src/game_map.ts
+++ b/packages/shared/src/game_map.ts
@@ -1,5 +1,5 @@
 import { AbstractGame } from "./abstract_game";
-import { BadukWithAbstractBoard } from "./variants/badukWithAbstractBoard";
+import { BadukWithAbstractBoardConstructor } from "./variants/badukWithAbstractBoard";
 import { Phantom } from "./variants/phantom";
 import { ParallelGo } from "./variants/parallel";
 import { Capture } from "./variants/capture";
@@ -14,13 +14,14 @@ import { OneColorGo } from "./variants/one_color";
 import { DriftGo } from "./variants/drift";
 import { QuantumGo } from "./variants/quantum";
 import { Baduk } from "./variants/baduk";
+import { deprecated_variants } from "./deprecated_variants";
 
 export const game_map: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [variant: string]: new (config?: any) => AbstractGame;
 } = {
   baduk: Baduk,
-  badukWithAbstractBoard: BadukWithAbstractBoard,
+  badukWithAbstractBoard: BadukWithAbstractBoardConstructor as any,
   phantom: Phantom,
   parallel: ParallelGo,
   capture: Capture,
@@ -57,7 +58,9 @@ export function makeGameObject(
 }
 
 export function getVariantList(): string[] {
-  return Object.keys(game_map);
+  return Object.keys(game_map).filter(
+    (variant) => !deprecated_variants.includes(variant),
+  );
 }
 
 export function getDefaultConfig(variant: string) {

--- a/packages/shared/src/lib/__tests__/board.test.ts
+++ b/packages/shared/src/lib/__tests__/board.test.ts
@@ -1,4 +1,4 @@
-import { Color } from "../../variants/badukWithAbstractBoard";
+import { Color } from "../../variants/baduk";
 import {
   BoardPattern,
   createBoard,

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -52,10 +52,10 @@ export function mapToNewBadukConfig(
   return { komi: config.komi, board: mapToNewBoardConfig(config) };
 }
 
-export const BadukWithAbstractBoardConstructor = function (
-  config?: BadukWithAbstractBoardConfig,
-): AbstractGame {
-  return new Baduk(
-    config === undefined ? undefined : mapToNewBadukConfig(config),
-  );
-};
+export class BadukWithAbstractBoard extends Baduk {
+  constructor(config?: BadukWithAbstractBoardConfig) {
+    const mapped_config =
+      config === undefined ? undefined : mapToNewBadukConfig(config);
+    super(mapped_config);
+  }
+}

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -1,4 +1,3 @@
-import { AbstractGame } from "../../abstract_game";
 import { Baduk, BadukConfig } from "../baduk";
 import { BoardConfig } from "../../lib/abstractBoard/boardFactory";
 

--- a/packages/vue-client/src/components/boards/BadukBoardAbstract.vue
+++ b/packages/vue-client/src/components/boards/BadukBoardAbstract.vue
@@ -1,112 +1,32 @@
 <script setup lang="ts">
-import { Color } from "@ogfcommunity/variants-shared";
-import type {
-  BadukWithAbstractBoardConfig,
-  BadukWithAbstractBoardState,
+import { BadukState } from "@ogfcommunity/variants-shared";
+import {
+  mapToNewBadukConfig,
+  type BadukWithAbstractBoardConfig,
 } from "@ogfcommunity/variants-shared/src/variants/badukWithAbstractBoard";
 import { computed } from "vue";
+import BadukBoardSelector from "./BadukBoardSelector.vue";
 
 const props = defineProps<{
   config: BadukWithAbstractBoardConfig;
-  gamestate: BadukWithAbstractBoardState;
+  gamestate: BadukState;
 }>();
 
-function colorToClassString(color: Color): string {
-  return color === Color.EMPTY
-    ? "click-placeholder"
-    : color === Color.BLACK
-    ? "stone black"
-    : "stone white";
-}
+const badukConfig = computed(() => mapToNewBadukConfig(props.config));
 
 const emit = defineEmits<{
-  (e: "move", Identifier: number): void;
+  (e: "move", move: string): void;
 }>();
 
-function intersectionClicked(identifier: number) {
-  emit("move", identifier);
+function emitMove(move: string) {
+  emit("move", move);
 }
-
-const viewBox = computed(() => {
-  const xPositions = props.gamestate.board.Intersections.map(
-    (i) => i.Position.X,
-  );
-  const yPositions = props.gamestate.board.Intersections.map(
-    (i) => i.Position.Y,
-  );
-  const minX = Math.min(...xPositions) - 1;
-  const minY = Math.min(...yPositions) - 1;
-  const width = Math.max(...xPositions) - Math.min(...xPositions) + 2;
-  const height = Math.max(...yPositions) - Math.min(...yPositions) + 2;
-  const vb = `${minX} ${minY} ${width} ${height}`;
-  return vb;
-});
 </script>
 
 <template>
-  <svg
-    class="board"
-    xmlns="http://www.w3.org/2000/svg"
-    width="100%"
-    height="100%"
-    v-bind:viewBox="viewBox"
-  >
-    <g
-      v-for="intersection in props.gamestate.board.Intersections"
-      :key="intersection.Identifier"
-    >
-      <line
-        v-for="neighbour in intersection.Neighbours.filter(
-          (n) => n.Identifier < intersection.Identifier,
-        )"
-        :key="neighbour.Identifier"
-        class="grid"
-        v-bind:x1="intersection.Position.X"
-        v-bind:x2="neighbour.Position.X"
-        v-bind:y1="intersection.Position.Y"
-        v-bind:y2="neighbour.Position.Y"
-      />
-    </g>
-    <g
-      v-for="intersection in props.gamestate.board.Intersections"
-      :key="intersection.Identifier"
-    >
-      <circle
-        v-bind:class="colorToClassString(intersection.StoneState.Color)"
-        v-on:click="intersectionClicked(intersection.Identifier)"
-        v-bind:cx="intersection.Position.X"
-        v-bind:cy="intersection.Position.Y"
-        r="0.4"
-      />
-    </g>
-  </svg>
+  <BadukBoardSelector
+    :config="badukConfig"
+    :gamestate="$props.gamestate"
+    @move="emitMove"
+  />
 </template>
-
-<style scoped>
-svg.board {
-  background-color: #dcb35c;
-}
-
-line {
-  stroke: black;
-  stroke-width: 0.05;
-  stroke-linecap: round;
-}
-
-.stone {
-  stroke: black;
-  stroke-width: 0.05;
-}
-
-.stone.black {
-  fill: black;
-}
-
-.stone.white {
-  fill: white;
-}
-
-.click-placeholder {
-  opacity: 0;
-}
-</style>


### PR DESCRIPTION
With the recent addition of graph boards to Baduk and inheriting variants, I believe that we should deprecate the old variant BadukWithAbstractBoard.
For this purpose I added a function that maps a config of BadukWithAbstractBoard to a config for Baduk, and created a (sort-of) constructor function that we can use in the game_map. So old games of this variant should still work, and we can remove the class.
Also added a list for deprecated variants, s.t. these can't be selected in the game creation form.