### PR TITLE
Fix area scoring of SFractional

### DIFF
--- a/packages/shared/src/variants/__tests__/s_fractional.test.ts
+++ b/packages/shared/src/variants/__tests__/s_fractional.test.ts
@@ -91,9 +91,9 @@ test("territory test", () => {
   expect(game.result).toBe("B+1.5");
 
   expect(state.scoreBoard).toEqual([
-    ["black", "", "", "white"],
-    ["black", "", "", "white"],
-    ["black", "", "", ""],
-    ["black", "", "", ""],
+    ["black", "black", "white", "white"],
+    ["black", "black", "white", "white"],
+    ["black", "black", "white", "white"],
+    ["black", "black", "", ""],
   ]);
 });

--- a/packages/shared/src/variants/s_fractional.ts
+++ b/packages/shared/src/variants/s_fractional.ts
@@ -259,6 +259,12 @@ export class SFractional extends AbstractGame<
     // identify territory over the board and calculate score
     this.board.forEach((placementColors, index) => {
       if (this.isOccupied(placementColors)) {
+        // area scoring
+        if (placementColors.includes("black")) {
+          scoreBoard.set(index, "black");
+        } else if (placementColors.includes("white")) {
+          scoreBoard.set(index, "white");
+        }
         return;
       }
 


### PR DESCRIPTION
This fixes the score board of SFractional. Previously it didn't mark or count the stones on the board, now it does.