### PR TITLE
Migrate QuantumBoard to DefaultBoard

### DIFF
--- a/packages/shared/src/lib/grid_compat.ts
+++ b/packages/shared/src/lib/grid_compat.ts
@@ -14,3 +14,14 @@ export function indexToMove(index: CoordinateLike | number): string {
   }
   return new Coordinate(index.x, index.y).toSgfRepr();
 }
+
+/**
+ * Translate a move string to the two main indices:
+ * SGF coordinate and numbers.
+ */
+export function moveToIndex(move: string): Coordinate | number {
+  if (/^[A-Za-z]{2}$/.test(move)) {
+    return Coordinate.fromSgfRepr(move);
+  }
+  return parseInt(move);
+}


### PR DESCRIPTION
https://github.com/govariantsteam/govariants/pull/327#discussion_r1842799084

The major benefit is that we're able to remove some duplicate codepaths for Grid and Graph boards.  I did fudge types quite a bit, so I'm open to ideas on improvement, but overall, it works, and I think the reduction in code (~50 lines) is worth it.

Tested: both grid and graph boards

![Screenshot_20241114_182904](https://github.com/user-attachments/assets/d8a2469e-1436-493d-8b25-09abd9d25b42)
Forgot to screnshot grid, but I promise I tested that too :)

