### PR TITLE
enable graph boards for freeze

### DIFF
--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -87,7 +87,7 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
     return this.phase === "gameover" ? [] : [this.next_to_play];
   }
 
-  private decodeMove(move: string): Coordinate {
+  protected decodeMove(move: string): Coordinate {
     if (isGridBadukConfig(this.config)) {
       return Coordinate.fromSgfRepr(move);
     }

--- a/packages/shared/src/variants/freeze.ts
+++ b/packages/shared/src/variants/freeze.ts
@@ -21,7 +21,7 @@ export class FreezeGo extends Baduk {
 
     const opponent = player === 0 ? Color.WHITE : Color.BLACK;
     this.frozen = this.board
-      .neighbors(Coordinate.fromSgfRepr(move))
+      .neighbors(this.decodeMove(move))
       .some(
         (pos) =>
           this.board.at(pos) === opponent && is_in_atari(pos, this.board),

--- a/packages/shared/src/variants/freeze.ts
+++ b/packages/shared/src/variants/freeze.ts
@@ -1,4 +1,4 @@
-import { Coordinate, CoordinateLike } from "../lib/coordinate";
+import { CoordinateLike } from "../lib/coordinate";
 import { getGroup, getOuterBorder } from "../lib/group_utils";
 import { Variant } from "../variant";
 import { Baduk, BadukBoard, BadukConfig, BadukState, Color } from "./baduk";

--- a/packages/vue-client/src/components/boards/FreezeGoBoard.vue
+++ b/packages/vue-client/src/components/boards/FreezeGoBoard.vue
@@ -4,18 +4,25 @@ import {
   Coordinate,
   type FreezeGoState,
   Color,
-  GridBadukConfig,
   getWidthAndHeight,
+  NewBadukConfig,
+  isGridBadukConfig,
+  GridBadukConfig,
 } from "@ogfcommunity/variants-shared";
 import { Grid } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
+import MulticolorGraphBoard from "./MulticolorGraphBoard.vue";
 
 const props = defineProps<{
-  config: GridBadukConfig;
+  config: NewBadukConfig;
   gamestate: FreezeGoState;
 }>();
 
-const board_dimensions = computed(() => getWidthAndHeight(props.config));
+const board_dimensions = computed(() =>
+  isGridBadukConfig(props.config)
+    ? getWidthAndHeight(props.config as GridBadukConfig)
+    : null,
+);
 
 const NORMAL_COLORS = { background: "#dcb35c", black: "black", white: "white" };
 const FROZEN_COLORS = {
@@ -31,8 +38,14 @@ const emit = defineEmits<{
 function positionClicked(pos: Coordinate) {
   emit("move", pos.toSgfRepr());
 }
+function graph_board_clicked(index: number) {
+  emit("move", index.toString());
+}
 
-const board = computed(() => {
+const grid_board = computed(() => {
+  if (!isGridBadukConfig(props.config)) {
+    return null;
+  }
   return Grid.from2DArray(props.gamestate.board)
     .map((color) => {
       const theme = props.gamestate.frozen ? FROZEN_COLORS : NORMAL_COLORS;
@@ -47,15 +60,43 @@ const board = computed(() => {
     })
     .to2DArray();
 });
+
+const graph_board = computed(() => {
+  if (isGridBadukConfig(props.config)) {
+    return null;
+  }
+  const sequence = props.gamestate.board.at(0) ?? [];
+
+  return sequence.map((color) => {
+    switch (color) {
+      case Color.BLACK:
+        return { colors: ["black"], annotation: undefined };
+      case Color.WHITE:
+        return { colors: ["white"], annotation: undefined };
+      case Color.EMPTY:
+        return null;
+    }
+  });
+});
 </script>
 
 <template>
   <MulticolorGridBoard
-    :board="board"
-    :board_dimensions="board_dimensions"
+    v-if="isGridBadukConfig(props.config)"
+    :board="grid_board!"
+    :board_dimensions="board_dimensions!"
     :background_color="
       gamestate.frozen ? FROZEN_COLORS.background : NORMAL_COLORS.background
     "
     @click="positionClicked"
+  />
+  <MulticolorGraphBoard
+    v-if="!isGridBadukConfig(props.config)"
+    :board="graph_board!"
+    :board_config="$props.config.board"
+    @click="graph_board_clicked"
+    :background_color="
+      gamestate.frozen ? FROZEN_COLORS.background : NORMAL_COLORS.background
+    "
   />
 </template>

--- a/packages/vue-client/src/config_form_map.ts
+++ b/packages/vue-client/src/config_form_map.ts
@@ -17,7 +17,7 @@ export const config_form_map: {
   tetris: BadukConfigForm,
   pyramid: GridBadukConfigForm,
   "thue-morse": BadukConfigForm,
-  freeze: GridBadukConfigForm,
+  freeze: BadukConfigForm,
   keima: GridBadukConfigForm,
   "one color": BadukConfigForm,
   drift: DriftGoConfigFormVue,


### PR DESCRIPTION
Refactor Freeze board component to enable the graph boards.

This is an addendum to the rework where we enabled graph boards for baduk.