### PR TITLE
Display upcoming moves in Thue-Morse and SFractional

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,5 +24,7 @@ export * from "./variants/baduk_utils";
 export * from "./lib/abstractBoard/boardFactory";
 export * from "./lib/abstractBoard/intersection";
 export * from "./variants/s_fractional";
+export { count_binary_ones } from "./variants/thue_morse";
+export { sFractionalMoveColors } from "./variants/s_fractional";
 
 export const SITE_NAME = "Go Variants";

--- a/packages/shared/src/variants/s_fractional.ts
+++ b/packages/shared/src/variants/s_fractional.ts
@@ -117,14 +117,7 @@ export class SFractional extends AbstractGame<
   }
 
   private nextStoneColors(): [Color, Color] {
-    const primaryColor = this.round % 2 === 0 ? "black" : "white";
-
-    const pairedRoundsIndex = Math.floor(this.round / 2);
-    const secondaryColor =
-      this.config.secondary_colors[
-        pairedRoundsIndex % this.config.secondary_colors.length
-      ];
-    return [primaryColor, secondaryColor];
+    return sFractionalMoveColors(this.round, this.config);
   }
 
   private playMoveInternal(move: Coordinate): void {
@@ -308,6 +301,23 @@ export class SFractional extends AbstractGame<
       secondary_colors: ["#0000FF", "#FF0000"],
     };
   }
+}
+
+/**
+ * Determines the colors of a stone in variant sfractional.
+ * @param round number of round when stone is or will be played.
+ * @param config config of a game instance
+ */
+export function sFractionalMoveColors(
+  round: number,
+  config: SFractionalConfig,
+): [Color, Color] {
+  const primaryColor = round % 2 === 0 ? "black" : "white";
+
+  const pairedRoundsIndex = Math.floor(round / 2);
+  const secondaryColor =
+    config.secondary_colors[pairedRoundsIndex % config.secondary_colors.length];
+  return [primaryColor, secondaryColor];
 }
 
 export const sFractionalVariant: Variant<SFractionalConfig> = {

--- a/packages/shared/src/variants/thue_morse.ts
+++ b/packages/shared/src/variants/thue_morse.ts
@@ -25,7 +25,12 @@ export class ThueMorse extends Baduk {
   }
 }
 
