### PR TITLE
Sanitize config as soon as it comes from db.

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -8,6 +8,7 @@ import {
   GamesFilter,
   AbstractGame,
   GameStateResponse,
+  sanitizeConfig,
 } from "@ogfcommunity/variants-shared";
 import { ObjectId, WithId, Document, Filter } from "mongodb";
 import { getDb } from "./db";
@@ -331,11 +332,12 @@ async function BACKFILL_addEmptyPlayersArray(game: GameResponse) {
 }
 
 function outwardFacingGame(db_game: WithId<Document>): GameResponse {
+  const config = sanitizeConfig(db_game.variant, db_game.config);
   return {
     id: db_game._id.toString(),
     variant: db_game.variant,
     moves: db_game.moves,
-    config: db_game.config,
+    config,
     players: db_game.players,
     time_control: db_game.time_control,
   };

--- a/packages/shared/src/__tests__/game_map.test.ts
+++ b/packages/shared/src/__tests__/game_map.test.ts
@@ -3,6 +3,7 @@ import {
   getDescription,
   getVariantList,
   makeGameObject,
+  sanitizeConfig,
   supportsSGF,
 } from "../variant_map";
 
@@ -16,8 +17,10 @@ test.each(getVariantList())("Build %s from default config", (variant) => {
 
 test("invalid variants", () => {
   const variant = "invalid_variant";
+  const config = { foo: "bar " };
   expect(getDescription(variant)).toBe("");
   expect(supportsSGF(variant)).toBe(false);
+  expect(sanitizeConfig(variant, config)).toEqual(config);
 });
 
 test("deprecated field contains baduk", () => {

--- a/packages/shared/src/variant.ts
+++ b/packages/shared/src/variant.ts
@@ -8,4 +8,5 @@ export interface Variant<ConfigT extends object = object> {
   deprecated?: boolean;
   defaultConfig: () => ConfigT;
   getPlayerColors?: (config: ConfigT, playerNr: number) => string[];
+  sanitizeConfig?: (config: object) => ConfigT;
 }

--- a/packages/shared/src/variant_map.ts
+++ b/packages/shared/src/variant_map.ts
@@ -70,6 +70,17 @@ export function getDefaultConfig(variant: string): object {
   return variant_map[variant]?.defaultConfig();
 }
 
+export function sanitizeConfig(
+  variant: string,
+  config: object,
+): object | undefined {
+  const sanitize = variant_map[variant]?.sanitizeConfig;
+  if (sanitize == null) {
+    return config;
+  }
+  return sanitize(config);
+}
+
 export function supportsSGF(variant: string) {
   return Boolean(variant_map[variant]?.gameClass.prototype.getSGF);
 }

--- a/packages/shared/src/variants/__tests__/baduk.test.ts
+++ b/packages/shared/src/variants/__tests__/baduk.test.ts
@@ -1,4 +1,5 @@
 import { Baduk, Color } from "../baduk";
+import { mapToNewConfig } from "../baduk_utils";
 import { KoError } from "../../lib/ko_detector";
 
 const B = Color.BLACK;
@@ -199,4 +200,15 @@ test("Capture test", () => {
 test("Board too big", () => {
   // SGF encoding only supports up to 52
   expect(() => new Baduk({ width: 500, height: 500, komi: 0 })).toThrow();
+});
+
+test("mapToNewConfig preserves extra fields", () => {
+  const legacyConfig = {
+    extra: "data",
+    width: 2,
+    height: 3,
+    komi: 5.5,
+  };
+  const newConfig = mapToNewConfig(legacyConfig);
+  expect(newConfig.extra).toEqual("data");
 });

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -54,7 +54,7 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
   protected sgf?: SgfRecorder;
 
   constructor(config: BadukConfig) {
-    super(isLegacyBadukConfig(config) ? mapToNewConfig(config) : config);
+    super(Baduk.sanitizeConfig(config));
 
     if (isGridBadukConfig(this.config)) {
       if (this.config.board.width >= 52 || this.config.board.height >= 52) {
@@ -252,6 +252,15 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
         return [];
     }
   }
+
+  static sanitizeConfig(config: unknown): NewBadukConfig {
+    const badukConfig = config as BadukConfig;
+    return (
+      isLegacyBadukConfig(badukConfig)
+        ? mapToNewConfig(badukConfig)
+        : badukConfig
+    ) as NewBadukConfig;
+  }
 }
 
 /** Returns true if the group containing (x, y) has at least one liberty. */
@@ -282,10 +291,13 @@ export class GridBaduk extends Baduk {
   }
 }
 
-export const badukVariant: Variant<BadukConfig> = {
+export const badukVariant: Variant<NewBadukConfig> = {
   gameClass: Baduk,
   description:
     "Traditional game of Baduk a.k.a. Go, Weiqi\n Surround stones to capture them\n Secure more territory + captures to win",
   defaultConfig: Baduk.defaultConfig,
   getPlayerColors: Baduk.getPlayerColors,
+  sanitizeConfig: Baduk.sanitizeConfig,
 };
+
+export const gridBadukVariant = badukVariant as Variant<NewGridBadukConfig>;

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -255,11 +255,9 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
 
   static sanitizeConfig(config: unknown): NewBadukConfig {
     const badukConfig = config as BadukConfig;
-    return (
-      isLegacyBadukConfig(badukConfig)
-        ? mapToNewConfig(badukConfig)
-        : badukConfig
-    ) as NewBadukConfig;
+    return isLegacyBadukConfig(badukConfig)
+      ? mapToNewConfig(badukConfig)
+      : badukConfig;
   }
 }
 

--- a/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
+++ b/packages/shared/src/variants/badukWithAbstractBoard/badukWithAbstractBoard.ts
@@ -1,6 +1,7 @@
-import { Baduk, BadukConfig } from "../baduk";
+import { Baduk } from "../baduk";
 import { BoardConfig } from "../../lib/abstractBoard/boardFactory";
 import { Variant } from "../../variant";
+import { NewBadukConfig } from "../baduk_utils";
 
 export enum BoardPattern {
   Unknown = 0,
@@ -48,7 +49,7 @@ function mapToNewBoardConfig(
 
 export function mapToNewBadukConfig(
   config: BadukWithAbstractBoardConfig,
-): BadukConfig {
+): NewBadukConfig {
   return { komi: config.komi, board: mapToNewBoardConfig(config) };
 }
 

--- a/packages/shared/src/variants/baduk_utils.ts
+++ b/packages/shared/src/variants/baduk_utils.ts
@@ -49,7 +49,9 @@ export function isLegacyBadukConfig(
   );
 }
 
-export function mapToNewConfig(config: LegacyBadukConfig): NewBadukConfig {
+export function mapToNewConfig<ConfigT extends LegacyBadukConfig>(
+  config: LegacyBadukConfig,
+): ConfigT & NewGridBadukConfig {
   return {
     ...config,
     board: {
@@ -57,5 +59,7 @@ export function mapToNewConfig(config: LegacyBadukConfig): NewBadukConfig {
       width: config.width,
       height: config.height,
     },
-  };
+  } as ConfigT & NewGridBadukConfig;
+  // Generally `as` is not great in TypeScript, but I believe it's true that
+  // the output of this function will be the intersection of ConfigT and NewGridBadukConfig
 }

--- a/packages/shared/src/variants/baduk_utils.ts
+++ b/packages/shared/src/variants/baduk_utils.ts
@@ -49,9 +49,7 @@ export function isLegacyBadukConfig(
   );
 }
 
-export function mapToNewConfig<ConfigT extends LegacyBadukConfig>(
-  config: LegacyBadukConfig,
-): ConfigT & NewGridBadukConfig {
+export function mapToNewConfig(config: LegacyBadukConfig): NewGridBadukConfig {
   return {
     ...config,
     board: {
@@ -59,7 +57,5 @@ export function mapToNewConfig<ConfigT extends LegacyBadukConfig>(
       width: config.width,
       height: config.height,
     },
-  } as ConfigT & NewGridBadukConfig;
-  // Generally `as` is not great in TypeScript, but I believe it's true that
-  // the output of this function will be the intersection of ConfigT and NewGridBadukConfig
+  };
 }

--- a/packages/shared/src/variants/baduk_utils.ts
+++ b/packages/shared/src/variants/baduk_utils.ts
@@ -49,7 +49,9 @@ export function isLegacyBadukConfig(
   );
 }
 
-export function mapToNewConfig(config: LegacyBadukConfig): NewGridBadukConfig {
+export function mapToNewConfig<ConfigT extends LegacyBadukConfig>(
+  config: ConfigT,
+): ConfigT & NewGridBadukConfig {
   return {
     ...config,
     board: {

--- a/packages/shared/src/variants/capture.ts
+++ b/packages/shared/src/variants/capture.ts
@@ -1,5 +1,6 @@
 import { Variant } from "../variant";
-import { Baduk, BadukConfig, badukVariant } from "./baduk";
+import { Baduk, badukVariant } from "./baduk";
+import { NewBadukConfig } from "./baduk_utils";
 
 export class Capture extends Baduk {
   playMove(player: number, move: string): void {
@@ -15,7 +16,7 @@ export class Capture extends Baduk {
   }
 }
 
-export const captureVariant: Variant<BadukConfig> = {
+export const captureVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: Capture,
   description: "Baduk but the first player who captures a stone wins",

--- a/packages/shared/src/variants/freeze.ts
+++ b/packages/shared/src/variants/freeze.ts
@@ -1,14 +1,8 @@
 import { CoordinateLike } from "../lib/coordinate";
 import { getGroup, getOuterBorder } from "../lib/group_utils";
 import { Variant } from "../variant";
-import {
-  Baduk,
-  BadukBoard,
-  BadukConfig,
-  BadukState,
-  badukVariant,
-  Color,
-} from "./baduk";
+import { Baduk, BadukBoard, BadukState, badukVariant, Color } from "./baduk";
+import { NewBadukConfig } from "./baduk_utils";
 
 export interface FreezeGoState extends BadukState {
   frozen: boolean;
@@ -48,7 +42,7 @@ function is_in_atari(pos: CoordinateLike, board: BadukBoard<Color>) {
   return num_liberties === 1;
 }
 
-export const freezeGoVariant: Variant<BadukConfig> = {
+export const freezeGoVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: FreezeGo,
   description: "Baduk but after an Atari, stones can't be captured",

--- a/packages/shared/src/variants/keima.ts
+++ b/packages/shared/src/variants/keima.ts
@@ -1,6 +1,7 @@
 import { Coordinate } from "../lib/coordinate";
 import { Variant } from "../variant";
-import { BadukConfig, BadukState, badukVariant, GridBaduk } from "./baduk";
+import { BadukState, badukVariant, GridBaduk } from "./baduk";
+import { NewBadukConfig } from "./baduk_utils";
 
 export interface KeimaState extends BadukState {
   keima?: string;
@@ -66,7 +67,7 @@ function is_keima_shape(a: Coordinate, b: Coordinate) {
   return false;
 }
 
-export const keimaVariant: Variant<BadukConfig> = {
+export const keimaVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: Keima,
   description:

--- a/packages/shared/src/variants/one_color.ts
+++ b/packages/shared/src/variants/one_color.ts
@@ -1,5 +1,6 @@
 import { Variant } from "../variant";
-import { BadukState, Color, Baduk, BadukConfig, badukVariant } from "./baduk";
+import { BadukState, Color, Baduk, badukVariant } from "./baduk";
+import { NewBadukConfig } from "./baduk_utils";
 
 export class OneColorGo extends Baduk {
   exportState(): BadukState {
@@ -12,7 +13,7 @@ export class OneColorGo extends Baduk {
   }
 }
 
-export const oneColorGoVariant: Variant<BadukConfig> = {
+export const oneColorGoVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: OneColorGo,
   description: "Baduk with obfuscated stone colors",

--- a/packages/shared/src/variants/phantom.ts
+++ b/packages/shared/src/variants/phantom.ts
@@ -1,6 +1,7 @@
-import { Baduk, BadukConfig, BadukState, badukVariant, Color } from "./baduk";
+import { Baduk, BadukState, badukVariant, Color } from "./baduk";
 import { Grid } from "../lib/grid";
 import { Variant } from "../variant";
+import { NewBadukConfig } from "./baduk_utils";
 
 export class Phantom extends Baduk {
   exportState(player?: number): BadukState {
@@ -30,7 +31,7 @@ function color_to_player(color: Color) {
   }
 }
 
-export const phantomVariant: Variant<BadukConfig> = {
+export const phantomVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: Phantom,
   description: "Baduk but other players stones are invisible",

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -1,6 +1,6 @@
-import { Baduk, Color, GridBaduk } from "./baduk";
+import { Color, GridBaduk, gridBadukVariant } from "./baduk";
 import { Grid } from "../lib/grid";
-import { GridBadukConfig } from "./baduk_utils";
+import { GridBadukConfig, NewGridBadukConfig } from "./baduk_utils";
 import { Variant } from "../variant";
 
 export class PyramidGo extends GridBaduk {
@@ -45,10 +45,9 @@ export class PyramidGo extends GridBaduk {
   }
 }
 
-export const pyramidVariant: Variant<GridBadukConfig> = {
+export const pyramidVariant: Variant<NewGridBadukConfig> = {
+  ...gridBadukVariant,
   gameClass: PyramidGo,
   description:
     "Baduk with pyramid scoring\n Center is worth most points, edge the least",
-  defaultConfig: Baduk.defaultConfig,
-  getPlayerColors: Baduk.getPlayerColors,
 };

--- a/packages/shared/src/variants/quantum.ts
+++ b/packages/shared/src/variants/quantum.ts
@@ -24,7 +24,7 @@ export interface QuantumGoState {
 class BadukHelper {
   public badukGame: Baduk;
 
-  constructor(config: BadukConfig) {
+  constructor(config: NewBadukConfig) {
     this.badukGame = new Baduk(config);
   }
 
@@ -298,7 +298,7 @@ function copyBoard(game: Baduk): BadukBoard<Color> {
   return game.board.map((color) => color);
 }
 
-export const quantumVariant: Variant<BadukConfig> = {
+export const quantumVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: QuantumGo,
   description: "Two boards whose stones are entangled",

--- a/packages/shared/src/variants/tetris.ts
+++ b/packages/shared/src/variants/tetris.ts
@@ -1,7 +1,8 @@
-import { Baduk, BadukConfig, badukVariant } from "./baduk";
+import { Baduk, badukVariant } from "./baduk";
 import { Coordinate } from "../lib/coordinate";
 import { getGroup } from "../lib/group_utils";
 import { Variant } from "../variant";
+import { NewBadukConfig } from "./baduk_utils";
 
 export class TetrisGo extends Baduk {
   protected postValidateMove(move: Coordinate): void {
@@ -13,7 +14,7 @@ export class TetrisGo extends Baduk {
   }
 }
 
-export const tetrisVariant: Variant<BadukConfig> = {
+export const tetrisVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: TetrisGo,
   description: "Baduk but players can't play Tetris shapes",

--- a/packages/shared/src/variants/thue_morse.ts
+++ b/packages/shared/src/variants/thue_morse.ts
@@ -1,5 +1,6 @@
 import { Variant } from "../variant";
-import { Baduk, BadukConfig, badukVariant } from "./baduk";
+import { Baduk, badukVariant } from "./baduk";
+import { NewBadukConfig } from "./baduk_utils";
 
 export class ThueMorse extends Baduk {
   private move_number = 0;
@@ -32,7 +33,7 @@ function count_binary_ones(n: number) {
     .filter((digit) => digit === "1").length;
 }
 
-export const thueMorseVariant: Variant<BadukConfig> = {
+export const thueMorseVariant: Variant<NewBadukConfig> = {
   ...badukVariant,
   gameClass: ThueMorse,
   description: "Baduk with move order according to Thue-Morse sequence",


### PR DESCRIPTION
Currently, we sanitize configs *inside* the Game objects, but there are other places that access configs.  (e.g. GameView).  Let's sanitize outwardFacingGame so that we can always assume we have a modern config.