### PR TITLE
fix bug where time control is undefined

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -9,6 +9,7 @@ import {
   AbstractGame,
   GameStateResponse,
   sanitizeConfig,
+  ITimeControlBase,
 } from "@ogfcommunity/variants-shared";
 import { ObjectId, WithId, Document, Filter } from "mongodb";
 import { getDb } from "./db";
@@ -196,7 +197,7 @@ export async function handleMoveAndTime(
 
   game.moves.push(moves);
 
-  emitGame(game.id, game.players?.length ?? 0, game_obj);
+  emitGame(game.id, game.players?.length ?? 0, game_obj, timeControl);
 
   return game;
 }
@@ -205,6 +206,7 @@ function emitGame(
   game_id: string,
   num_players: number,
   game_obj: AbstractGame,
+  time_control: ITimeControlBase,
 ): void {
   const next_to_play = game_obj.nextToPlay();
   const specialMoves = game_obj.specialMoves();
@@ -218,6 +220,7 @@ function emitGame(
       special_moves: specialMoves,
       result: game_obj.result,
       seat: null,
+      timeControl: time_control,
     });
 
   for (let seat = 0; seat < num_players; seat++) {
@@ -228,6 +231,7 @@ function emitGame(
       special_moves: specialMoves,
       result: game_obj.result,
       seat: seat,
+      timeControl: time_control,
     };
     io().to(`game/${game_id}/${seat}`).emit("move", gameStateResponse);
   }

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -45,7 +45,9 @@ const time_control = ref<ITimeControlBase | null>(null);
 
 function setNewState(stateResponse: GameStateResponse): void {
   const { timeControl: timeControl, ...state } = stateResponse;
-  if (timeControl) time_control.value = timeControl ?? null;
+  if (timeControl) {
+    time_control.value = timeControl;
+  }
 
   state_map.set(
     encodeSeatAndRound(stateResponse.round, stateResponse.seat),


### PR DESCRIPTION
This aims to fix a time control bug that unfortunately I introduced with the game state changes.

The problem is when a move is played, the state sent does not include the time control object. As a consequence the clock does not display the times.

I've also made it so the game state map does not include the time control object any more ,for clarity and potentially saving memory space. I think even if users browse through the game history, its ok if we display the current times.