-function count_binary_ones(n: number) {
+/**
+ * Returns number of 1s in binary representation.
+ * Can be used to calculate the Thue-Morse sequence.
+ * @param n number to process
+ */
+export function count_binary_ones(n: number) {
   return n
     .toString(2)
     .split("")

--- a/packages/vue-client/src/components/GameView/PlayerSymbol.vue
+++ b/packages/vue-client/src/components/GameView/PlayerSymbol.vue
@@ -33,6 +33,7 @@ svg {
   margin: 10px;
   width: 40px;
   height: 40px;
-  filter: drop-shadow(3px 5px 6px rgb(0 0 0 / 0.4));
+  filter: drop-shadow(3px 5px 6px rgb(0 0 0 / 0.4))
+    drop-shadow(-3px -5px 6px rgb(255 255 255 / 0.4));
 }
 </style>

--- a/packages/vue-client/src/components/MoveSequenceDisplay.vue
+++ b/packages/vue-client/src/components/MoveSequenceDisplay.vue
@@ -40,6 +40,7 @@ const colors_range = computed(() => {
   flex-direction: row;
   gap: 5px;
   align-items: center;
+  flex-wrap: wrap;
 }
 .stone_preview {
   margin: 10px;

--- a/packages/vue-client/src/components/MoveSequenceDisplay.vue
+++ b/packages/vue-client/src/components/MoveSequenceDisplay.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
 
 const colors_range = computed(() => {
   const result = [];
-  for (var i = 0; i < props.length; i++) {
+  for (let i = 0; i < props.length; i++) {
     result.push(props.getColors(props.round + i));
   }
   return result;
@@ -25,7 +25,8 @@ const colors_range = computed(() => {
   <div class="moveSequenceDisplay">
     <font-awesome-icon icon="fa-solid fa-arrow-right" />
     <svg
-      v-for="colors of colors_range"
+      v-for="(colors, index) of colors_range"
+      v-bind:key="index"
       v-bind:viewBox="`0 0 2 2`"
       class="stone_preview"
     >

--- a/packages/vue-client/src/components/MoveSequenceDisplay.vue
+++ b/packages/vue-client/src/components/MoveSequenceDisplay.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import TaegeukStone from "./TaegeukStone.vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+
+library.add(faArrowRight);
+
+const props = defineProps<{
+  getColors: (n: number) => string[];
+  round: number;
+  length: number;
+}>();
+
+const colors_range = computed(() => {
+  const result = [];
+  for (var i = 0; i < props.length; i++) {
+    result.push(props.getColors(props.round + i));
+  }
+  return result;
+});
+</script>
+<template>
+  <div class="moveSequenceDisplay">
+    <font-awesome-icon icon="fa-solid fa-arrow-right" />
+    <svg
+      v-for="colors of colors_range"
+      v-bind:viewBox="`0 0 2 2`"
+      class="stone_preview"
+    >
+      <TaegeukStone v-if="colors" :colors="colors" :r="1" :cx="1" :cy="1" />
+    </svg>
+  </div>
+</template>
+
+<style scoped>
+.moveSequenceDisplay {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+  align-items: center;
+}
+.stone_preview {
+  margin: 10px;
+  width: 40px;
+  height: 40px;
+  filter: drop-shadow(3px 5px 6px rgb(0 0 0 / 0.4))
+    drop-shadow(-3px -5px 6px rgb(255 255 255 / 0.4));
+}
+</style>

--- a/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
@@ -33,7 +33,7 @@ function move(move: string) {
   />
   <div class="center_aligner">
     <MoveSequenceDisplay
-      :length="config.secondary_colors.length * 2"
+      :length="Math.min(8, config.secondary_colors.length * 2)"
       :round="displayed_round"
       :get-colors="getMoveColor"
     />

--- a/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import {
+  SFractionalConfig,
+  sFractionalMoveColors,
+  SFractionalState,
+} from "@ogfcommunity/variants-shared";
+import MoveSequenceDisplay from "../MoveSequenceDisplay.vue";
+import SFractionalBoardSelector from "../boards/SFractional/SFractionalBoardSelector.vue";
+
+const props = defineProps<{
+  gamestate: SFractionalState;
+  config: SFractionalConfig;
+  displayed_round: number;
+}>();
+
+function getMoveColor(n: number): string[] {
+  return sFractionalMoveColors(n, props.config);
+}
+
+const emit = defineEmits<{
+  (e: "move", move: string): void;
+}>();
+
+function move(move: string) {
+  emit("move", move);
+}
+</script>
+<template>
+  <SFractionalBoardSelector
+    :gamestate="$props.gamestate"
+    :config="$props.config"
+    v-on:move="move"
+  />
+  <div class="center_aligner">
+    <MoveSequenceDisplay
+      :length="config.secondary_colors.length * 2"
+      :round="displayed_round"
+      :get-colors="getMoveColor"
+    />
+  </div>
+</template>
+
+<style scoped>
+.center_aligner {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+}
+</style>

--- a/packages/vue-client/src/components/PlayingTable/ThueMorseTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/ThueMorseTable.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { BadukState, GridBadukConfig } from "@ogfcommunity/variants-shared";
+import BadukBoardSelector from "../boards/BadukBoardSelector.vue";
+import MoveSequenceDisplay from "../MoveSequenceDisplay.vue";
+import { count_binary_ones } from "@ogfcommunity/variants-shared";
+
+defineProps<{
+  gamestate: BadukState;
+  config: GridBadukConfig;
+  displayed_round: number;
+}>();
+
+function getThueMorseColor(n: number): string[] {
+  return [count_binary_ones(n) % 2 ? "white" : "black"];
+}
+
+const emit = defineEmits<{
+  (e: "move", move: string): void;
+}>();
+
+function move(move: string) {
+  emit("move", move);
+}
+</script>
+<template>
+  <BadukBoardSelector
+    :gamestate="$props.gamestate"
+    :config="$props.config"
+    v-on:move="move"
+  />
+  <div class="center_aligner">
+    <MoveSequenceDisplay
+      :length="4"
+      :round="displayed_round"
+      :get-colors="getThueMorseColor"
+    />
+  </div>
+</template>
+
+<style scoped>
+.center_aligner {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+}
+</style>

--- a/packages/vue-client/src/playing_table_map.ts
+++ b/packages/vue-client/src/playing_table_map.ts
@@ -1,4 +1,6 @@
 import { Component } from "vue";
+import ThueMorseTable from "./components/PlayingTable/ThueMorseTable.vue";
+import SFractionalTable from "./components/PlayingTable/SFractionalTable.vue";
 
 // This map can be used to set which component is displayed in the
 // GameView for a given variant. If there is no entry for a variant,
@@ -7,4 +9,7 @@ import { Component } from "vue";
 // board in GameView.
 export const playing_table_map: {
   [variant: string]: Component<{ config: unknown; gamestate: unknown }>;
-} = {};
+} = {
+  "thue-morse": ThueMorseTable,
+  sfractional: SFractionalTable,
+};

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -39,6 +39,7 @@ const variantGameView = computed(
 const variantDescriptionShort = computed(() => getDescription(variant.value));
 const user = useCurrentUser();
 const playing_as = ref<undefined | number>(undefined);
+const displayed_round = computed(() => view_round.value ?? current_round.value);
 
 function setNewState(stateResponse: GameStateResponse): void {
   state_map.set(
@@ -49,9 +50,7 @@ function setNewState(stateResponse: GameStateResponse): void {
     current_round.value = stateResponse.round;
   }
   if (
-    (view_round.value === stateResponse.round ||
-      (view_round.value === null &&
-        stateResponse.round === current_round.value)) &&
+    stateResponse.round === displayed_round.value &&
     playing_as.value === (stateResponse.seat ?? undefined)
   ) {
     game_state.value = stateResponse;
@@ -213,6 +212,7 @@ const createTimeControlPreview = (
       v-bind:is="variantGameView"
       v-bind:gamestate="game_state.state"
       v-bind:config="config"
+      v-bind:displayed_round="displayed_round"
       v-on:move="makeMove"
     />
     <NavButtons :gameRound="current_round" v-model="view_round" />


### PR DESCRIPTION
Here I added a component that can be used to display upcoming moves for variants with an unusual move sequence. I added a white shadow to stones displayed (also in the PlayerSymbol) to create contrast with dark-theme.

![grafik](https://github.com/user-attachments/assets/196aeb2c-8e3a-46b6-a842-bd3e3393d648)

![grafik](https://github.com/user-attachments/assets/8ab95ee8-b5e0-450b-a45e-6d2f202cc655)
