### PR TITLE
Game creation form style improvements

### DIFF
--- a/packages/vue-client/src/assets/main.css
+++ b/packages/vue-client/src/assets/main.css
@@ -28,6 +28,7 @@
 .config-form-column {
   display: flex;
   flex-direction: column;
+  gap: 2px;
 }
 
 .navElement,
@@ -113,4 +114,9 @@ a,
 .info-label {
   font-weight: bold;
   margin-right: 0.5em;
+}
+
+.large-button {
+  width: 100%;
+  padding: 0.4em 0.8em;
 }

--- a/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
@@ -35,9 +35,3 @@ function setBoardConfig(boardConfig: BoardConfig): void {
     <input type="number" step="0.5" v-model="config.komi" />
   </form>
 </template>
-
-<style scoped>
-input {
-  width: fit-content;
-}
-</style>

--- a/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukWithAbstractBoardConfigForm.vue
@@ -51,7 +51,7 @@ watch(patternRef, () => {
 <template>
   <div class="config-form-column">
     <label>Pattern</label>
-    <select v-model="patternRef" style="width: fit-content">
+    <select v-model="patternRef">
       <option :value="BoardPattern.Rectangular">Rectangular</option>
       <option :value="BoardPattern.Polygonal">Polygonal</option>
       <option :value="BoardPattern.Circular">Circular</option>
@@ -87,9 +87,3 @@ watch(patternRef, () => {
     <input type="number" step="0.5" v-model="komiRef" />
   </div>
 </template>
-
-<style scoped>
-input {
-  width: fit-content;
-}
-</style>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
@@ -28,7 +28,7 @@ function emitConfigChange(config: BoardConfig) {
   <div class="config-form-column">
     <template v-if="$props.gridOnly !== true">
       <label>Pattern</label>
-      <select v-model="board_type" style="width: fit-content">
+      <select v-model="board_type">
         <option :value="BoardPattern.Grid">Rectangular</option>
         <option :value="BoardPattern.GridWithHoles">
           Rectangular with holes

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -36,9 +36,3 @@ function emitConfigChange() {
     <input type="number" step="1" v-model="config.yShift" />
   </form>
 </template>
-
-<style scoped>
-input {
-  width: fit-content;
-}
-</style>

--- a/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
+++ b/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
@@ -101,12 +101,14 @@ const setTimeControlConfig = (
         v-on:configChanged="setConfig"
       />
       <TimeControlConfigForm v-on:config-changed="setTimeControlConfig" />
-      <button v-on:click="createGame">Create Game</button>
+      <button v-on:click="createGame" class="large-button">Create Game</button>
     </template>
     <template v-else>
       <textarea v-model="configString"></textarea>
       <TimeControlConfigForm v-on:config-changed="setTimeControlConfig" />
-      <button v-on:click="parseConfigThenCreateGame">Create Game</button>
+      <button v-on:click="parseConfigThenCreateGame" class="large-button">
+        Create Game
+      </button>
     </template>
   </div>
 </template>
@@ -119,5 +121,9 @@ textarea {
 }
 .game-creation-form {
   margin-bottom: 0.5rem;
+  .large-button {
+    margin-top: 5px;
+    font-size: large;
+  }
 }
 </style>

--- a/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
@@ -22,16 +22,10 @@ function emitConfigChange() {
     <label>Number of players</label>
     <input type="number" min="1" v-model="config.num_players" />
     <label>Collision Handling</label>
-    <select v-model="config.collision_handling" style="width: fit-content">
+    <select v-model="config.collision_handling">
       <option :value="'merge'">Merge</option>
       <option :value="'pass'">Pass</option>
       <option :value="'ko'">Ko</option>
     </select>
   </form>
 </template>
-
-<style scoped>
-input {
-  width: fit-content;
-}
-</style>

--- a/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
@@ -111,12 +111,6 @@ function emitConfigChange() {
 </template>
 
 <style scoped>
-input {
-  width: fit-content;
-}
-select {
-  width: fit-content;
-}
 .fischerCappedToggle {
   display: flex;
   flex-direction: row;

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -293,5 +293,8 @@ const createTimeControlPreview = (
   .seat-list {
     max-height: var(--board-side-length);
   }
+  .info-attribute {
+    white-space: pre-wrap;
+  }
 }
 </style>

--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -205,5 +205,8 @@ function onConfigChange(c: object) {
   .seat-list {
     max-height: var(--board-side-length);
   }
+  .info-attribute {
+    white-space: pre-wrap;
+  }
 }
 </style>


### PR DESCRIPTION
- give 100% width to all input fields in the game creation form (I believe it was originally my mistake to limit the width).
- give the "Create Game"-button 100% width and vertical padding
- add small gap in the column

![grafik](https://github.com/user-attachments/assets/fa2f39f6-1758-4e45-91f6-b909ad8ea8ed)

- enable in-text line breaks in short variant description (the baduk short description looks weird ever since I added it).