### PR TITLE
add score board in multicolor boards

### DIFF
--- a/packages/vue-client/src/components/boards/BadukGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukGraphBoard.vue
@@ -6,7 +6,6 @@ import {
 } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import MulticolorGraphBoard from "./MulticolorGraphBoard.vue";
-import { UnicolorStone } from "./board_types";
 
 const props = defineProps<{
   gamestate: BadukState;
@@ -34,12 +33,12 @@ const score_board = computed(() => {
   }
 
   return (props.gamestate.score_board.at(0) ?? []).map(
-    (color): UnicolorStone | null => {
+    (color): string[] | null => {
       switch (color) {
         case Color.BLACK:
-          return { color: "black", annotation: undefined };
+          return ["black"];
         case Color.WHITE:
-          return { color: "white", annotation: undefined };
+          return ["white"];
         case Color.EMPTY:
           return null;
       }

--- a/packages/vue-client/src/components/boards/BadukGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/BadukGraphBoard.vue
@@ -6,6 +6,7 @@ import {
 } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import MulticolorGraphBoard from "./MulticolorGraphBoard.vue";
+import { UnicolorStone } from "./board_types";
 
 const props = defineProps<{
   gamestate: BadukState;
@@ -27,6 +28,25 @@ const board = computed(() => {
   });
 });
 
+const score_board = computed(() => {
+  if (!props.gamestate.score_board) {
+    return undefined;
+  }
+
+  return (props.gamestate.score_board.at(0) ?? []).map(
+    (color): UnicolorStone | null => {
+      switch (color) {
+        case Color.BLACK:
+          return { color: "black", annotation: undefined };
+        case Color.WHITE:
+          return { color: "white", annotation: undefined };
+        case Color.EMPTY:
+          return null;
+      }
+    },
+  );
+});
+
 const emit = defineEmits<{
   (e: "move", move: string): void;
 }>();
@@ -40,6 +60,7 @@ function click(index: number) {
   <MulticolorGraphBoard
     :board="board"
     :board_config="$props.config.board"
+    :score_board="score_board"
     @click="click"
   />
 </template>

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -8,13 +8,14 @@ import {
   Intersection,
   createGraph,
 } from "@ogfcommunity/variants-shared";
-import { MulticolorStone, UnicolorStone } from "./board_types";
+import { MulticolorStone } from "./board_types";
+import ScoreMark from "./ScoreMark.vue";
 
 const props = defineProps<{
   board: (MulticolorStone | null)[];
   background_color?: string;
   board_config: BoardConfig;
-  score_board?: (UnicolorStone | null)[];
+  score_board?: (string[] | null)[];
 }>();
 
 const intersections = computed(() =>
@@ -107,16 +108,11 @@ const viewBox = computed(() => {
     </g>
     <g v-if="score_board">
       <template v-for="(intersection, index) in intersections" :key="index">
-        <rect
+        <ScoreMark
           v-if="score_board?.at(index)"
-          v-bind:x="intersection.position.X - 0.2"
-          v-bind:y="intersection.position.Y - 0.2"
-          v-bind:fill="score_board[index]?.color"
-          stroke="gray"
-          stroke-width="0.05"
-          width="0.4"
-          height="0.4"
-          opacity="0.6"
+          :colors="score_board[index]"
+          :cx="intersection.position.X"
+          :cy="intersection.position.Y"
         />
       </template>
     </g>

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -110,7 +110,7 @@ const viewBox = computed(() => {
       <template v-for="(intersection, index) in intersections" :key="index">
         <ScoreMark
           v-if="score_board?.at(index)"
-          :colors="score_board[index]"
+          :colors="score_board[index]!"
           :cx="intersection.position.X"
           :cy="intersection.position.Y"
         />

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -8,12 +8,13 @@ import {
   Intersection,
   createGraph,
 } from "@ogfcommunity/variants-shared";
-import { MulticolorStone } from "./board_types";
+import { MulticolorStone, UnicolorStone } from "./board_types";
 
 const props = defineProps<{
   board: (MulticolorStone | null)[];
   background_color?: string;
   board_config: BoardConfig;
+  score_board?: (UnicolorStone | null)[];
 }>();
 
 const intersections = computed(() =>
@@ -103,6 +104,21 @@ const viewBox = computed(() => {
         :r="0.48"
         :annotation="props.board.at(index)?.annotation!"
       />
+    </g>
+    <g v-if="score_board">
+      <template v-for="(intersection, index) in intersections" :key="index">
+        <rect
+          v-if="score_board?.at(index)"
+          v-bind:x="intersection.position.X - 0.2"
+          v-bind:y="intersection.position.Y - 0.2"
+          v-bind:fill="score_board[index]?.color"
+          stroke="gray"
+          stroke-width="0.05"
+          width="0.4"
+          height="0.4"
+          opacity="0.6"
+        />
+      </template>
     </g>
     <g>
       <rect

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -98,8 +98,8 @@ function positionHovered(pos: Coordinate) {
     </g>
     <g v-if="score_board">
       <ScoreMark
-        v-for="pos in positions.filter((pos) => score_board![pos.y][pos.x] !== null)"
-        v-bind:key="pos"
+        v-for="(pos, index) in positions.filter((pos) => score_board![pos.y][pos.x] !== null)"
+        v-bind:key="index"
         :colors="score_board![pos.y][pos.x]!"
         :cx="pos.x"
         :cy="pos.y"

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -99,7 +99,7 @@ function positionHovered(pos: Coordinate) {
     <g v-if="score_board">
       <ScoreMark
         v-for="pos in positions.filter((pos) => score_board![pos.y][pos.x] !== null)"
-        :colors="score_board![pos.y][pos.x]"
+        :colors="score_board![pos.y][pos.x]!"
         :cx="pos.x"
         :cy="pos.y"
       />

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -99,6 +99,7 @@ function positionHovered(pos: Coordinate) {
     <g v-if="score_board">
       <ScoreMark
         v-for="pos in positions.filter((pos) => score_board![pos.y][pos.x] !== null)"
+        v-bind:key="pos"
         :colors="score_board![pos.y][pos.x]!"
         :cx="pos.x"
         :cy="pos.y"

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -4,13 +4,14 @@ import TaegeukStone from "../TaegeukStone.vue";
 import IntersectionAnnotation from "../IntersectionAnnotation.vue";
 import { Coordinate } from "@ogfcommunity/variants-shared";
 import { positionsGetter } from "./board_utils";
-import { MulticolorStone, UnicolorStone } from "./board_types";
+import { MulticolorStone } from "./board_types";
+import ScoreMark from "./ScoreMark.vue";
 
 const props = defineProps<{
   board: (MulticolorStone | null)[][];
   background_color?: string;
   board_dimensions: { width: number; height: number };
-  score_board?: (UnicolorStone | null)[][];
+  score_board?: (string[] | null)[][];
 }>();
 
 const width = computed(() => props.board_dimensions.width);
@@ -96,17 +97,11 @@ function positionHovered(pos: Coordinate) {
       />
     </g>
     <g v-if="score_board">
-      <rect
+      <ScoreMark
         v-for="pos in positions.filter((pos) => score_board![pos.y][pos.x] !== null)"
-        :key="`${pos.x}${pos.y}`"
-        v-bind:x="pos.x - 0.2"
-        v-bind:y="pos.y - 0.2"
-        v-bind:fill="score_board![pos.y][pos.x]!.color"
-        stroke="gray"
-        stroke-width="0.05"
-        width="0.4"
-        height="0.4"
-        opacity="0.6"
+        :colors="score_board![pos.y][pos.x]"
+        :cx="pos.x"
+        :cy="pos.y"
       />
     </g>
     <g>

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -4,12 +4,13 @@ import TaegeukStone from "../TaegeukStone.vue";
 import IntersectionAnnotation from "../IntersectionAnnotation.vue";
 import { Coordinate } from "@ogfcommunity/variants-shared";
 import { positionsGetter } from "./board_utils";
-import { MulticolorStone } from "./board_types";
+import { MulticolorStone, UnicolorStone } from "./board_types";
 
 const props = defineProps<{
   board: (MulticolorStone | null)[][];
   background_color?: string;
   board_dimensions: { width: number; height: number };
+  score_board?: (UnicolorStone | null)[][];
 }>();
 
 const width = computed(() => props.board_dimensions.width);
@@ -92,6 +93,20 @@ function positionHovered(pos: Coordinate) {
         :cy="y"
         :r="0.48"
         :annotation="props.board[y][x]?.annotation!"
+      />
+    </g>
+    <g v-if="score_board">
+      <rect
+        v-for="pos in positions.filter((pos) => score_board![pos.y][pos.x] !== null)"
+        :key="`${pos.x}${pos.y}`"
+        v-bind:x="pos.x - 0.2"
+        v-bind:y="pos.y - 0.2"
+        v-bind:fill="score_board![pos.y][pos.x]!.color"
+        stroke="gray"
+        stroke-width="0.05"
+        width="0.4"
+        height="0.4"
+        opacity="0.6"
       />
     </g>
     <g>

--- a/packages/vue-client/src/components/boards/SFractional/SFractionalGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/SFractional/SFractionalGraphBoard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SFractionalState } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
-import { MulticolorStone } from "../board_types";
+import { MulticolorStone, UnicolorStone } from "../board_types";
 import MulticolorGraphBoard from "../MulticolorGraphBoard.vue";
 import { BoardConfig } from "@ogfcommunity/variants-shared";
 
@@ -19,6 +19,16 @@ const board = computed(() => {
   }));
 });
 
+const score_board = computed(() => {
+  if (!props.gamestate.scoreBoard) {
+    return undefined;
+  }
+
+  return (props.gamestate.scoreBoard.at(0) ?? []).map(
+    (color): UnicolorStone | null => (color !== "" ? { color: color } : null),
+  );
+});
+
 const emit = defineEmits<{
   (e: "move", move: string): void;
 }>();
@@ -32,6 +42,7 @@ function click(index: number) {
   <MulticolorGraphBoard
     :board="board"
     :board_config="$props.boardConfig"
+    :score_board="score_board"
     @click="click"
   />
 </template>

--- a/packages/vue-client/src/components/boards/SFractional/SFractionalGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/SFractional/SFractionalGraphBoard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SFractionalState } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
-import { MulticolorStone, UnicolorStone } from "../board_types";
+import { MulticolorStone } from "../board_types";
 import MulticolorGraphBoard from "../MulticolorGraphBoard.vue";
 import { BoardConfig } from "@ogfcommunity/variants-shared";
 
@@ -25,7 +25,7 @@ const score_board = computed(() => {
   }
 
   return (props.gamestate.scoreBoard.at(0) ?? []).map(
-    (color): UnicolorStone | null => (color !== "" ? { color: color } : null),
+    (color): string[] | null => (color !== "" ? [color] : null),
   );
 });
 

--- a/packages/vue-client/src/components/boards/SFractional/SFractionalGridBoard.vue
+++ b/packages/vue-client/src/components/boards/SFractional/SFractionalGridBoard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SFractionalState } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
-import { MulticolorStone, UnicolorStone } from "../board_types";
+import { MulticolorStone } from "../board_types";
 import MulticolorGridBoard from "../MulticolorGridBoard.vue";
 import { Coordinate, GridBoardConfig } from "@ogfcommunity/variants-shared";
 
@@ -27,9 +27,7 @@ const score_board = computed(() => {
   }
 
   return props.gamestate.scoreBoard.map((row) =>
-    row.map((color): UnicolorStone | null =>
-      color !== "" ? { color: color } : null,
-    ),
+    row.map((color): string[] | null => (color !== "" ? [color] : null)),
   );
 });
 

--- a/packages/vue-client/src/components/boards/SFractional/SFractionalGridBoard.vue
+++ b/packages/vue-client/src/components/boards/SFractional/SFractionalGridBoard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { SFractionalState } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
-import { MulticolorStone } from "../board_types";
+import { MulticolorStone, UnicolorStone } from "../board_types";
 import MulticolorGridBoard from "../MulticolorGridBoard.vue";
 import { Coordinate, GridBoardConfig } from "@ogfcommunity/variants-shared";
 
@@ -21,6 +21,18 @@ const board = computed(() => {
   );
 });
 
+const score_board = computed(() => {
+  if (!props.gamestate.scoreBoard) {
+    return undefined;
+  }
+
+  return props.gamestate.scoreBoard.map((row) =>
+    row.map((color): UnicolorStone | null =>
+      color !== "" ? { color: color } : null,
+    ),
+  );
+});
+
 const emit = defineEmits<{
   (e: "move", move: string): void;
 }>();
@@ -34,6 +46,7 @@ function click(pos: Coordinate) {
   <MulticolorGridBoard
     :board_dimensions="board_dimensions"
     :board="board"
+    :score_board="score_board"
     @click="click"
   />
 </template>

--- a/packages/vue-client/src/components/boards/ScoreMark.vue
+++ b/packages/vue-client/src/components/boards/ScoreMark.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const width = 0.4;
+const height = 0.4;
+const stroke_width = 0.05;
+
+const props = defineProps<{
+  colors: string[];
+  cx: number;
+  cy: number;
+}>();
+
+const segmentHeight = computed(
+  () => +(height / props.colors.length).toFixed(3),
+);
+</script>
+
+<template>
+  <rect
+    v-bind:x="cx - (width + stroke_width) / 2"
+    v-bind:y="cy - (height + stroke_width) / 2"
+    stroke="gray"
+    v-bind:stroke-width="stroke_width"
+    v-bind:width="width + stroke_width"
+    v-bind:height="height + stroke_width"
+    fill-opacity="0.0"
+    opacity="0.6"
+  />
+  <rect
+    v-for="(color, index) of colors"
+    v-bind:x="cx - 0.2"
+    v-bind:y="cy - 0.2 + segmentHeight * index"
+    v-bind:fill="color"
+    v-bind:width="width"
+    v-bind:height="segmentHeight"
+    opacity="0.6"
+  />
+</template>

--- a/packages/vue-client/src/components/boards/ScoreMark.vue
+++ b/packages/vue-client/src/components/boards/ScoreMark.vue
@@ -29,7 +29,7 @@ const segmentHeight = computed(() => +(height / props.colors.length));
     v-for="(color, index) of colors"
     v-bind:key="index"
     v-bind:x="cx - width / 2"
-    v-bind:y="cy - width / 2 + segmentHeight * index"
+    v-bind:y="cy - height / 2 + segmentHeight * index"
     v-bind:fill="color"
     v-bind:width="width"
     v-bind:height="segmentHeight"

--- a/packages/vue-client/src/components/boards/ScoreMark.vue
+++ b/packages/vue-client/src/components/boards/ScoreMark.vue
@@ -11,9 +11,7 @@ const props = defineProps<{
   cy: number;
 }>();
 
-const segmentHeight = computed(
-  () => +(height / props.colors.length).toFixed(3),
-);
+const segmentHeight = computed(() => +(height / props.colors.length));
 </script>
 
 <template>
@@ -29,6 +27,7 @@ const segmentHeight = computed(
   />
   <rect
     v-for="(color, index) of colors"
+    v-bind:key="index"
     v-bind:x="cx - 0.2"
     v-bind:y="cy - 0.2 + segmentHeight * index"
     v-bind:fill="color"

--- a/packages/vue-client/src/components/boards/ScoreMark.vue
+++ b/packages/vue-client/src/components/boards/ScoreMark.vue
@@ -28,8 +28,8 @@ const segmentHeight = computed(() => +(height / props.colors.length));
   <rect
     v-for="(color, index) of colors"
     v-bind:key="index"
-    v-bind:x="cx - 0.2"
-    v-bind:y="cy - 0.2 + segmentHeight * index"
+    v-bind:x="cx - width / 2"
+    v-bind:y="cy - width / 2 + segmentHeight * index"
     v-bind:fill="color"
     v-bind:width="width"
     v-bind:height="segmentHeight"

--- a/packages/vue-client/src/components/boards/board_types.ts
+++ b/packages/vue-client/src/components/boards/board_types.ts
@@ -2,8 +2,3 @@ export interface MulticolorStone {
   colors: string[];
   annotation?: "CR" | "MA";
 }
-
-export interface UnicolorStone {
-  color: string;
-  annotation?: "CR" | "MA";
-}

--- a/packages/vue-client/src/components/boards/board_types.ts
+++ b/packages/vue-client/src/components/boards/board_types.ts
@@ -2,3 +2,8 @@ export interface MulticolorStone {
   colors: string[];
   annotation?: "CR" | "MA";
 }
+
+export interface UnicolorStone {
+  color: string;
+  annotation?: "CR" | "MA";
+}


### PR DESCRIPTION
This adds score boards to multicolor boards. ~~Only unicolor score because I did not know how to best display a multicolor score marking (rectangle), but I believe for all our current variants, this is sufficient.~~ <- added multicolor score markings

Also I didn't implement the mapping from game state in all boards - I'm thinking we should probably try to reduce the number of board implementations, I'm just unsure how.

This is one step for #137

![grafik](https://github.com/user-attachments/assets/9047b317-b2a4-490a-b01a-b42d612a22b3)

On graph boards it looks a bit funny, maybe due to rounding problems (?)

![grafik](https://github.com/user-attachments/assets/dab2cbb7-2508-480b-89ff-e17376de9c6d)
