### PR TITLE
Use badukVariant values by default.

### DIFF
--- a/packages/shared/src/variants/capture.ts
+++ b/packages/shared/src/variants/capture.ts
@@ -1,5 +1,5 @@
 import { Variant } from "../variant";
-import { Baduk, BadukConfig } from "./baduk";
+import { Baduk, BadukConfig, badukVariant } from "./baduk";
 
 export class Capture extends Baduk {
   playMove(player: number, move: string): void {
@@ -16,8 +16,7 @@ export class Capture extends Baduk {
 }
 
 export const captureVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: Capture,
   description: "Baduk but the first player who captures a stone wins",
-  defaultConfig: Baduk.defaultConfig,
-  getPlayerColors: Baduk.getPlayerColors,
 };

--- a/packages/shared/src/variants/freeze.ts
+++ b/packages/shared/src/variants/freeze.ts
@@ -1,7 +1,14 @@
 import { CoordinateLike } from "../lib/coordinate";
 import { getGroup, getOuterBorder } from "../lib/group_utils";
 import { Variant } from "../variant";
-import { Baduk, BadukBoard, BadukConfig, BadukState, Color } from "./baduk";
+import {
+  Baduk,
+  BadukBoard,
+  BadukConfig,
+  BadukState,
+  badukVariant,
+  Color,
+} from "./baduk";
 
 export interface FreezeGoState extends BadukState {
   frozen: boolean;
@@ -42,8 +49,7 @@ function is_in_atari(pos: CoordinateLike, board: BadukBoard<Color>) {
 }
 
 export const freezeGoVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: FreezeGo,
   description: "Baduk but after an Atari, stones can't be captured",
-  defaultConfig: Baduk.defaultConfig,
-  getPlayerColors: Baduk.getPlayerColors,
 };

--- a/packages/shared/src/variants/keima.ts
+++ b/packages/shared/src/variants/keima.ts
@@ -1,6 +1,6 @@
 import { Coordinate } from "../lib/coordinate";
 import { Variant } from "../variant";
-import { Baduk, BadukConfig, BadukState, GridBaduk } from "./baduk";
+import { BadukConfig, BadukState, badukVariant, GridBaduk } from "./baduk";
 
 export interface KeimaState extends BadukState {
   keima?: string;
@@ -67,9 +67,8 @@ function is_keima_shape(a: Coordinate, b: Coordinate) {
 }
 
 export const keimaVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: Keima,
   description:
     "Baduk but players play two moves that must form a Keima (Knight's move) shape",
-  defaultConfig: Baduk.defaultConfig,
-  getPlayerColors: Baduk.getPlayerColors,
 };

--- a/packages/shared/src/variants/one_color.ts
+++ b/packages/shared/src/variants/one_color.ts
@@ -1,5 +1,5 @@
 import { Variant } from "../variant";
-import { BadukState, Color, Baduk, BadukConfig } from "./baduk";
+import { BadukState, Color, Baduk, BadukConfig, badukVariant } from "./baduk";
 
 export class OneColorGo extends Baduk {
   exportState(): BadukState {
@@ -13,7 +13,7 @@ export class OneColorGo extends Baduk {
 }
 
 export const oneColorGoVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: OneColorGo,
   description: "Baduk with obfuscated stone colors",
-  defaultConfig: Baduk.defaultConfig,
 };

--- a/packages/shared/src/variants/phantom.ts
+++ b/packages/shared/src/variants/phantom.ts
@@ -1,4 +1,4 @@
-import { Baduk, BadukConfig, BadukState, Color } from "./baduk";
+import { Baduk, BadukConfig, BadukState, badukVariant, Color } from "./baduk";
 import { Grid } from "../lib/grid";
 import { Variant } from "../variant";
 
@@ -31,8 +31,7 @@ function color_to_player(color: Color) {
 }
 
 export const phantomVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: Phantom,
   description: "Baduk but other players stones are invisible",
-  defaultConfig: Baduk.defaultConfig,
-  getPlayerColors: Baduk.getPlayerColors,
 };

--- a/packages/shared/src/variants/quantum.ts
+++ b/packages/shared/src/variants/quantum.ts
@@ -2,7 +2,7 @@ import { AbstractGame } from "../abstract_game";
 import { BoardPattern } from "../lib/abstractBoard/boardFactory";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";
 import { Variant } from "../variant";
-import { Baduk, BadukBoard, BadukConfig, Color } from "./baduk";
+import { Baduk, BadukBoard, BadukConfig, badukVariant, Color } from "./baduk";
 import {
   NewBadukConfig,
   NewGridBadukConfig,
@@ -299,6 +299,7 @@ function copyBoard(game: Baduk): BadukBoard<Color> {
 }
 
 export const quantumVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: QuantumGo,
   description: "Two boards whose stones are entangled",
   defaultConfig(): NewGridBadukConfig {
@@ -307,5 +308,4 @@ export const quantumVariant: Variant<BadukConfig> = {
       komi: 7.5,
     };
   },
-  getPlayerColors: Baduk.getPlayerColors,
 };

--- a/packages/shared/src/variants/tetris.ts
+++ b/packages/shared/src/variants/tetris.ts
@@ -1,4 +1,4 @@
-import { Baduk, BadukConfig } from "./baduk";
+import { Baduk, BadukConfig, badukVariant } from "./baduk";
 import { Coordinate } from "../lib/coordinate";
 import { getGroup } from "../lib/group_utils";
 import { Variant } from "../variant";
@@ -14,8 +14,7 @@ export class TetrisGo extends Baduk {
 }
 
 export const tetrisVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: TetrisGo,
   description: "Baduk but players can't play Tetris shapes",
-  defaultConfig: Baduk.defaultConfig,
-  getPlayerColors: Baduk.getPlayerColors,
 };

--- a/packages/shared/src/variants/thue_morse.ts
+++ b/packages/shared/src/variants/thue_morse.ts
@@ -1,5 +1,5 @@
 import { Variant } from "../variant";
-import { Baduk, BadukConfig } from "./baduk";
+import { Baduk, BadukConfig, badukVariant } from "./baduk";
 
 export class ThueMorse extends Baduk {
   private move_number = 0;
@@ -33,8 +33,7 @@ function count_binary_ones(n: number) {
 }
 
 export const thueMorseVariant: Variant<BadukConfig> = {
+  ...badukVariant,
   gameClass: ThueMorse,
   description: "Baduk with move order according to Thue-Morse sequence",
-  defaultConfig: Baduk.defaultConfig,
-  getPlayerColors: Baduk.getPlayerColors,
 };


### PR DESCRIPTION
Problem: lots of this:

```
  defaultConfig: Baduk.defaultConfig,
  getPlayerColors: Baduk.getPlayerColors,
  // In the future
  sanitizeConfig: Baduk.sanitizeConfig,
  anotherProperty: Baduk.anotherProperty,
```

Not sure if this is the way, but I'm looking to prevent a bunch of copied code for Baduk-based variants.  Would love your thoughts.