### PR TITLE
change order of last move indicator and click placeholder

### DIFF
--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -98,14 +98,6 @@ const stagedMove = computed(() =>
           :r="0.47"
         />
         <circle
-          v-else
-          class="click-placeholder"
-          v-on:click="intersectionClicked(index)"
-          v-bind:cx="intersection.position.X"
-          v-bind:cy="intersection.position.Y"
-          r="0.47"
-        />
-        <circle
           v-if="$props.gamestate.lastMoves.includes(index)"
           v-bind:cx="intersection.position.X"
           v-bind:cy="intersection.position.Y"
@@ -113,6 +105,14 @@ const stagedMove = computed(() =>
           stroke="#dbdbdb"
           stroke-width="0.05"
           class="last-move-indicator"
+        />
+        <circle
+          v-if="!$props.gamestate.boardState.at(index)"
+          class="click-placeholder"
+          v-on:click="intersectionClicked(index)"
+          v-bind:cx="intersection.position.X"
+          v-bind:cy="intersection.position.Y"
+          r="0.47"
         />
       </g>
     </g>


### PR DESCRIPTION
This fixes a problem that can occur with the last move indicator in fractional when a played stone gets immediately captured. Then previously the last move indicator was positioned in front of the click placeholder, making it impossible to play a move at that position.

To fix this, I changed the order of elements. Had to adjust the v-else to a v-if with negated condition.