### PR TITLE
Add enforce-style-attribute lint rule

### DIFF
--- a/packages/vue-client/.eslintrc.cjs
+++ b/packages/vue-client/.eslintrc.cjs
@@ -18,5 +18,6 @@ module.exports = {
         varsIgnorePattern: "^_",
       },
     ],
+    "vue/enforce-style-attribute": "error",
   },
 };

--- a/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
@@ -36,7 +36,7 @@ function setBoardConfig(boardConfig: BoardConfig): void {
   </form>
 </template>
 
-<style>
+<style scoped>
 input {
   width: fit-content;
 }

--- a/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
@@ -88,7 +88,7 @@ watch(patternRef, () => {
   </div>
 </template>
 
-<style>
+<style scoped>
 input {
   width: fit-content;
 }

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -37,7 +37,7 @@ function emitConfigChange() {
   </form>
 </template>
 
-<style>
+<style scoped>
 input {
   width: fit-content;
 }

--- a/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
+++ b/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
@@ -111,7 +111,7 @@ const setTimeControlConfig = (
   </div>
 </template>
 
-<style>
+<style scoped>
 textarea {
   width: 300px;
   height: 150px;

--- a/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
@@ -30,7 +30,7 @@ function emitConfigChange() {
   </form>
 </template>
 
-<style>
+<style scoped>
 input {
   width: fit-content;
 }

--- a/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
@@ -110,7 +110,7 @@ function emitConfigChange() {
   </form>
 </template>
 
-<style>
+<style scoped>
 input {
   width: fit-content;
 }

--- a/packages/vue-client/src/components/GameView/SeatComponent.vue
+++ b/packages/vue-client/src/components/GameView/SeatComponent.vue
@@ -77,7 +77,7 @@ const time_config = computed(
   </div>
 </template>
 
-<style>
+<style scoped>
 .seat {
   border-radius: 10px;
   border: 2px solid gray;

--- a/packages/vue-client/src/components/GamesFilterForm.vue
+++ b/packages/vue-client/src/components/GamesFilterForm.vue
@@ -42,7 +42,7 @@ const filter = computed(() => {
   </form>
 </template>
 
-<style>
+<style scoped>
 .gamesFilterForm {
   display: flex;
   flex-direction: row;

--- a/packages/vue-client/src/views/AboutView.vue
+++ b/packages/vue-client/src/views/AboutView.vue
@@ -16,7 +16,7 @@
   </main>
 </template>
 
-<style>
+<style scoped>
 @media (min-width: 1024px) {
   .about {
     min-height: 100vh;

--- a/packages/vue-client/src/views/LoginView.vue
+++ b/packages/vue-client/src/views/LoginView.vue
@@ -61,7 +61,7 @@ const submit = () =>
   </main>
 </template>
 
-<style>
+<style scoped>
 .error {
   color: red;
 }

--- a/packages/vue-client/src/views/RegisterView.vue
+++ b/packages/vue-client/src/views/RegisterView.vue
@@ -55,7 +55,7 @@ const submit = () =>
   </main>
 </template>
 
-<style>
+<style scoped>
 .error {
   color: red;
 }

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -23,7 +23,7 @@ function toUpperCaseFirstLetter(string: string) {
   </div>
 </template>
 
-<style>
+<style scoped>
 .rules-page {
   font-family: "helvetica", "arial", "sans-serif";
 }


### PR DESCRIPTION
Inspired by  #298, `scoped` seems to be best practice.  Let's enforce it everywhere.
