### PR TITLE
Hide download button if it's not supported

### DIFF
--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -2,6 +2,7 @@
 import {
   HasTimeControlConfig,
   timeControlMap,
+  game_map,
 } from "@ogfcommunity/variants-shared";
 import * as requests from "../requests";
 import SeatComponent from "@/components/GameView/SeatComponent.vue";
@@ -253,7 +254,7 @@ const createTimeControlPreview = (
 
   <PlayersToMove :next-to-play="game_state?.next_to_play" />
 
-  <DownloadSGF :gameId="gameId" />
+  <DownloadSGF v-if="game_map[variant]?.prototype.getSGF" :gameId="gameId" />
   <div v-if="game_state?.result" style="font-weight: bold; font-size: 24pt">
     Result: {{ game_state?.result }}
   </div>


### PR DESCRIPTION
Most variants don't support file download, so we can hide the button for them:

<img width="250" alt="Screenshot 2024-06-23 at 7 39 20 PM" src="https://github.com/govariantsteam/govariants/assets/25233703/d8ee8aec-72ea-4617-ba22-70e40239610a">