### PR TITLE
Validate if there are follow-up moves in Keima variant

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,7 +18,7 @@ export {
   type FractionalConfig,
   type FractionalState,
 } from "./variants/fractional";
-export { type KeimaState } from "./variants/keima";
+export { type KeimaState, getKeimaMoves } from "./variants/keima";
 export * from "./variants/drift";
 export * from "./variants/baduk_utils";
 export * from "./lib/abstractBoard/boardFactory";

--- a/packages/shared/src/variants/__tests__/keima.test.ts
+++ b/packages/shared/src/variants/__tests__/keima.test.ts
@@ -6,7 +6,7 @@ const _ = Color.EMPTY;
 const W = Color.WHITE;
 
 test("Play a game - wrong player", () => {
-  const game = new Keima({ width: 2, height: 2, komi: 0.5 });
+  const game = new Keima({ width: 3, height: 3, komi: 0.5 });
 
   expect(game.nextToPlay()).toEqual([0]);
   game.playMove(0, "aa");
@@ -15,7 +15,7 @@ test("Play a game - wrong player", () => {
 });
 
 test("Play a game - non keima move throws", () => {
-  const game = new Keima({ width: 2, height: 2, komi: 0.5 });
+  const game = new Keima({ width: 3, height: 3, komi: 0.5 });
 
   game.playMove(0, "aa");
   expect(() => game.playMove(0, "bb")).toThrow("Knight's move");
@@ -43,4 +43,29 @@ test("Play a game", () => {
     [B, _, W, _],
     [_, _, _, _],
   ]);
+});
+
+test("No possible follow-up moves throws", () => {
+  const game = new Keima({ width: 4, height: 4, komi: 0.5 });
+
+  game.playMove(0, "ac");
+  game.playMove(0, "cb");
+  game.playMove(1, "pass");
+  game.playMove(0, "cc");
+  game.playMove(0, "ab");
+  game.playMove(1, "pass");
+  game.playMove(0, "bb");
+  game.playMove(0, "da");
+  game.playMove(1, "pass");
+  game.playMove(0, "bd");
+  game.playMove(0, "dc");
+
+  expect(game.exportState().board).toEqual([
+    [_, _, _, B],
+    [B, B, B, _],
+    [B, _, B, B],
+    [_, B, _, _],
+  ]);
+
+  expect(() => game.playMove(1, "dd")).toThrow();
 });

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -145,6 +145,12 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
     return { pass: "Pass", resign: "Resign" };
   }
 
+  /**
+   * Places a stone at the board and resolves captures.
+   * Mutates only the internal board property (important for
+   * certain inheriting classes)
+   * @param move the coordinate of the added stone
+   */
   protected playMoveInternal(move: Coordinate): void {
     this.board.set(move, this.next_to_play === 0 ? Color.BLACK : Color.WHITE);
 

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -148,7 +148,7 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
   /**
    * Places a stone at the board and resolves captures.
    * Mutates only the internal board property (important for
-   * certain inheriting classes)
+   * some inheriting classes e.g. keima)
    * @param move the coordinate of the added stone
    */
   protected playMoveInternal(move: Coordinate): void {

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -145,7 +145,7 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
     return { pass: "Pass", resign: "Resign" };
   }
 
-  private playMoveInternal(move: Coordinate): void {
+  protected playMoveInternal(move: Coordinate): void {
     this.board.set(move, this.next_to_play === 0 ? Color.BLACK : Color.WHITE);
 
     const opponent_color = this.next_to_play === 0 ? Color.WHITE : Color.BLACK;

--- a/packages/shared/src/variants/keima.ts
+++ b/packages/shared/src/variants/keima.ts
@@ -3,6 +3,7 @@ import { Grid } from "../lib/grid";
 import { getGroup } from "../lib/group_utils";
 import { Variant } from "../variant";
 import {
+  BadukConfig,
   BadukState,
   badukVariant,
   Color,
@@ -17,6 +18,13 @@ export interface KeimaState extends BadukState {
 
 export class Keima extends GridBaduk {
   private move_number = 0;
+
+  constructor(config: BadukConfig) {
+    super(config);
+    if (this.config.board.height < 3 && this.config.board.width < 3) {
+      throw new Error("Minimum board vor Keima is 3x2");
+    }
+  }
 
   playMove(player: number, move: string): void {
     super.playMove(player, move);

--- a/packages/shared/src/variants/keima.ts
+++ b/packages/shared/src/variants/keima.ts
@@ -1,6 +1,14 @@
 import { Coordinate } from "../lib/coordinate";
+import { Grid } from "../lib/grid";
+import { getGroup } from "../lib/group_utils";
 import { Variant } from "../variant";
-import { BadukState, badukVariant, GridBaduk } from "./baduk";
+import {
+  BadukState,
+  badukVariant,
+  Color,
+  GridBaduk,
+  groupHasLiberties,
+} from "./baduk";
 import { NewBadukConfig } from "./baduk_utils";
 
 export interface KeimaState extends BadukState {
@@ -12,15 +20,19 @@ export class Keima extends GridBaduk {
 
   playMove(player: number, move: string): void {
     super.playMove(player, move);
+    if (move === "pass") {
+      if (is_keima_move_number(this.move_number)) {
+        throw new Error("Can't pass during keima move");
+      }
+      // increment an additional time, so pass is handled like one
+      // keima (i.e. two moves)
+      this.move_number++;
+    }
     this.increment_next_to_play();
   }
 
   protected postValidateMove(move: Coordinate): void {
     super.postValidateMove(move);
-
-    if (this.last_move === "pass") {
-      return;
-    }
 
     if (is_keima_move_number(this.move_number)) {
       const curr = move;
@@ -30,6 +42,24 @@ export class Keima extends GridBaduk {
           "Second move must form a Keima (Knight's move) with the first move!",
         );
       }
+    } else if (
+      // check if there are any legal follow-up moves
+      getKeimaMoves(move, this.board).every((pos) => {
+        const boardCopy = this.board.map((x) => x);
+        // simulate a move
+        this.playMoveInternal(pos);
+        // this only checks if the follow-up move is suicidal, but it could also
+        // potentially be illegal due to ko.
+        const isSuicidal = !groupHasLiberties(
+          getGroup(pos, this.board),
+          this.board,
+        );
+        // reset board
+        this.board = boardCopy;
+        return isSuicidal;
+      })
+    ) {
+      throw new Error("There is no legal follow-up move.");
     }
   }
 
@@ -46,6 +76,12 @@ export class Keima extends GridBaduk {
           ? this.last_move
           : undefined,
     };
+  }
+
+  specialMoves(): { [key: string]: string } {
+    return is_keima_move_number(this.move_number)
+      ? { resign: "Resign" }
+      : super.specialMoves();
   }
 }
 
@@ -65,6 +101,25 @@ function is_keima_shape(a: Coordinate, b: Coordinate) {
     return true;
   }
   return false;
+}
+
+export function getKeimaMoves(
+  { x, y }: Coordinate,
+  board: Grid<Color>,
+): Coordinate[] {
+  const moves = [
+    new Coordinate(x + 1, y + 2),
+    new Coordinate(x - 1, y + 2),
+    new Coordinate(x + 1, y - 2),
+    new Coordinate(x - 1, y - 2),
+    new Coordinate(x + 2, y + 1),
+    new Coordinate(x - 2, y + 1),
+    new Coordinate(x + 2, y - 1),
+    new Coordinate(x - 2, y - 1),
+  ];
+  return moves
+    .filter((pos) => board.isInBounds(pos))
+    .filter((pos) => board.at(pos) === Color.EMPTY);
 }
 
 export const keimaVariant: Variant<NewBadukConfig> = {

--- a/packages/vue-client/src/components/boards/KeimaBoard.vue
+++ b/packages/vue-client/src/components/boards/KeimaBoard.vue
@@ -1,21 +1,3 @@
-<script lang="ts">
-function getKeimaMoves({ x, y }: Coordinate, board: Grid<Color>): Coordinate[] {
-  const moves = [
-    new Coordinate(x + 1, y + 2),
-    new Coordinate(x - 1, y + 2),
-    new Coordinate(x + 1, y - 2),
-    new Coordinate(x - 1, y - 2),
-    new Coordinate(x + 2, y + 1),
-    new Coordinate(x - 2, y + 1),
-    new Coordinate(x + 2, y - 1),
-    new Coordinate(x - 2, y - 1),
-  ];
-  return moves
-    .filter((pos) => board.isInBounds(pos))
-    .filter((pos) => board.at(pos) === Color.EMPTY);
-}
-</script>
-
 <script setup lang="ts">
 import MulticolorGridBoard from "./MulticolorGridBoard.vue";
 import {
@@ -24,6 +6,7 @@ import {
   Grid,
   Color,
   getWidthAndHeight,
+  getKeimaMoves,
 } from "@ogfcommunity/variants-shared";
 import { GridBadukConfig } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";


### PR DESCRIPTION
Here are some change proposals to variant Keima based on the poll + discussion that we had here: [https://forums.online-go.com/t/collective-development-of-a-server-for-variants/43682/154](url)

- Validate and throw if there are no legal keima follow-up moves.
- Players can pass or play one keima, but they can't place a single stone and then pass.

This rules makes it so the variant basically can't be played on boards <= 2x2, but I only just realised that I should include a check for that.