### PR TITLE
indicator of last moves in variant fractional

### DIFF
--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -120,7 +120,7 @@ export class Fractional extends AbstractBaduk<
         intersection.stone ? Array.from(intersection.stone.colors) : null,
       ),
       ...stagedMove,
-      lastMoves: this.lastMoves.map((move, playerNr) =>
+      lastMoves: this.lastMoves.map((move) =>
         move ? this.intersections.indexOf(move) : null,
       ),
     };

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -40,6 +40,8 @@ export interface FractionalConfig extends AbstractBadukConfig {
 export interface FractionalState {
   boardState: (Color[] | null)[];
   stagedMove?: { intersectionID: number; colors: Color[] };
+  // number representing index of intersection
+  lastMoves: (number | null)[];
 }
 
 export class Fractional extends AbstractBaduk<
@@ -49,10 +51,12 @@ export class Fractional extends AbstractBaduk<
   FractionalState
 > {
   private stagedMoves: (FractionalIntersection | null)[];
+  private lastMoves: (FractionalIntersection | null)[];
 
   constructor(config: FractionalConfig) {
     super(config);
     this.stagedMoves = this.stagedMovesDefaults();
+    this.lastMoves = this.lastMovesDefaults();
   }
 
   playMove(p: number, m: string): void {
@@ -93,6 +97,7 @@ export class Fractional extends AbstractBaduk<
 
       this.removeChains(false);
 
+      this.lastMoves = this.stagedMoves;
       this.stagedMoves = this.stagedMovesDefaults();
       super.increaseRound();
     }
@@ -115,6 +120,9 @@ export class Fractional extends AbstractBaduk<
         intersection.stone ? Array.from(intersection.stone.colors) : null,
       ),
       ...stagedMove,
+      lastMoves: this.lastMoves.map((move, playerNr) =>
+        move ? this.intersections.indexOf(move) : null,
+      ),
     };
   }
 
@@ -147,6 +155,12 @@ export class Fractional extends AbstractBaduk<
   }
 
   private stagedMovesDefaults(): (FractionalIntersection | null)[] {
+    return new Array<FractionalIntersection | null>(this.numPlayers()).fill(
+      null,
+    );
+  }
+
+  private lastMovesDefaults(): (FractionalIntersection | null)[] {
     return new Array<FractionalIntersection | null>(this.numPlayers()).fill(
       null,
     );

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -110,7 +110,8 @@ const stagedMove = computed(() =>
           v-bind:cx="intersection.position.X"
           v-bind:cy="intersection.position.Y"
           r="0.3"
-          fill="#dbdbdb"
+          stroke="#dbdbdb"
+          stroke-width="0.05"
           class="last-move-indicator"
         />
       </g>

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -105,6 +105,14 @@ const stagedMove = computed(() =>
           v-bind:cy="intersection.position.Y"
           r="0.47"
         />
+        <circle
+          v-if="$props.gamestate.lastMoves.includes(index)"
+          v-bind:cx="intersection.position.X"
+          v-bind:cy="intersection.position.Y"
+          r="0.3"
+          fill="#dbdbdb"
+          class="last-move-indicator"
+        />
       </g>
     </g>
     <TaegeukStone
@@ -130,5 +138,9 @@ line {
 
 .click-placeholder {
   opacity: 0;
+}
+
+.last-move-indicator {
+  mix-blend-mode: difference;
 }
 </style>


### PR DESCRIPTION
Adds an indicator of last rounds moves in variant fractional. Example:

![grafik](https://github.com/user-attachments/assets/1e0e91b5-d826-462c-93f1-a5b75c51a0d1)