### PR TITLE
Upgrade node version used in GH actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Github no longer supports node v16, moving to 20. (I think Heroku is using that anyway)