### PR TITLE
remove intersection id

### DIFF
--- a/packages/shared/src/lib/abstractBaduk/abstractBaduk.ts
+++ b/packages/shared/src/lib/abstractBaduk/abstractBaduk.ts
@@ -49,7 +49,7 @@ export abstract class AbstractBaduk<
       [];
     const checkedIntersections: Map<number, Set<TChainType>> = new Map();
 
-    changedIntersections.forEach((intersection) => {
+    changedIntersections.forEach((intersection, index) => {
       if (!intersection.stone) {
         // This shouldn't be possible.
         // Maybe use better typing to show that all intersections here have stones.
@@ -59,9 +59,9 @@ export abstract class AbstractBaduk<
       const uncheckedChainTypes = new Set(
         Array.from(intersection.stone.getChainTypes()).filter(
           (chainType) =>
-            !(
-              checkedIntersections.get(intersection.id) ?? new Set<TChainType>()
-            ).has(chainType),
+            !(checkedIntersections.get(index) ?? new Set<TChainType>()).has(
+              chainType,
+            ),
         ),
       );
 
@@ -131,6 +131,8 @@ export abstract class AbstractBaduk<
     chainTypes: Set<TChainType>,
     checked: Map<number, Set<TChainType>> = new Map(),
   ): Map<TChainType, null | Set<BadukIntersection<TChainType, TStone>>> {
+    const intersection_index = this.intersections.indexOf(intersection);
+
     if (intersection.stone === null) {
       // Liberty spotted
       return new Map(
@@ -139,10 +141,10 @@ export abstract class AbstractBaduk<
     }
 
     const checkedChainTypes =
-      checked.get(intersection.id) ??
+      checked.get(intersection_index) ??
       (() => {
         const defaultValue = new Set<TChainType>();
-        checked.set(intersection.id, defaultValue);
+        checked.set(intersection_index, defaultValue);
         return defaultValue;
       })();
 

--- a/packages/shared/src/lib/abstractBaduk/badukIntersection.ts
+++ b/packages/shared/src/lib/abstractBaduk/badukIntersection.ts
@@ -12,8 +12,8 @@ export class BadukIntersection<
 > extends Intersection {
   stone: TStone | null;
 
-  constructor(v: Vector2D, id: number) {
-    super(v, id);
+  constructor(v: Vector2D) {
+    super(v);
     this.stone = null;
   }
 }

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -50,7 +50,7 @@ export interface SierpinskyBoardConfig {
 }
 
 export interface IntersectionConstructor<TIntersection extends Intersection> {
-  new (vector: Vector2D, id: number): TIntersection;
+  new (vector: Vector2D): TIntersection;
 }
 
 export function createBoard<TIntersection extends Intersection>(
@@ -104,7 +104,7 @@ function createGridBoard<TIntersection extends Intersection>(
     array2D.push(new Array<TIntersection>());
     for (let x = 0; x < config.width; x++) {
       const id = y * config.width + x;
-      const intersection = new intersectionConstructor(new Vector2D(x, y), id);
+      const intersection = new intersectionConstructor(new Vector2D(x, y));
 
       intersections.push(intersection);
       array2D[y].push(intersection);
@@ -177,17 +177,14 @@ function convertIntersections<TIntersection extends Intersection>(
   old: IntersectionOld[],
   intersectionConstructor: IntersectionConstructor<TIntersection>,
 ): TIntersection[] {
-  const intersections = new Map<TIntersection["id"], TIntersection>(
-    old.map((o) => [
-      o.Identifier,
-      new intersectionConstructor(o.Position, o.Identifier),
-    ]),
+  const intersections = new Map<number, TIntersection>(
+    old.map((o, index) => [index, new intersectionConstructor(o.Position)]),
   );
-  old.forEach((i) =>
+  old.forEach((i, index) =>
     i.Neighbours.forEach((n) =>
       intersections
-        .get(i.Identifier)!
-        .connectTo(intersections.get(n.Identifier)!, false),
+        .get(index)!
+        .connectTo(intersections.get(old.indexOf(n))!, false),
     ),
   );
 

--- a/packages/shared/src/lib/abstractBoard/boardFactory.ts
+++ b/packages/shared/src/lib/abstractBoard/boardFactory.ts
@@ -103,7 +103,6 @@ function createGridBoard<TIntersection extends Intersection>(
   for (let y = 0; y < config.height; y++) {
     array2D.push(new Array<TIntersection>());
     for (let x = 0; x < config.width; x++) {
-      const id = y * config.width + x;
       const intersection = new intersectionConstructor(new Vector2D(x, y));
 
       intersections.push(intersection);

--- a/packages/shared/src/lib/abstractBoard/intersection.ts
+++ b/packages/shared/src/lib/abstractBoard/intersection.ts
@@ -5,14 +5,12 @@ import type { Vector2D } from "../../variants/badukWithAbstractBoard/abstractBoa
 */
 
 export class Intersection {
-  id: number;
   neighbours: this[];
   position: Vector2D;
 
-  constructor(v: Vector2D, id: number) {
+  constructor(v: Vector2D) {
     this.position = v;
     this.neighbours = [];
-    this.id = id;
   }
 
   connectTo(intersection: this, bothSides: boolean) {
@@ -29,7 +27,7 @@ export class Intersection {
   export(): Intersection {
     // TODO: How to export? Why is it needed?
     // TODO: Polymorphic this as return type? Can't construct new this(), right?
-    const intersection = new Intersection(this.position.Export(), this.id);
+    const intersection = new Intersection(this.position.Export());
     //ToDo: How to export Neighbours?
     return intersection;
   }

--- a/packages/shared/src/lib/graph.ts
+++ b/packages/shared/src/lib/graph.ts
@@ -88,6 +88,10 @@ export class Graph<T> implements Fillable<number, T> {
   serialize() {
     return [...this.data];
   }
+
+  get length(): number {
+    return this.data.length;
+  }
 }
 
 function identity<T>(x: T): T {

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/BadukBoardAbstract.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/BadukBoardAbstract.ts
@@ -22,7 +22,6 @@ export class BadukBoardAbstract implements IBadukBoard {
           this.Array2D.push(new Array<Intersection>());
           for (let j = 0; j < conf.width; j++) {
             const intersection = new Intersection(new Vector2D(i, j));
-            intersection.Identifier = i * conf.width + j;
 
             this.Intersections.push(intersection);
             this.Array2D[i].push(intersection);

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/CircularBoardHelper.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/CircularBoardHelper.ts
@@ -21,7 +21,6 @@ export function CreateCircularBoard(
         const intersection = new Intersection(
           new Vector2D(radius * Math.sin(angle), radius * Math.cos(angle)),
         );
-        intersection.Identifier = i * nodes_per_ring + x;
         return intersection;
       }),
     );

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/PolygonalBoardHelper.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/PolygonalBoardHelper.ts
@@ -487,7 +487,6 @@ export function CreatePolygonalBoard(size: number): Intersection[] {
 
   for (let z = 0; z < intersections.length; z++) {
     const i = intersections[z];
-    i.Identifier = z;
     i.Position = i.Position.Substract(shift);
   }
 

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/SierpinskyBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/SierpinskyBoard.ts
@@ -16,12 +16,7 @@ export function createSierpinskyBoard(depth: number): Intersection[] {
 
   const sierpinskyTriangle = new SierpinskyTriangle(middleIntersections, depth);
 
-  return [...middleIntersections, ...sierpinskyTriangle.flatten()].map(
-    (intersection, index) => {
-      intersection.Identifier = index;
-      return intersection;
-    },
-  );
+  return [...middleIntersections, ...sierpinskyTriangle.flatten()];
 }
 
 // Not sure if this is usable, I'd like to leave it here as comment for the time being.

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/TrihexagonalBoardHelper.ts
@@ -67,10 +67,6 @@ export class TrihexagonalBoardHelper {
       })
       .to2DArray()
       .flat()
-      .filter((value): value is Intersection => value !== null)
-      .map((intersection, index) => {
-        intersection.Identifier = index;
-        return intersection;
-      });
+      .filter((value): value is Intersection => value !== null);
   }
 }

--- a/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/intersection.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/abstractBoard/intersection.ts
@@ -4,13 +4,11 @@ import type { Vector2D } from "./Vector2D";
 export class Intersection {
   Neighbours: Intersection[];
   Position: Vector2D;
-  Identifier: number;
   StoneState: StoneState;
 
   constructor(v: Vector2D) {
     this.Position = v;
     this.Neighbours = [];
-    this.Identifier = 0;
     this.StoneState = new StoneState(Color.EMPTY);
   }
 
@@ -27,7 +25,6 @@ export class Intersection {
 
   Export(): Intersection {
     const intersection = new Intersection(this.Position.Export());
-    intersection.Identifier = this.Identifier;
     intersection.StoneState = this.StoneState.Export();
     //ToDo: How to export Neighbours?
     return intersection;

--- a/packages/shared/src/variants/fractional/fractional.test.ts
+++ b/packages/shared/src/variants/fractional/fractional.test.ts
@@ -18,6 +18,10 @@ class FractionalTestGame extends Fractional {
       (i) => i.neighbours.length === 2,
     );
   }
+
+  indexOf(intersection: FractionalIntersection): number | undefined {
+    return this.intersections.indexOf(intersection);
+  }
 }
 
 test("Surrounded merge stone", () => {
@@ -36,9 +40,15 @@ test("Surrounded merge stone", () => {
   expect(game.firstCorner?.neighbours[0]).toBeTruthy();
   expect(game.firstCorner?.neighbours[1]).toBeTruthy();
 
-  const cornerId = game.firstCorner?.id.toString() ?? "";
-  const neighbour0Id = game.firstCorner?.neighbours[0].id.toString() ?? "";
-  const neighbour1Id = game.firstCorner?.neighbours[1].id.toString() ?? "";
+  const cornerId = game.firstCorner
+    ? game.indexOf(game.firstCorner)?.toString() ?? ""
+    : "";
+  const neighbour0Id = game.firstCorner
+    ? game.indexOf(game.firstCorner.neighbours[0])?.toString() ?? ""
+    : "";
+  const neighbour1Id = game.firstCorner
+    ? game.indexOf(game.firstCorner.neighbours[1])?.toString() ?? ""
+    : "";
 
   // Round 1
   game.playMove(0, neighbour0Id);
@@ -53,7 +63,5 @@ test("Surrounded merge stone", () => {
 
   const state = game.exportState();
   expect(state.intersections.filter((i) => i.stone).length).toBe(2);
-  expect(
-    state.intersections.find((i) => i.id === Number(cornerId))?.stone,
-  ).toBeNull();
+  expect(state.intersections.at(Number(cornerId))?.stone).toBeNull();
 });

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -62,9 +62,7 @@ export class Fractional extends AbstractBaduk<
     }
 
     if (move.intersection.stone) {
-      throw new Error(
-        `There is already a stone at intersection ${move.intersection.id}`,
-      );
+      throw new Error(`There is already a stone at intersection ${m}`);
     }
 
     this.stagedMoves[move.player.index] = move.intersection;
@@ -154,9 +152,7 @@ export class Fractional extends AbstractBaduk<
   /** Asserts there is exactly one move of type FractionalMove and returns it */
   private decodeMove(p: number, m: string): FractionalMove | null {
     const player = this.config.players[p];
-    const intersection = this.intersections.find(
-      (intersection) => intersection.id === Number.parseInt(m),
-    );
+    const intersection = this.intersections.at(Number.parseInt(m));
     return player && intersection
       ? { player: { ...player, index: p }, intersection }
       : null;

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -3,6 +3,7 @@ import type {
   FractionalConfig,
   FractionalState,
 } from "@ogfcommunity/variants-shared";
+import { createGraph } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import TaegeukStone from "../TaegeukStone.vue";
 
@@ -35,6 +36,7 @@ const boardRect = computed(
     };
   },
 );
+const board = computed(() => createGraph(props.gamestate.intersections, null));
 
 const viewBox = computed(() => {
   // viewBox is slightly larger than board
@@ -65,26 +67,26 @@ const stagedMove = computed(() => props.gamestate.stagedMove);
     />
     <g class="lines">
       <g
-        v-for="intersection in props.gamestate.intersections"
-        :key="intersection.id"
+        v-for="(intersection, index) in props.gamestate.intersections"
+        :key="index"
       >
         <line
-          v-for="neighbour in intersection.neighbours.filter(
-            (n) => n.id < intersection.id,
-          )"
-          :key="neighbour.id"
+          v-for="neighbour_index in board
+            .neighbors(index)
+            .filter((n) => n < index)"
+          :key="neighbour_index"
           class="grid"
           :x1="intersection.position.X"
-          :x2="neighbour.position.X"
+          :x2="props.gamestate.intersections[neighbour_index].position.X"
           :y1="intersection.position.Y"
-          :y2="neighbour.position.Y"
+          :y2="props.gamestate.intersections[neighbour_index].position.Y"
         />
       </g>
     </g>
     <g class="stones">
       <g
-        v-for="intersection in props.gamestate.intersections"
-        :key="intersection.id"
+        v-for="(intersection, index) in props.gamestate.intersections"
+        :key="index"
       >
         <TaegeukStone
           v-if="intersection.stone"
@@ -96,7 +98,7 @@ const stagedMove = computed(() => props.gamestate.stagedMove);
         <circle
           v-else
           class="click-placeholder"
-          v-on:click="intersectionClicked(intersection.id)"
+          v-on:click="intersectionClicked(index)"
           v-bind:cx="intersection.position.X"
           v-bind:cy="intersection.position.Y"
           r="0.47"

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -13,6 +13,7 @@ import {
   BoardConfig,
   createBoard,
   Intersection,
+  createGraph,
 } from "@ogfcommunity/variants-shared";
 
 const props = defineProps<{
@@ -21,7 +22,10 @@ const props = defineProps<{
   board_config: BoardConfig;
 }>();
 
-const intersections = createBoard(props.board_config, Intersection);
+const intersections = computed(() =>
+  createBoard(props.board_config, Intersection),
+);
+const board = computed(() => createGraph(intersections.value, null));
 const hovered: Ref<number> = ref(-1);
 
 const emit = defineEmits<{
@@ -39,8 +43,8 @@ function positionHovered(index: number) {
 }
 
 const viewBox = computed(() => {
-  const xPositions = intersections.map((i) => i.position.X);
-  const yPositions = intersections.map((i) => i.position.Y);
+  const xPositions = intersections.value.map((i) => i.position.X);
+  const yPositions = intersections.value.map((i) => i.position.Y);
   const minX = Math.min(...xPositions);
   const minY = Math.min(...yPositions);
   const width = Math.max(...xPositions) - Math.min(...xPositions);
@@ -72,53 +76,53 @@ const viewBox = computed(() => {
       :fill="background_color ?? '#dcb35c'"
     />
 
-    <g v-for="intersection in intersections" :key="intersection.id">
+    <g v-for="(intersection, index) in intersections" :key="index">
       <line
-        v-for="neighbour in intersection.neighbours.filter(
-          (n) => n.id < intersection.id,
-        )"
-        :key="neighbour.id"
+        v-for="neighbour_index in board
+          .neighbors(index)
+          .filter((n) => n < index)"
+        :key="neighbour_index"
         class="grid"
         v-bind:x1="intersection.position.X"
-        v-bind:x2="neighbour.position.X"
+        v-bind:x2="intersections[neighbour_index].position.X"
         v-bind:y1="intersection.position.Y"
-        v-bind:y2="neighbour.position.Y"
+        v-bind:y2="intersections[neighbour_index].position.Y"
       />
     </g>
-    <g v-for="intersection in intersections" :key="intersection.id">
+    <g v-for="(intersection, index) in intersections" :key="index">
       <TaegeukStone
         :key="`${intersection.position.X},${intersection.position.Y}`"
         :cx="intersection.position.X"
         :cy="intersection.position.Y"
         :r="0.48"
-        :colors="props.board?.at(intersection.id)?.colors ?? []"
-        @click="positionClicked(intersection.id)"
-        @mouseover="positionHovered(intersection.id)"
+        :colors="props.board?.at(index)?.colors ?? []"
+        @click="positionClicked(index)"
+        @mouseover="positionHovered(index)"
       />
     </g>
     <g>
       <IntersectionAnnotation
-        v-for="intersection in intersections.filter(
-          (x) => props.board.at(x.id)?.annotation,
+        v-for="(intersection, index) in intersections.filter(
+          (_, idx) => props.board.at(idx)?.annotation,
         )"
-        :key="intersection.id"
+        :key="index"
         :cx="intersection.position.X"
         :cy="intersection.position.Y"
         :r="0.48"
-        :annotation="props.board.at(intersection.id)?.annotation!"
+        :annotation="props.board.at(index)?.annotation!"
       />
     </g>
     <g>
       <rect
-        v-for="intersection in intersections"
-        :key="intersection.id"
-        @click="positionClicked(intersection.id)"
-        @mouseover="positionHovered(intersection.id)"
+        v-for="(intersection, index) in intersections"
+        :key="index"
+        @click="positionClicked(index)"
+        @mouseover="positionHovered(index)"
         :x="intersection.position.X - 0.5"
         :y="intersection.position.Y - 0.5"
         width="1"
         height="1"
-        :fill="hovered == intersection.id ? 'pink' : 'transparent'"
+        :fill="hovered == index ? 'pink' : 'transparent'"
         opacity="0.5"
       />
     </g>

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -25,7 +25,7 @@ const props = defineProps<{
 const intersections = computed(() =>
   createBoard(props.board_config, Intersection),
 );
-const board = computed(() => createGraph(intersections.value, null));
+const graph = computed(() => createGraph(intersections.value, null));
 const hovered: Ref<number> = ref(-1);
 
 const emit = defineEmits<{
@@ -78,7 +78,7 @@ const viewBox = computed(() => {
 
     <g v-for="(intersection, index) in intersections" :key="index">
       <line
-        v-for="neighbour_index in board
+        v-for="neighbour_index in graph
           .neighbors(index)
           .filter((n) => n < index)"
         :key="neighbour_index"


### PR DESCRIPTION
fixes: #261 

Instead of using an ID in the intersection class, use its index in the intersection array as unique identifier. This ensures consistency with the variant implementation, which use the graph class.