### PR TITLE
unsub and subscribe to new seat in one api call

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -133,6 +133,16 @@ io.on("connection", (socket) => {
       await socket.leave(topic);
     }
   });
+
+  socket.on("select_seat", async ([game_id, seat, nr_of_players]) => {
+    // unsubscribe from all seats
+    for (let i = 0; i < nr_of_players; i++) {
+      await socket.leave(`game/${game_id}/${i}`);
+    }
+
+    // subscribe to new seat
+    await socket.join(`game/${game_id}/${seat}`);
+  });
 });
 
 // If production, serve the React repo!

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -134,7 +134,7 @@ io.on("connection", (socket) => {
     }
   });
 
-  socket.on("select_seat", async ([game_id, seat, nr_of_players]) => {
+  socket.on("unique_subscribe", async ([game_id, seat, nr_of_players]) => {
     // unsubscribe from all seats
     for (let i = 0; i < nr_of_players; i++) {
       await socket.leave(`game/${game_id}/${i}`);

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -126,7 +126,7 @@ const setPlayingAs = (seat: number) => {
   }
 
   playing_as.value = seat;
-  socket.emit("select_seat", [props.gameId, seat, players.value.length]);
+  socket.emit("unique_subscribe", [props.gameId, seat, players.value.length]);
 };
 
 function makeMove(move_str: string) {

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -114,28 +114,19 @@ const leave = (seat: number) => {
     });
 };
 
-function unsubscribeAllSeats(): void {
-  if (players.value) {
-    socket.emit(
-      "unsubscribe",
-      players.value.map((_, index) => `game/${props.gameId}/${index}`),
-    );
-  }
-}
-
 const setPlayingAs = (seat: number) => {
-  if (!user.value) {
+  if (!user.value || !players.value) {
     return;
   }
-  unsubscribeAllSeats();
+
   if (playing_as.value === seat) {
     playing_as.value = undefined;
+    socket.emit("unsubscribe", [`game/${props.gameId}/${seat}`]);
     return;
   }
-  if (players.value && players.value[seat]?.id === user.value.id) {
-    playing_as.value = seat;
-    socket.emit("subscribe", [`game/${props.gameId}/${seat}`]);
-  }
+
+  playing_as.value = seat;
+  socket.emit("select_seat", [props.gameId, seat, players.value.length]);
 };
 
 function makeMove(move_str: string) {


### PR DESCRIPTION
This is an attempt to fix the bug mentioned in [https://forums.online-go.com/t/game-setup-parallel-fractional-go-game-4/53321/39](url)

I've experienced this bug on the live site too, but could not reproduce locally. So I'm not sure if this will indeed fix the bug.

In any case, I believe this is an improvement because it reduces the number of api calls when a player selects a seat. Previously two calls were triggered, one to unsubscribe and one to subscribe to the new seat. The above mentioned error could happen if the unsubscribe call is slower than the subscribe call.