### PR TITLE
add playing table map

### DIFF
--- a/packages/vue-client/src/playing_table_map.ts
+++ b/packages/vue-client/src/playing_table_map.ts
@@ -1,31 +1,5 @@
 import { Component } from "vue";
-import BadukBoardSelector from "./components/boards/BadukBoardSelector.vue";
-import BadukBoardAbstract from "./components/boards/BadukBoardAbstract.vue";
-import ParallelGoBoard from "./components/boards/ParallelGoBoard.vue";
-import ChessBoard from "./components/boards/ChessBoard.vue";
-import FreezeGoBoard from "./components/boards/FreezeGoBoard.vue";
-import FractionalBoard from "./components/boards/FractionalBoard.vue";
-import KeimaBoard from "./components/boards/KeimaBoard.vue";
-import QuantumBoard from "./components/boards/QuantumBoard.vue";
-import SFractionalBoardSelector from "./components/boards/SFractional/SFractionalBoardSelector.vue";
 
 export const playing_table_map: {
   [variant: string]: Component<{ config: unknown; gamestate: unknown }>;
-} = {
-  baduk: BadukBoardSelector,
-  phantom: BadukBoardSelector,
-  badukWithAbstractBoard: BadukBoardAbstract,
-  parallel: ParallelGoBoard,
-  capture: BadukBoardSelector,
-  chess: ChessBoard,
-  tetris: BadukBoardSelector,
-  pyramid: BadukBoardSelector,
-  "thue-morse": BadukBoardSelector,
-  freeze: FreezeGoBoard,
-  fractional: FractionalBoard,
-  keima: KeimaBoard,
-  "one color": BadukBoardSelector,
-  drift: BadukBoardSelector,
-  quantum: QuantumBoard,
-  sfractional: SFractionalBoardSelector,
-};
+} = {};

--- a/packages/vue-client/src/playing_table_map.ts
+++ b/packages/vue-client/src/playing_table_map.ts
@@ -1,0 +1,31 @@
+import { Component } from "vue";
+import BadukBoardSelector from "./components/boards/BadukBoardSelector.vue";
+import BadukBoardAbstract from "./components/boards/BadukBoardAbstract.vue";
+import ParallelGoBoard from "./components/boards/ParallelGoBoard.vue";
+import ChessBoard from "./components/boards/ChessBoard.vue";
+import FreezeGoBoard from "./components/boards/FreezeGoBoard.vue";
+import FractionalBoard from "./components/boards/FractionalBoard.vue";
+import KeimaBoard from "./components/boards/KeimaBoard.vue";
+import QuantumBoard from "./components/boards/QuantumBoard.vue";
+import SFractionalBoardSelector from "./components/boards/SFractional/SFractionalBoardSelector.vue";
+
+export const playing_table_map: {
+  [variant: string]: Component<{ config: unknown; gamestate: unknown }>;
+} = {
+  baduk: BadukBoardSelector,
+  phantom: BadukBoardSelector,
+  badukWithAbstractBoard: BadukBoardAbstract,
+  parallel: ParallelGoBoard,
+  capture: BadukBoardSelector,
+  chess: ChessBoard,
+  tetris: BadukBoardSelector,
+  pyramid: BadukBoardSelector,
+  "thue-morse": BadukBoardSelector,
+  freeze: FreezeGoBoard,
+  fractional: FractionalBoard,
+  keima: KeimaBoard,
+  "one color": BadukBoardSelector,
+  drift: BadukBoardSelector,
+  quantum: QuantumBoard,
+  sfractional: SFractionalBoardSelector,
+};

--- a/packages/vue-client/src/playing_table_map.ts
+++ b/packages/vue-client/src/playing_table_map.ts
@@ -1,5 +1,10 @@
 import { Component } from "vue";
 
+// This map can be used to set which component is displayed in the
+// GameView for a given variant. If there is no entry for a variant,
+// then we default to the component in board_map.
+// This should be used when we want to display more than just the
+// board in GameView.
 export const playing_table_map: {
   [variant: string]: Component<{ config: unknown; gamestate: unknown }>;
 } = {};

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -15,11 +15,11 @@ import type {
   GameStateResponse,
 } from "@ogfcommunity/variants-shared";
 import { computed, ref, watchEffect, type Ref } from "vue";
-import { board_map } from "@/board_map";
 import { socket } from "../requests";
 import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 import DownloadSGF from "@/components/GameView/DownloadSGF.vue";
+import { playing_table_map } from "@/playing_table_map";
 
 const props = defineProps<{ gameId: string }>();
 
@@ -32,7 +32,7 @@ const players = ref<User[]>();
 // null <-> viewing the latest round
 // while viewing history of game, maybe we should prevent player from making a move (accidentally)
 const view_round: Ref<number | null> = ref(null);
-const variantGameView = computed(() => board_map[variant.value]);
+const variantPlayingTable = computed(() => playing_table_map[variant.value]);
 const variantDescriptionShort = computed(() => getDescription(variant.value));
 const user = useCurrentUser();
 const playing_as = ref<undefined | number>(undefined);
@@ -206,8 +206,8 @@ const createTimeControlPreview = (
 <template>
   <div>
     <component
-      v-if="variantGameView && game_state?.state"
-      v-bind:is="variantGameView"
+      v-if="variantPlayingTable && game_state?.state"
+      v-bind:is="variantPlayingTable"
       v-bind:gamestate="game_state.state"
       v-bind:config="config"
       v-on:move="makeMove"

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -33,7 +33,7 @@ const players = ref<User[]>();
 // null <-> viewing the latest round
 // while viewing history of game, maybe we should prevent player from making a move (accidentally)
 const view_round: Ref<number | null> = ref(null);
-const variantPlayingTable = computed(
+const variantGameView = computed(
   () => playing_table_map[variant.value] ?? board_map[variant.value],
 );
 const variantDescriptionShort = computed(() => getDescription(variant.value));
@@ -209,8 +209,8 @@ const createTimeControlPreview = (
 <template>
   <div>
     <component
-      v-if="variantPlayingTable && game_state?.state"
-      v-bind:is="variantPlayingTable"
+      v-if="variantGameView && game_state?.state"
+      v-bind:is="variantGameView"
       v-bind:gamestate="game_state.state"
       v-bind:config="config"
       v-on:move="makeMove"

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -20,6 +20,7 @@ import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 import DownloadSGF from "@/components/GameView/DownloadSGF.vue";
 import { playing_table_map } from "@/playing_table_map";
+import { board_map } from "@/board_map";
 
 const props = defineProps<{ gameId: string }>();
 
@@ -32,7 +33,9 @@ const players = ref<User[]>();
 // null <-> viewing the latest round
 // while viewing history of game, maybe we should prevent player from making a move (accidentally)
 const view_round: Ref<number | null> = ref(null);
-const variantPlayingTable = computed(() => playing_table_map[variant.value]);
+const variantPlayingTable = computed(
+  () => playing_table_map[variant.value] ?? board_map[variant.value],
+);
 const variantDescriptionShort = computed(() => getDescription(variant.value));
 const user = useCurrentUser();
 const playing_as = ref<undefined | number>(undefined);


### PR DESCRIPTION
issue #134

I added `playing_table_map` that is a copy of `board_map`, and use this new map in GameView. Notably the GamesList still uses `board_map`.

Should be no functional change yet. This PR is to discuss whether we want this structural change.