### PR TITLE
send state via api instead of all moves

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -7,6 +7,7 @@ import {
   playMove,
   takeSeat,
   leaveSeat,
+  getGameState,
 } from "./games";
 import {
   checkUsername,
@@ -22,6 +23,7 @@ import {
   UserResponse,
 } from "@ogfcommunity/variants-shared";
 import { io } from "./socket_io";
+import { GameInitialResponse } from "@ogfcommunity/variants-shared/src/api_types";
 
 export const router = express.Router();
 
@@ -172,4 +174,35 @@ router.get("/logout", async function (req, res) {
       res.json({});
     });
   });
+});
+
+router.get("/games/:gameId/state/initial", async (req, res) => {
+  try {
+    const game = await getGame(req.params.gameId);
+    const stateResponse = await getGameState(game, null, null);
+    const result: GameInitialResponse = {
+      variant: game.variant,
+      config: game.config,
+      id: game.id,
+      players: game.players,
+      stateResponse: stateResponse,
+    };
+    res.send(result);
+  } catch (e) {
+    res.status(500);
+    res.json(e.message);
+  }
+});
+
+router.get("/games/:gameId/state", async (req, res) => {
+  try {
+    const seat = req.query.seat === "" ? null : Number(req.query.seat);
+    const round = req.query.round === "" ? null : Number(req.query.round);
+    const game = await getGame(req.params.gameId);
+    const stateResponse = await getGameState(game, seat, round);
+    res.send(stateResponse);
+  } catch (e) {
+    res.status(500);
+    res.json(e.message);
+  }
 });

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -209,7 +209,7 @@ function emitGame(
   const specialMoves = game_obj.specialMoves();
 
   io()
-    .to(`game/${game_id}/`)
+    .to(`game/${game_id}`)
     .emit("move", {
       state: game_obj.exportState(null),
       round: game_obj.round,

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -278,16 +278,31 @@ export async function getGameState(
   seat: number | null,
   round: number | null,
 ): Promise<GameStateResponse> {
-  const game_obj = makeGameObject(game.variant, game.config);
+  let game_obj = makeGameObject(game.variant, game.config);
 
   for (let i = 0; i < game.moves.length; i++) {
-    if (game_obj.round === round) {
+    if (round !== null && game_obj.round > round) {
       break;
     }
 
     const encoded_move = game.moves[i];
     const { player, move } = getOnlyMove(encoded_move);
     game_obj.playMove(player, move);
+  }
+
+  if (round !== null && game_obj.round > round) {
+    // user is viewing past round
+    game_obj = makeGameObject(game.variant, game.config);
+    for (let i = 0; i < game.moves.length; i++) {
+      if (game_obj.round === round) {
+        // stop at start of round, so staged moves etc. are not included
+        break;
+      }
+
+      const encoded_move = game.moves[i];
+      const { player, move } = getOnlyMove(encoded_move);
+      game_obj.playMove(player, move);
+    }
   }
 
   return {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -124,12 +124,12 @@ io.on("connection", (socket) => {
   });
 
   // source: https://socket.io/how-to/implement-a-subscription-model
-  socket.on("subscribe", (topics) => {
-    socket.join(topics);
+  socket.on("subscribe", async (topics) => {
+    await socket.join(topics);
   });
 
-  socket.on("unsubscribe", (topic) => {
-    socket.leave(topic);
+  socket.on("unsubscribe", async (topic) => {
+    await socket.leave(topic);
   });
 });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -128,8 +128,10 @@ io.on("connection", (socket) => {
     await socket.join(topics);
   });
 
-  socket.on("unsubscribe", async (topic) => {
-    await socket.leave(topic);
+  socket.on("unsubscribe", async (topics) => {
+    for (const topic of topics) {
+      await socket.leave(topic);
+    }
   });
 });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -122,6 +122,15 @@ io.on("connection", (socket) => {
     io.emit("pong", data);
     console.log("ping");
   });
+
+  // source: https://socket.io/how-to/implement-a-subscription-model
+  socket.on("subscribe", (topics) => {
+    socket.join(topics);
+  });
+
+  socket.on("unsubscribe", (topic) => {
+    socket.leave(topic);
+  });
 });
 
 // If production, serve the React repo!

--- a/packages/shared/src/api_types.ts
+++ b/packages/shared/src/api_types.ts
@@ -27,3 +27,20 @@ export type GamesFilter = {
   user_id?: string;
   variant?: string;
 };
+
+export type GameStateResponse = {
+  state: unknown;
+  round: number;
+  next_to_play: number[];
+  special_moves: { [key: string]: string };
+  result: string;
+  seat: number | null;
+  timeControl?: ITimeControlBase;
+};
+
+export type GameInitialResponse = Omit<
+  GameResponse,
+  "moves" | "timeControl"
+> & {
+  stateResponse: GameStateResponse;
+};

--- a/packages/shared/src/variants/fractional/fractional.test.ts
+++ b/packages/shared/src/variants/fractional/fractional.test.ts
@@ -52,8 +52,6 @@ test("Surrounded merge stone", () => {
   game.playMove(2, cornerId);
 
   const state = game.exportState();
-  expect(state.intersections.filter((i) => i.stone).length).toBe(2);
-  expect(
-    state.intersections.find((i) => i.id === Number(cornerId))?.stone,
-  ).toBeNull();
+  expect(state.boardState.filter((i) => i).length).toBe(2);
+  expect(state.boardState.at(Number(cornerId))).toBeNull();
 });

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -38,8 +38,8 @@ export interface FractionalConfig extends AbstractBadukConfig {
 
 // TODO: Circular dependencies! Does state have to be JSON.stringifyable?
 export interface FractionalState {
-  intersections: FractionalIntersection[];
-  stagedMove?: { intersection: FractionalIntersection; colors: Color[] };
+  boardState: (Color[] | null)[];
+  stagedMove?: { intersectionID: number; colors: Color[] };
 }
 
 export class Fractional extends AbstractBaduk<
@@ -107,13 +107,15 @@ export class Fractional extends AbstractBaduk<
       player != null && stagedIntersection
         ? {
             stagedMove: {
-              intersection: stagedIntersection,
+              intersectionID: stagedIntersection.id,
               colors: this.getPlayerColors(player),
             },
           }
         : {};
     return {
-      intersections: this.intersections,
+      boardState: this.intersections.map((intersection) =>
+        intersection.stone ? Array.from(intersection.stone.colors) : null,
+      ),
       ...stagedMove,
     };
   }

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -36,7 +36,6 @@ export interface FractionalConfig extends AbstractBadukConfig {
   players: FractionalPlayerConfig[];
 }
 
-// TODO: Circular dependencies! Does state have to be JSON.stringifyable?
 export interface FractionalState {
   boardState: (Color[] | null)[];
   stagedMove?: { intersectionID: number; colors: Color[] };

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import type {
-  FractionalConfig,
-  FractionalState,
+import {
+  createBoard,
+  type FractionalConfig,
+  type FractionalState,
 } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import TaegeukStone from "../TaegeukStone.vue";
+import { Intersection } from "../../../../shared/src/lib/abstractBoard/intersection";
 
 const props = defineProps<{
   config: FractionalConfig;
@@ -19,10 +21,14 @@ function intersectionClicked(identifier: number) {
   emit("move", identifier);
 }
 
+const intersections = computed(() =>
+  createBoard(props.config.board, Intersection),
+);
+
 const boardRect = computed(
   (): { x: number; y: number; width: number; height: number } => {
-    const xPositions = props.gamestate.intersections.map((i) => i.position.X);
-    const yPositions = props.gamestate.intersections.map((i) => i.position.Y);
+    const xPositions = intersections.value.map((i) => i.position.X);
+    const yPositions = intersections.value.map((i) => i.position.Y);
     const xMin = Math.min(...xPositions);
     const xMax = Math.max(...xPositions);
     const yMin = Math.min(...yPositions);
@@ -45,7 +51,15 @@ const viewBox = computed(() => {
   return `${x} ${y} ${width} ${height}`;
 });
 
-const stagedMove = computed(() => props.gamestate.stagedMove);
+const stagedMove = computed(() =>
+  props.gamestate.stagedMove
+    ? {
+        intersection:
+          intersections.value[props.gamestate.stagedMove.intersectionID],
+        colors: props.gamestate.stagedMove.colors,
+      }
+    : undefined,
+);
 </script>
 
 <template>
@@ -64,10 +78,7 @@ const stagedMove = computed(() => props.gamestate.stagedMove);
       :height="boardRect.height"
     />
     <g class="lines">
-      <g
-        v-for="intersection in props.gamestate.intersections"
-        :key="intersection.id"
-      >
+      <g v-for="intersection in intersections" :key="intersection.id">
         <line
           v-for="neighbour in intersection.neighbours.filter(
             (n) => n.id < intersection.id,
@@ -82,13 +93,10 @@ const stagedMove = computed(() => props.gamestate.stagedMove);
       </g>
     </g>
     <g class="stones">
-      <g
-        v-for="intersection in props.gamestate.intersections"
-        :key="intersection.id"
-      >
+      <g v-for="(intersection, index) in intersections" :key="intersection.id">
         <TaegeukStone
-          v-if="intersection.stone"
-          :colors="[...intersection.stone.colors]"
+          v-if="$props.gamestate.boardState.at(index)"
+          :colors="[...$props.gamestate.boardState.at(index)]"
           :cx="intersection.position.X"
           :cy="intersection.position.Y"
           :r="0.47"

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -21,10 +21,7 @@ import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 
 const props = defineProps<{ gameId: string }>();
 
-const state_map = new Map<
-  { round: number; seat: number | null },
-  GameStateResponse
->();
+const state_map = new Map<string, GameStateResponse>();
 const view_state = ref<GameStateResponse | undefined>();
 const current_round = ref(0);
 let variant = ref("");
@@ -42,7 +39,7 @@ const playing_as = ref<undefined | number>(undefined);
 
 function setNewState(stateResponse: GameStateResponse): void {
   state_map.set(
-    { round: stateResponse.round, seat: stateResponse.seat },
+    encodeSeatAndRound(stateResponse.round, stateResponse.seat),
     stateResponse,
   );
   if (current_round.value < stateResponse.round) {
@@ -58,8 +55,12 @@ function setNewState(stateResponse: GameStateResponse): void {
   }
 }
 
+function encodeSeatAndRound(round: number, seat: number | null): string {
+  return `${round};${seat ?? ""}`;
+}
+
 async function setViewState(round: number, seat: number | null): Promise<void> {
-  const maybe_state = state_map.get({ seat: seat, round: round });
+  const maybe_state = state_map.get(encodeSeatAndRound(round, seat));
   if (maybe_state) {
     view_state.value = maybe_state;
     return;

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -115,8 +115,11 @@ const leave = (seat: number) => {
 };
 
 function unsubscribeAllSeats(): void {
-  for (let i = 0; i < (players.value?.length ?? 0); i++) {
-    socket.emit("unsubscribe", `game/${props.gameId}/${i}`);
+  if (players.value) {
+    socket.emit(
+      "unsubscribe",
+      players.value.map((_, index) => `game/${props.gameId}/${index}`),
+    );
   }
 }
 

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import {
-  makeGameObject,
-  type GameResponse,
-  getOnlyMove,
   HasTimeControlConfig,
   timeControlMap,
 } from "@ogfcommunity/variants-shared";
@@ -13,8 +10,9 @@ import type {
   User,
   IPerPlayerTimeControlBase,
   IConfigWithTimeControl,
+  GameStateResponse,
 } from "@ogfcommunity/variants-shared";
-import { computed, reactive, ref, watchEffect, type Ref } from "vue";
+import { computed, ref, watchEffect, type Ref } from "vue";
 import { board_map } from "@/board_map";
 import { socket } from "../requests";
 import { variant_short_description_map } from "../components/variant_descriptions/variant_description.consts";
@@ -23,81 +21,80 @@ import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 
 const props = defineProps<{ gameId: string }>();
 
-const DEFAULT_GAME: GameResponse = {
-  id: "",
-  variant: "",
-  moves: [],
-  config: {},
-};
-
+const state_map = new Map<
+  { round: number; seat: number | null },
+  GameStateResponse
+>();
+const view_state = ref<GameStateResponse | undefined>();
+const current_round = ref(0);
+let variant = ref("");
+let config: object | undefined = undefined;
+const players = ref();
 // null <-> viewing the latest round
 // while viewing history of game, maybe we should prevent player from making a move (accidentally)
 const view_round: Ref<number | null> = ref(null);
-
-const gameResponse: GameResponse = reactive(DEFAULT_GAME);
-const game = computed(() => {
-  if (!gameResponse.variant) {
-    return { result: null, state: null };
-  }
-  const game_obj = makeGameObject(gameResponse.variant, gameResponse.config);
-
-  let state: unknown = null;
-  gameResponse.moves.forEach((m) => {
-    if (
-      view_round.value !== null &&
-      state === null &&
-      game_obj.round === view_round.value
-    ) {
-      state = structuredClone(game_obj.exportState(playing_as.value));
-    }
-
-    const { player, move } = getOnlyMove(m);
-    game_obj.playMove(player, move);
-  });
-  const result =
-    game_obj.phase === "gameover" ? game_obj.result || "Game over" : null;
-
-  if (state === null) {
-    state = game_obj.exportState(playing_as.value);
-  }
-  return {
-    result,
-    state,
-    round: game_obj.round,
-    next_to_play: game_obj.nextToPlay(),
-  };
-});
-const specialMoves = computed(() =>
-  !gameResponse.variant || !gameResponse.config
-    ? {}
-    : makeGameObject(gameResponse.variant, gameResponse.config).specialMoves(),
-);
-const variantGameView = computed(() => board_map[gameResponse.variant]);
+const variantGameView = computed(() => board_map[variant.value]);
 const variantDescriptionShort = computed(
-  () => variant_short_description_map[gameResponse.variant] ?? "",
+  () => variant_short_description_map[variant.value] ?? "",
 );
-watchEffect(async () => {
-  // TODO: provide a cleanup function to cancel the request.
-  await requests
-    .get(`/games/${props.gameId}`)
-    .then((result) => Object.assign(gameResponse, result))
-    .catch(alert);
+const user = useCurrentUser();
+const playing_as = ref<undefined | number>(undefined);
 
-  const userSeats = gameResponse.players
-    ?.map((playerUser: User | undefined, index: number) =>
-      playerUser && playerUser?.id === user.value?.id ? index : null,
-    )
-    .filter((index: number | null): index is number => index !== null);
-  if (userSeats?.length === 1) {
-    setPlayingAs(userSeats[0]);
+function setNewState(stateResponse: GameStateResponse): void {
+  state_map.set(
+    { round: stateResponse.round, seat: stateResponse.seat },
+    stateResponse,
+  );
+  if (current_round.value < stateResponse.round) {
+    current_round.value = stateResponse.round;
   }
+  if (
+    (view_round.value === stateResponse.round ||
+      (view_round.value === null &&
+        stateResponse.round === current_round.value)) &&
+    playing_as.value === (stateResponse.seat ?? undefined)
+  ) {
+    view_state.value = stateResponse;
+  }
+}
+
+async function setViewState(round: number, seat: number | null): Promise<void> {
+  const maybe_state = state_map.get({ seat: seat, round: round });
+  if (maybe_state) {
+    view_state.value = maybe_state;
+    return;
+  }
+  await requests
+    .get(`/games/${props.gameId}/state/?seat=${seat ?? ""}&round=${round}`)
+    .then(setNewState)
+    .catch(alert);
+  return;
+}
+
+watchEffect(() => {
+  setViewState(
+    view_round.value ?? current_round.value,
+    playing_as.value ?? null,
+  );
+});
+
+watchEffect(async () => {
+  await requests
+    .get(`/games/${props.gameId}/state/initial`)
+    .then((result) => {
+      variant.value = result.variant;
+      config = result.config;
+      players.value = result.players;
+      setNewState(result.stateResponse);
+    })
+    .catch(alert);
 });
 
 const sit = (seat: number) => {
   requests
     .post(`/games/${props.gameId}/sit/${seat}`, {})
-    .then((players: User[]) => {
-      gameResponse.players = players;
+    .then((players_array: User[]) => {
+      players.value = players_array;
       playing_as.value = seat;
     });
 };
@@ -105,30 +102,29 @@ const sit = (seat: number) => {
 const leave = (seat: number) => {
   requests
     .post(`/games/${props.gameId}/leave/${seat}`, {})
-    .then((players: User[]) => {
-      gameResponse.players = players;
+    .then((players_array: User[]) => {
+      players.value = players_array;
       if (playing_as.value === seat) {
         playing_as.value = undefined;
       }
     });
 };
 
-const user = useCurrentUser();
-
-const playing_as = ref<undefined | number>(undefined);
 const setPlayingAs = (seat: number) => {
   if (!user.value) {
     return;
   }
   if (playing_as.value === seat) {
     playing_as.value = undefined;
+    socket.emit(
+      "unsubscribe",
+      players.value.map((player) => `game/${props.gameId}/${player}`),
+    );
     return;
   }
-  if (
-    gameResponse.players &&
-    gameResponse.players[seat]?.id === user.value.id
-  ) {
+  if (players.value && players.value[seat]?.id === user.value.id) {
     playing_as.value = seat;
+    socket.emit("subscribe", [`game/${props.gameId}/${seat}`]);
   }
 };
 
@@ -146,40 +142,39 @@ function makeMove(move_str: string) {
   }
 
   move[playing_as.value] = move_str;
-  requests
-    .post(`/games/${gameResponse.id}/move`, move)
-    .then((res: GameResponse) => {
-      Object.assign(gameResponse, res);
-    })
-    .catch(alert);
+  requests.post(`/games/${props.gameId}/move`, move).catch(alert);
 }
 
 watchEffect((onCleanup) => {
   if (!props.gameId) {
     return;
   }
-  const message = `game/${props.gameId}`;
-  socket.on(message, (data) => {
-    Object.assign(gameResponse, data);
-  });
+  const topic = `game/${props.gameId}`;
+  socket.emit("subscribe", [topic]);
+  socket.on("move", (state: GameStateResponse) =>
+    setViewState(state.round, state.seat),
+  );
+
   const seatsMessage = `game/${props.gameId}/seats`;
   socket.on(seatsMessage, (data) => {
-    gameResponse.players = data;
+    players.value = data;
   });
 
   onCleanup(() => {
-    socket.off(message);
+    socket.emit("unsubscribe", [topic]);
+    socket.off("move");
     socket.off(seatsMessage);
   });
 });
+
 const createTimeControlPreview = (
-  game: GameResponse,
+  config: unknown,
 ): IPerPlayerTimeControlBase | null => {
-  if (HasTimeControlConfig(game.config)) {
-    const config = (game.config as IConfigWithTimeControl).time_control;
-    const clock = timeControlMap.get(config.type);
+  if (HasTimeControlConfig(config)) {
+    const time_control_config = (config as IConfigWithTimeControl).time_control;
+    const clock = timeControlMap.get(time_control_config.type);
     if (!clock) {
-      throw new Error(`Invalid time control: ${config.type}`);
+      throw new Error(`Invalid time control: ${time_control_config.type}`);
     }
     return {
       clockState: clock.initialState(config),
@@ -193,19 +188,19 @@ const createTimeControlPreview = (
 <template>
   <div>
     <component
-      v-if="variantGameView && game.state"
+      v-if="variantGameView && view_state?.state"
       v-bind:is="variantGameView"
-      v-bind:gamestate="game.state"
-      v-bind:config="gameResponse.config"
+      v-bind:gamestate="view_state.state"
+      v-bind:config="config"
       v-on:move="makeMove"
     />
-    <NavButtons :gameRound="game.round" v-model="view_round" />
+    <NavButtons :gameRound="current_round" v-model="view_round" />
 
     <div id="variant-info">
       <div>
         <span class="info-label">Variant:</span>
         <span class="info-attribute">
-          {{ gameResponse.variant ?? "unknown" }}
+          {{ variant ?? "unknown" }}
         </span>
       </div>
 
@@ -216,7 +211,7 @@ const createTimeControlPreview = (
     </div>
   </div>
   <div className="seat-list">
-    <div v-for="(player, idx) in gameResponse.players" :key="idx">
+    <div v-for="(player, idx) in players" :key="idx">
       <SeatComponent
         :user_id="user?.id"
         :occupant="player"
@@ -226,17 +221,17 @@ const createTimeControlPreview = (
         @select="setPlayingAs(idx)"
         :selected="playing_as"
         :time_control="
-          gameResponse.time_control?.forPlayer[idx] ??
-          createTimeControlPreview(gameResponse)
+          view_state?.timeControl?.forPlayer[idx] ??
+          createTimeControlPreview(config)
         "
-        :time_config="(gameResponse.config as IConfigWithTimeControl).time_control"
-        :is_players_turn="game.next_to_play?.includes(idx) ?? false"
+        :time_config="(config as IConfigWithTimeControl).time_control"
+        :is_players_turn="view_state?.next_to_play?.includes(idx) ?? false"
       />
     </div>
 
     <div>
       <button
-        v-for="(value, key) in specialMoves"
+        v-for="(value, key) in view_state?.special_moves"
         :key="key"
         @click="makeMove(key as string)"
       >
@@ -245,10 +240,10 @@ const createTimeControlPreview = (
     </div>
   </div>
 
-  <PlayersToMove :next-to-play="game.next_to_play" />
+  <PlayersToMove :next-to-play="view_state?.next_to_play" />
 
-  <div v-if="game.result" style="font-weight: bold; font-size: 24pt">
-    Result: {{ game.result }}
+  <div v-if="view_state?.result" style="font-weight: bold; font-size: 24pt">
+    Result: {{ view_state?.result }}
   </div>
 </template>
 

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -155,9 +155,9 @@ watchEffect((onCleanup) => {
   }
   const topic = `game/${props.gameId}`;
   socket.emit("subscribe", [topic]);
-  socket.on("move", (state: GameStateResponse) =>
-    setViewState(state.round, state.seat),
-  );
+  socket.on("move", (state: GameStateResponse) => {
+    setNewState(state);
+  });
 
   const seatsMessage = `game/${props.gameId}/seats`;
   socket.on(seatsMessage, (data) => {

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -24,8 +24,8 @@ const props = defineProps<{ gameId: string }>();
 const state_map = new Map<string, GameStateResponse>();
 const view_state = ref<GameStateResponse | undefined>();
 const current_round = ref(0);
-let variant = ref("");
-let config: object | undefined = undefined;
+const variant = ref("");
+const config: Ref<object | undefined> = ref();
 const players = ref<User[]>();
 // null <-> viewing the latest round
 // while viewing history of game, maybe we should prevent player from making a move (accidentally)
@@ -84,7 +84,7 @@ watchEffect(async () => {
     .get(`/games/${props.gameId}/state/initial`)
     .then((result) => {
       variant.value = result.variant;
-      config = result.config;
+      config.value = result.config;
       players.value = result.players;
       setNewState(result.stateResponse);
     })

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -26,7 +26,7 @@ const view_state = ref<GameStateResponse | undefined>();
 const current_round = ref(0);
 let variant = ref("");
 let config: object | undefined = undefined;
-const players = ref();
+const players = ref<User[]>();
 // null <-> viewing the latest round
 // while viewing history of game, maybe we should prevent player from making a move (accidentally)
 const view_round: Ref<number | null> = ref(null);
@@ -111,16 +111,19 @@ const leave = (seat: number) => {
     });
 };
 
+function unsubscribeAllSeats(): void {
+  for (let i = 0; i < (players.value?.length ?? 0); i++) {
+    socket.emit("unsubscribe", `game/${props.gameId}/${i}`);
+  }
+}
+
 const setPlayingAs = (seat: number) => {
   if (!user.value) {
     return;
   }
+  unsubscribeAllSeats();
   if (playing_as.value === seat) {
     playing_as.value = undefined;
-    socket.emit(
-      "unsubscribe",
-      players.value.map((player) => `game/${props.gameId}/${player}`),
-    );
     return;
   }
   if (players.value && players.value[seat]?.id === user.value.id) {


### PR DESCRIPTION
### Changes
- Add server endpoints for getting (initial-) game information. Importantly this does not include the moves array, instead the view state defining properties. So the received information can depend on the selected seat.
- add a subscription based system for sending the state to the appropriate clients when a move is made. I believe this does not fully work yet, unfortunately.
- major change of the game view page to work with the new structures

### Remarks:
- I did not remove the endpoint that returns the game moves array. I'm not sure if its used by the game list. We may need to change that too, to make sure that hidden information can't leak.
- I tested (among other things) the staged moves of parallel. At the moment they don't show up in the game view unfortunately, I don't know the reason yet.
- In the game view I've added a map that stores all known values of states depending on (round|seat)-combinations. My idea is to avoid making redundant network calls with this. But I'm not sure if it does what I want it to do.