### PR TITLE
pass round to playing table in demo

### DIFF
--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -44,6 +44,7 @@ const game = computed(() =>
     playing_as.value,
   ),
 );
+const displayed_round = computed(() => view_round.value ?? moves.length);
 
 function getGame(
   variant: string,
@@ -135,6 +136,7 @@ function onConfigChange(c: object) {
       v-bind:is="variantGameView"
       v-bind:gamestate="transformedGameData.gamestate"
       v-bind:config="transformedGameData.config"
+      v-bind:displayed_round="displayed_round"
       v-on:move="makeMove"
     />
     <NavButtons v-model="view_round" :gameRound="game.round" />


### PR DESCRIPTION
This makes it so the upcoming moves display works in the demo board.

Remark about the displayed_round: Not all variant view components have this prop, and as a result I get this warning:

![grafik](https://github.com/user-attachments/assets/4723d32a-e3e3-419f-95f5-7dd99021dc25)

But in testing, it didn't seem to break anything (also in the game view component).