### PR TITLE
disable hover in games list

### DIFF
--- a/packages/vue-client/src/components/GameListItem.vue
+++ b/packages/vue-client/src/components/GameListItem.vue
@@ -27,12 +27,14 @@ const variantGameView = computed(() => board_map[props.game.variant]);
 <template>
   <li class="game-list-item">
     <RouterLink v-bind:to="{ name: 'game', params: { gameId: props.game.id } }">
-      <component
-        v-if="variantGameView"
-        v-bind:is="variantGameView"
-        v-bind:gamestate="game.state"
-        v-bind:config="props.game.config"
-      />
+      <div class="event-blocker">
+        <component
+          v-if="variantGameView"
+          v-bind:is="variantGameView"
+          v-bind:gamestate="game.state"
+          v-bind:config="props.game.config"
+        />
+      </div>
       <div class="variant-text">{{ props.game.variant }}</div>
     </RouterLink>
   </li>
@@ -44,6 +46,9 @@ li.game-list-item {
   width: 50%;
   list-style-type: none;
   display: inline-block;
+  .event-blocker {
+    pointer-events: none;
+  }
 }
 
 .variant-text {


### PR DESCRIPTION
In the games list, this disables hover (and other pointer events) on the board by wrapping it with a div with a style for this purpose. Clicking the outer link still works and navigates to the Game page.

issue: #107 (although just for the games list)