### PR TITLE
fix board dimensions layout

### DIFF
--- a/packages/vue-client/src/components/boards/BadukBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukBoard.vue
@@ -40,8 +40,6 @@ function positionClicked(pos: Coordinate) {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    width="100%"
-    height="100%"
     v-bind:viewBox="`-1 -1 ${width + 1} ${height + 1}`"
   >
     <rect

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -63,13 +63,7 @@ const stagedMove = computed(() =>
 </script>
 
 <template>
-  <svg
-    class="board"
-    xmlns="http://www.w3.org/2000/svg"
-    width="100%"
-    height="100%"
-    :viewBox="viewBox"
-  >
+  <svg class="board" xmlns="http://www.w3.org/2000/svg" :viewBox="viewBox">
     <rect
       class="background"
       :x="boardRect.x"

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -60,8 +60,6 @@ const viewBox = computed(() => {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    width="100%"
-    height="100%"
     v-bind:viewBox="`${viewBox.minX - 1} ${viewBox.minY - 1} ${
       viewBox.width + 2
     } ${viewBox.height + 2}`"

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -43,8 +43,6 @@ function positionHovered(pos: Coordinate) {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    width="100%"
-    height="100%"
     v-bind:viewBox="`-1 -1 ${width + 1} ${height + 1}`"
   >
     <rect

--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -119,14 +119,14 @@ const graph_boards = computed(() => {
 
 <template>
   <template v-if="gridConfig">
-    <div style="width: 50%; height: 100%; display: inline-block">
+    <div style="width: 50%; height: min-content; display: inline-block">
       <MulticolorGridBoard
         :board="board_0"
         :board_dimensions="board_dimensions!"
         @click="emitMove($event.toSgfRepr())"
       />
     </div>
-    <div style="width: 50%; height: 100%; display: inline-block">
+    <div style="width: 50%; height: min-content; display: inline-block">
       <MulticolorGridBoard
         :board="board_1"
         :board_dimensions="board_dimensions!"
@@ -136,14 +136,14 @@ const graph_boards = computed(() => {
   </template>
 
   <template v-if="graphConfig">
-    <div style="width: 50%; height: 100%; display: inline-block">
+    <div style="display: inline-block">
       <MulticolorGraphBoard
         :board="graph_boards.board_0"
         :board_config="graphConfig!.board"
         @click="emitMove($event.toString())"
       />
     </div>
-    <div style="width: 50%; height: 100%; display: inline-block">
+    <div style="display: inline-block">
       <MulticolorGraphBoard
         :board="graph_boards.board_1"
         :board_config="graphConfig!.board"


### PR DESCRIPTION
fixes #257

There were conflicting definitions of width and height of the board svg element. Note that GameView.vue has the following style definition:

```
@media (min-width: 664px) {
  .board {
    width: var(--board-side-length);
    height: var(--board-side-length);
  }
}
```

Additionally, the board implementations had width and height set to 100%, which caused the nav-buttons and variant description to overflow into the next grid element.

Previously:

![grafik](https://github.com/govariantsteam/govariants/assets/77507448/75361fef-3486-4e71-83b1-71177c26a2af)

After:

![grafik](https://github.com/govariantsteam/govariants/assets/77507448/ab74742d-9d1f-42bd-a8f6-6ba40e514fda)
