### PR TITLE
Add lint rule to prevent /src/ imports and fix instances.

### DIFF
--- a/packages/vue-client/.eslintrc.cjs
+++ b/packages/vue-client/.eslintrc.cjs
@@ -19,5 +19,11 @@ module.exports = {
       },
     ],
     "vue/enforce-style-attribute": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: ["@ogfcommunity/variants-shared/src/*"],
+      },
+    ],
   },
 };

--- a/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { TimeControlType } from "@ogfcommunity/variants-shared/src/time_control";
+import { TimeControlType } from "@ogfcommunity/variants-shared";
 function shouldShowPeriodTime(type: TimeControlType) {
   return type == TimeControlType.ByoYomi || type === TimeControlType.Canadian;
 }
@@ -9,11 +9,9 @@ function shouldShowPeriodTime(type: TimeControlType) {
 import type {
   IByoYomiConfig,
   ICanadianTimeConfig,
+  ITimeControlConfig,
+  IFischerConfig,
 } from "@ogfcommunity/variants-shared";
-import {
-  type ITimeControlConfig,
-  type IFischerConfig,
-} from "@ogfcommunity/variants-shared/src/time_control";
 import { ref } from "vue";
 
 const typeRef = ref(null);

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -3,9 +3,9 @@ import { ref, watch, computed } from "vue";
 import {
   type IPerPlayerTimeControlBase,
   timeControlMap,
+  type ITimeControlConfig,
 } from "@ogfcommunity/variants-shared";
 import { isDefined } from "@vueuse/core";
-import type { ITimeControlConfig } from "@ogfcommunity/variants-shared/src/time_control";
 
 const props = defineProps<{
   time_control: IPerPlayerTimeControlBase;


### PR DESCRIPTION
Now linter can catch the `@ogfcommunity/variants-shared/src/path/to/file` imports!