### PR TITLE
Layout changes

### DIFF
--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -56,9 +56,7 @@ const toggleMenuFn = (event: MouseEvent) => {
       </div>
     </div>
   </nav>
-  <div class="pageWrapper">
-    <Suspense><RouterView /></Suspense>
-  </div>
+  <Suspense><RouterView /></Suspense>
 </template>
 
 <style scoped>

--- a/packages/vue-client/src/assets/main.css
+++ b/packages/vue-client/src/assets/main.css
@@ -5,21 +5,21 @@
   height: 100%;
 }
 
-.pageWrapper {
+.grid-page-layout {
   max-width: 1280px;
   margin: 0 auto;
   padding: 0 2rem;
 }
 
 @media (max-width: 540px) {
-  .pageWrapper {
+  .grid-page-layout {
     padding-left: 0.2rem;
     padding-right: 0.2rem;
   }
 }
 
 @media (min-width: 1024px) {
-  .pageWrapper {
+  .grid-page-layout {
     display: grid;
     grid-template-columns: 1fr 1fr;
   }

--- a/packages/vue-client/src/views/AboutView.vue
+++ b/packages/vue-client/src/views/AboutView.vue
@@ -1,18 +1,22 @@
 <template>
   <main>
-    <h2>Who are we?</h2>
-    <p>
-      <span>Check us out on </span>
-      <a href="https://github.com/benjaminpjones/govariants">Github</a>
-    </p>
-    <p>
-      <span>Or post in the </span>
-      <a
-        href="https://forums.online-go.com/t/collective-development-of-a-server-for-variants/43682"
-      >
-        OGS Forums
-      </a>
-    </p>
+    <div class="pageWrapper">
+      <div>
+        <h2>Who are we?</h2>
+        <p>
+          <span>Check us out on </span>
+          <a href="https://github.com/benjaminpjones/govariants">Github</a>
+        </p>
+        <p>
+          <span>Or post in the </span>
+          <a
+            href="https://forums.online-go.com/t/collective-development-of-a-server-for-variants/43682"
+          >
+            OGS Forums
+          </a>
+        </p>
+      </div>
+    </div>
   </main>
 </template>
 

--- a/packages/vue-client/src/views/AboutView.vue
+++ b/packages/vue-client/src/views/AboutView.vue
@@ -1,11 +1,11 @@
 <template>
   <main>
-    <div class="pageWrapper">
+    <div class="grid-page-layout">
       <div>
         <h2>Who are we?</h2>
         <p>
           <span>Check us out on </span>
-          <a href="https://github.com/benjaminpjones/govariants">Github</a>
+          <a href="https://github.com/govariantsteam/govariants">Github</a>
         </p>
         <p>
           <span>Or post in the </span>

--- a/packages/vue-client/src/views/ComponentView.vue
+++ b/packages/vue-client/src/views/ComponentView.vue
@@ -52,7 +52,7 @@ function update_board_state(pos: Coordinate) {
 
 <template>
   <main>
-    <div class="PageWrapper">
+    <div class="grid-page-layout">
       <div>
         <h2>Page to test unused components</h2>
         <SocketTest />

--- a/packages/vue-client/src/views/ComponentView.vue
+++ b/packages/vue-client/src/views/ComponentView.vue
@@ -52,40 +52,44 @@ function update_board_state(pos: Coordinate) {
 
 <template>
   <main>
-    <h2>Page to test unused components</h2>
-    <SocketTest />
-    <MulticolorGridBoard
-      :board_dimensions="{ width: 3, height: 4 }"
-      :board="board_state"
-      @click="update_board_state"
-    />
-    <select name="colors" v-model="current_color">
-      <option value="blue">Blue</option>
-      <option value="red">Red</option>
-      <option value="green">Green</option>
-      <option value="yellow">Yellow</option>
-    </select>
-    <svg height="600" width="600" viewBox="-300 -300 600 600">
-      <TaegeukStone
-        v-bind:r="r"
-        v-bind:cx="cx"
-        v-bind:cy="cy"
-        v-bind:colors="distinct_colors.slice(0, num_colors)"
-      />
-    </svg>
-    <div>
-      <label>Number of colors (1-20):</label>
-      <input type="number" v-model="num_colors" />
-    </div>
-    <div>
-      <label>Radius:</label>
-      <input type="number" v-model="r" />
-    </div>
-    <div>
-      <label>cx:</label>
-      <input type="number" v-model="cx" />
-      <label>cy:</label>
-      <input type="number" v-model="cy" />
+    <div class="PageWrapper">
+      <div>
+        <h2>Page to test unused components</h2>
+        <SocketTest />
+        <MulticolorGridBoard
+          :board_dimensions="{ width: 3, height: 4 }"
+          :board="board_state"
+          @click="update_board_state"
+        />
+        <select name="colors" v-model="current_color">
+          <option value="blue">Blue</option>
+          <option value="red">Red</option>
+          <option value="green">Green</option>
+          <option value="yellow">Yellow</option>
+        </select>
+        <svg height="600" width="600" viewBox="-300 -300 600 600">
+          <TaegeukStone
+            v-bind:r="r"
+            v-bind:cx="cx"
+            v-bind:cy="cy"
+            v-bind:colors="distinct_colors.slice(0, num_colors)"
+          />
+        </svg>
+        <div>
+          <label>Number of colors (1-20):</label>
+          <input type="number" v-model="num_colors" />
+        </div>
+        <div>
+          <label>Radius:</label>
+          <input type="number" v-model="r" />
+        </div>
+        <div>
+          <label>cx:</label>
+          <input type="number" v-model="cx" />
+          <label>cy:</label>
+          <input type="number" v-model="cy" />
+        </div>
+      </div>
     </div>
   </main>
 </template>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -218,7 +218,7 @@ const createTimeControlPreview = (
 
 <template>
   <main>
-    <div class="pageWrapper">
+    <div class="grid-page-layout">
       <div>
         <!-- Left column -->
         <component

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -217,67 +217,81 @@ const createTimeControlPreview = (
 </script>
 
 <template>
-  <div>
-    <component
-      v-if="variantGameView && transformedGameData"
-      v-bind:is="variantGameView"
-      v-bind:gamestate="transformedGameData.gamestate"
-      v-bind:config="transformedGameData.config"
-      v-bind:displayed_round="displayed_round"
-      v-on:move="makeMove"
-    />
-    <NavButtons :gameRound="current_round" v-model="view_round" />
-
-    <div id="variant-info">
+  <main>
+    <div class="pageWrapper">
       <div>
-        <span class="info-label">Variant:</span>
-        <span class="info-attribute">
-          {{ variant ?? "unknown" }}
-        </span>
+        <!-- Left column -->
+        <component
+          v-if="variantGameView && transformedGameData"
+          v-bind:is="variantGameView"
+          v-bind:gamestate="transformedGameData.gamestate"
+          v-bind:config="transformedGameData.config"
+          v-bind:displayed_round="displayed_round"
+          v-on:move="makeMove"
+        />
+        <NavButtons :gameRound="current_round" v-model="view_round" />
+
+        <div id="variant-info">
+          <div>
+            <span class="info-label">Variant:</span>
+            <span class="info-attribute">
+              {{ variant ?? "unknown" }}
+            </span>
+          </div>
+
+          <div>
+            <span class="info-label">Description:</span>
+            <span class="info-attribute">{{ variantDescriptionShort }}</span>
+          </div>
+        </div>
+
+        <PlayersToMove :next-to-play="game_state?.next_to_play" />
       </div>
 
       <div>
-        <span class="info-label">Description:</span>
-        <span class="info-attribute">{{ variantDescriptionShort }}</span>
+        <!-- Right column -->
+        <div className="seat-list">
+          <div v-for="(player, idx) in players" :key="idx">
+            <SeatComponent
+              :user_id="user?.id"
+              :occupant="player"
+              :player_n="idx"
+              @sit="sit(idx)"
+              @leave="leave(idx)"
+              @select="setPlayingAs(idx)"
+              :selected="playing_as"
+              :time_control="
+                time_control?.forPlayer[idx] ?? createTimeControlPreview(config)
+              "
+              :is_players_turn="
+                game_state?.next_to_play?.includes(idx) ?? false
+              "
+              :variant="variant"
+              :config="config"
+            />
+          </div>
+
+          <div>
+            <button
+              v-for="(value, key) in game_state?.special_moves"
+              :key="key"
+              @click="makeMove(key as string)"
+            >
+              {{ value }}
+            </button>
+          </div>
+        </div>
+
+        <DownloadSGF v-if="supportsSGF(variant)" :gameId="gameId" />
+        <div
+          v-if="game_state?.result"
+          style="font-weight: bold; font-size: 24pt"
+        >
+          Result: {{ game_state?.result }}
+        </div>
       </div>
     </div>
-  </div>
-  <div className="seat-list">
-    <div v-for="(player, idx) in players" :key="idx">
-      <SeatComponent
-        :user_id="user?.id"
-        :occupant="player"
-        :player_n="idx"
-        @sit="sit(idx)"
-        @leave="leave(idx)"
-        @select="setPlayingAs(idx)"
-        :selected="playing_as"
-        :time_control="
-          time_control?.forPlayer[idx] ?? createTimeControlPreview(config)
-        "
-        :is_players_turn="game_state?.next_to_play?.includes(idx) ?? false"
-        :variant="variant"
-        :config="config"
-      />
-    </div>
-
-    <div>
-      <button
-        v-for="(value, key) in game_state?.special_moves"
-        :key="key"
-        @click="makeMove(key as string)"
-      >
-        {{ value }}
-      </button>
-    </div>
-  </div>
-
-  <PlayersToMove :next-to-play="game_state?.next_to_play" />
-
-  <DownloadSGF v-if="supportsSGF(variant)" :gameId="gameId" />
-  <div v-if="game_state?.result" style="font-weight: bold; font-size: 24pt">
-    Result: {{ game_state?.result }}
-  </div>
+  </main>
 </template>
 
 <style scoped>

--- a/packages/vue-client/src/views/HomeView.vue
+++ b/packages/vue-client/src/views/HomeView.vue
@@ -6,14 +6,14 @@ import { SITE_NAME } from "@ogfcommunity/variants-shared";
 
 <template>
   <main>
-    <h2>Welcome to {{ SITE_NAME }}!</h2>
-    <div>
-      <GameCreationForm />
-      <hr />
-      <GameList />
-      <!-- <hr />
-      <SocketTest />
-      <hr /> -->
+    <div class="pageWrapper">
+      <div>
+        <h2>Welcome to {{ SITE_NAME }}!</h2>
+        <GameCreationForm />
+      </div>
+      <div>
+        <GameList />
+      </div>
     </div>
   </main>
 </template>

--- a/packages/vue-client/src/views/HomeView.vue
+++ b/packages/vue-client/src/views/HomeView.vue
@@ -6,7 +6,7 @@ import { SITE_NAME } from "@ogfcommunity/variants-shared";
 
 <template>
   <main>
-    <div class="pageWrapper">
+    <div class="grid-page-layout">
       <div>
         <h2>Welcome to {{ SITE_NAME }}!</h2>
         <GameCreationForm />

--- a/packages/vue-client/src/views/LoginView.vue
+++ b/packages/vue-client/src/views/LoginView.vue
@@ -22,7 +22,7 @@ const submit = () =>
 
 <template>
   <main>
-    <div class="pageWrapper">
+    <div class="grid-page-layout">
       <div>
         <div>
           <label for="username">Username</label>

--- a/packages/vue-client/src/views/LoginView.vue
+++ b/packages/vue-client/src/views/LoginView.vue
@@ -22,42 +22,46 @@ const submit = () =>
 
 <template>
   <main>
-    <div>
-      <label for="username">Username</label>
-      <input
-        id="username"
-        name="username"
-        type="text"
-        autocomplete="username"
-        required
-        v-model="username"
-      />
+    <div class="pageWrapper">
+      <div>
+        <div>
+          <label for="username">Username</label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            autocomplete="username"
+            required
+            v-model="username"
+          />
+        </div>
+        <div>
+          <label for="current-password">Password</label>
+          <input
+            id="current-password"
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+            v-model="password"
+          />
+        </div>
+        <div>
+          <button type="submit" @click="submit">Log in</button>
+        </div>
+        <hr />
+        <input
+          type="button"
+          v-on:click="store.guestLogin()"
+          value="Log in as guest"
+        />
+        <div>
+          Don't have an account?
+          <RouterLink to="register">Register here!</RouterLink>
+        </div>
+        <span class="error">{{ error }}</span>
+      </div>
     </div>
-    <div>
-      <label for="current-password">Password</label>
-      <input
-        id="current-password"
-        name="password"
-        type="password"
-        autocomplete="current-password"
-        required
-        v-model="password"
-      />
-    </div>
-    <div>
-      <button type="submit" @click="submit">Log in</button>
-    </div>
-    <hr />
-    <input
-      type="button"
-      v-on:click="store.guestLogin()"
-      value="Log in as guest"
-    />
-    <div>
-      Don't have an account?
-      <RouterLink to="register">Register here!</RouterLink>
-    </div>
-    <span class="error">{{ error }}</span>
   </main>
 </template>
 

--- a/packages/vue-client/src/views/RegisterView.vue
+++ b/packages/vue-client/src/views/RegisterView.vue
@@ -22,36 +22,40 @@ const submit = () =>
 
 <template>
   <main>
-    <div>
-      <label for="username">Username</label>
-      <input
-        id="username"
-        name="username"
-        type="text"
-        autocomplete="username"
-        required
-        v-model="username"
-      />
+    <div class="pageWrapper">
+      <div>
+        <div>
+          <label for="username">Username</label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            autocomplete="username"
+            required
+            v-model="username"
+          />
+        </div>
+        <div>
+          <label for="current-password">Password</label>
+          <input
+            id="current-password"
+            name="password"
+            type="password"
+            autocomplete="current-password"
+            required
+            v-model="password"
+          />
+        </div>
+        <div>
+          <button type="submit" @click="submit">Register</button>
+        </div>
+        <div>
+          Already have an account?
+          <RouterLink to="login">Log in!</RouterLink>
+        </div>
+        <span class="error">{{ error }}</span>
+      </div>
     </div>
-    <div>
-      <label for="current-password">Password</label>
-      <input
-        id="current-password"
-        name="password"
-        type="password"
-        autocomplete="current-password"
-        required
-        v-model="password"
-      />
-    </div>
-    <div>
-      <button type="submit" @click="submit">Register</button>
-    </div>
-    <div>
-      Already have an account?
-      <RouterLink to="login">Log in!</RouterLink>
-    </div>
-    <span class="error">{{ error }}</span>
   </main>
 </template>
 

--- a/packages/vue-client/src/views/RegisterView.vue
+++ b/packages/vue-client/src/views/RegisterView.vue
@@ -22,7 +22,7 @@ const submit = () =>
 
 <template>
   <main>
-    <div class="pageWrapper">
+    <div class="grid-page-layout">
       <div>
         <div>
           <label for="username">Username</label>

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -16,11 +16,17 @@ function toUpperCaseFirstLetter(string: string) {
 </script>
 
 <template>
-  <div class="rules-page">
-    <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
-    <p v-if="!rulesDescription">Under Construction</p>
-    <div v-if="rulesDescription" v-html="rulesDescription"></div>
-  </div>
+  <main>
+    <div class="pageWrapper">
+      <div>
+        <div class="rules-page">
+          <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
+          <p v-if="!rulesDescription">Under Construction</p>
+          <div v-if="rulesDescription" v-html="rulesDescription"></div>
+        </div>
+      </div>
+    </div>
+  </main>
 </template>
 
 <style scoped>

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -17,7 +17,7 @@ function toUpperCaseFirstLetter(string: string) {
 
 <template>
   <main>
-    <div class="pageWrapper">
+    <div class="grid-page-layout">
       <div>
         <div class="rules-page">
           <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>

--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -130,7 +130,7 @@ function onConfigChange(c: object) {
 </script>
 
 <template>
-  <div class="pageWrapper">
+  <div class="grid-page-layout">
     <div>
       <component
         v-if="variantGameView && game.state"

--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -130,67 +130,69 @@ function onConfigChange(c: object) {
 </script>
 
 <template>
-  <div>
-    <component
-      v-if="variantGameView && game.state"
-      v-bind:is="variantGameView"
-      v-bind:gamestate="transformedGameData.gamestate"
-      v-bind:config="transformedGameData.config"
-      v-bind:displayed_round="displayed_round"
-      v-on:move="makeMove"
-    />
-    <NavButtons v-model="view_round" :gameRound="game.round" />
+  <div class="pageWrapper">
+    <div>
+      <component
+        v-if="variantGameView && game.state"
+        v-bind:is="variantGameView"
+        v-bind:gamestate="transformedGameData.gamestate"
+        v-bind:config="transformedGameData.config"
+        v-bind:displayed_round="displayed_round"
+        v-on:move="makeMove"
+      />
+      <NavButtons v-model="view_round" :gameRound="game.round" />
 
-    <div id="variant-info">
-      <div>
-        <span class="info-label">Variant:</span>
-        <span class="info-attribute">
-          {{ props.variant ?? "unknown" }}
-        </span>
-      </div>
+      <div id="variant-info">
+        <div>
+          <span class="info-label">Variant:</span>
+          <span class="info-attribute">
+            {{ props.variant ?? "unknown" }}
+          </span>
+        </div>
 
-      <div>
-        <span class="info-label">Description:</span>
-        <span class="info-attribute">{{ variantDescriptionShort }}</span>
+        <div>
+          <span class="info-label">Description:</span>
+          <span class="info-attribute">{{ variantDescriptionShort }}</span>
+        </div>
       </div>
     </div>
-  </div>
-  <div className="seat-list">
-    <div v-for="(_, idx) in game.numPlayers" :key="idx">
-      <SeatComponent
-        :user_id="user?.id"
-        :occupant="user || undefined"
-        :player_n="idx"
-        @select="setPlayingAs(idx)"
-        :selected="playing_as"
-        :time_control="null"
-        :is_players_turn="game.next_to_play?.includes(idx) ?? false"
-        :variant="variant"
-        :config="config"
+    <div className="seat-list">
+      <div v-for="(_, idx) in game.numPlayers" :key="idx">
+        <SeatComponent
+          :user_id="user?.id"
+          :occupant="user || undefined"
+          :player_n="idx"
+          @select="setPlayingAs(idx)"
+          :selected="playing_as"
+          :time_control="null"
+          :is_players_turn="game.next_to_play?.includes(idx) ?? false"
+          :variant="variant"
+          :config="config"
+        />
+      </div>
+
+      <div>
+        <button
+          v-for="(value, key) in specialMoves"
+          :key="key"
+          @click="makeMove(key as string)"
+        >
+          {{ value }}
+        </button>
+      </div>
+
+      <PlayersToMove :next-to-play="game.next_to_play" />
+
+      <component
+        v-bind:is="variantConfigForm"
+        v-bind:initialConfig="getDefaultConfig(variant)"
+        v-on:configChanged="onConfigChange"
       />
     </div>
 
-    <div>
-      <button
-        v-for="(value, key) in specialMoves"
-        :key="key"
-        @click="makeMove(key as string)"
-      >
-        {{ value }}
-      </button>
+    <div v-if="game.result" style="font-weight: bold; font-size: 24pt">
+      Result: {{ game.result }}
     </div>
-
-    <PlayersToMove :next-to-play="game.next_to_play" />
-
-    <component
-      v-bind:is="variantConfigForm"
-      v-bind:initialConfig="getDefaultConfig(variant)"
-      v-on:configChanged="onConfigChange"
-    />
-  </div>
-
-  <div v-if="game.result" style="font-weight: bold; font-size: 24pt">
-    Result: {{ game.result }}
   </div>
 </template>
 


### PR DESCRIPTION
### Proposed Changes
- Pull pageWrapper into each View
- in Home View, move the games list into the right column
- in Game View, add Divs for left and right column

### Reasoning
With the first change, it is easier for each view to define its layout individually. This also helps with the second change.
In the right column, the games list is easier accessible on desktop. For mobile it moves below as usual.
In the Game view, previously each added html element was positioned as a new element in the grid layout, resulting in elements being positioned seemingly randomly. I think it makes more sense to have a left- and right column that encapsulate all other elements.

### Screenshots
![grafik](https://github.com/user-attachments/assets/c5db201c-1a74-4e9f-bb83-0b41b0181857)

![grafik](https://github.com/user-attachments/assets/eb65db81-db15-499b-b894-c84ad407d45e)

![grafik](https://github.com/user-attachments/assets/cfaebeb9-c021-4db0-a29d-08962b6b92d0)

![grafik](https://github.com/user-attachments/assets/03e934ac-da59-436d-a085-66ac33fcdf8d)
