### PR TITLE
Rules List

### DIFF
--- a/packages/shared/src/variant_map.ts
+++ b/packages/shared/src/variant_map.ts
@@ -116,3 +116,12 @@ export function uiTransform(variant: string, config: object, state: object) {
   }
   return variant_object.uiTransform(config, state);
 }
+
+export function getVariantsWithRulesDescription(): string[] {
+  return Object.entries(variant_map)
+    .filter(
+      ([_name, variant]) =>
+        !variant.deprecated && variant.rulesDescription !== undefined,
+    )
+    .map(([name, _variant]) => name);
+}

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -4,11 +4,11 @@ import UserNav from "./components/UserNav.vue";
 import { ref } from "vue";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { faBars } from "@fortawesome/free-solid-svg-icons";
+import { faBars, faBook } from "@fortawesome/free-solid-svg-icons";
 import { faHouse } from "@fortawesome/free-solid-svg-icons";
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
 
-library.add(faBars, faHouse, faCircleInfo);
+library.add(faBars, faHouse, faCircleInfo, faBook);
 const is_menu_closed = ref(true);
 
 const closeMenuFn = (event: MouseEvent) => {
@@ -49,6 +49,12 @@ const toggleMenuFn = (event: MouseEvent) => {
             icon="fa-solid fa-circle-info"
             class="icon"
           />About</RouterLink
+        >
+        <RouterLink class="navElement" to="/variants/rules-list"
+          ><font-awesome-icon
+            icon="fa-solid fa-book"
+            class="icon"
+          />Rules</RouterLink
         >
       </div>
       <div>

--- a/packages/vue-client/src/assets/base.css
+++ b/packages/vue-client/src/assets/base.css
@@ -93,7 +93,6 @@
   }
 }
 
-/* TODO: Check why this is here, can we remove this? */
 *,
 *::before,
 *::after {

--- a/packages/vue-client/src/assets/main.css
+++ b/packages/vue-client/src/assets/main.css
@@ -13,8 +13,8 @@
 
 @media (max-width: 540px) {
   .grid-page-layout {
-    padding-left: 0.2rem;
-    padding-right: 0.2rem;
+    padding-left: 12px;
+    padding-right: 12px;
   }
 }
 

--- a/packages/vue-client/src/router/index.ts
+++ b/packages/vue-client/src/router/index.ts
@@ -48,6 +48,11 @@ const router = createRouter({
       component: () => import("../views/RulesView.vue"),
       props: true,
     },
+    {
+      path: "/variants/rules-list",
+      name: "rules-list",
+      component: () => import("../views/RulesListView.vue"),
+    },
   ],
 });
 

--- a/packages/vue-client/src/utils/format-utils.ts
+++ b/packages/vue-client/src/utils/format-utils.ts
@@ -1,0 +1,7 @@
+export function toUpperCaseFirstLetter(string: string) {
+  if (string.length === 0) {
+    return "";
+  }
+
+  return string[0].toUpperCase() + string.slice(1);
+}

--- a/packages/vue-client/src/views/RulesListView.vue
+++ b/packages/vue-client/src/views/RulesListView.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { toUpperCaseFirstLetter } from "@/utils/format-utils";
+import { getVariantsWithRulesDescription } from "@ogfcommunity/variants-shared";
+import { RouterLink } from "vue-router";
+
+const variantsWithRulesDescription = getVariantsWithRulesDescription();
+</script>
+
+<template>
+  <main>
+    <h1>Rule Descriptions</h1>
+    <div class="rule-links-container">
+      <RouterLink
+        v-for="variant in variantsWithRulesDescription"
+        :key="variant"
+        class="rules-link"
+        v-bind:to="{ name: 'rules', params: { variant: variant } }"
+      >
+        {{ toUpperCaseFirstLetter(variant) }}
+      </RouterLink>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+main {
+  padding: 0 2rem;
+}
+.rule-links-container {
+  display: flex;
+  flex-direction: row;
+  flex-flow: wrap;
+}
+.rules-link {
+  border: 1px solid var(--color-border);
+  margin: 15px;
+  text-align: center;
+  padding: 1rem 2rem;
+  font-size: large;
+  background-color: var(--color-background-soft);
+  &:hover {
+    background-color: var(--color-background-mute);
+  }
+}
+</style>

--- a/packages/vue-client/src/views/RulesListView.vue
+++ b/packages/vue-client/src/views/RulesListView.vue
@@ -14,7 +14,7 @@ const variantsWithRulesDescription = getVariantsWithRulesDescription();
         v-for="variant in variantsWithRulesDescription"
         :key="variant"
         class="rules-link"
-        v-bind:to="{ name: 'rules', params: { variant: variant } }"
+        :to="{ name: 'rules', params: { variant: variant } }"
       >
         {{ toUpperCaseFirstLetter(variant) }}
       </RouterLink>

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { getRulesDescription } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
+import VariantDemoView from "./VariantDemoView.vue";
 
 const props = defineProps<{ variant: string }>();
 
@@ -21,6 +22,10 @@ function toUpperCaseFirstLetter(string: string) {
     <p v-if="!rulesDescription">Under Construction</p>
     <div v-if="rulesDescription" v-html="rulesDescription"></div>
   </div>
+  <div class="demo-container">
+    <h1>Demo</h1>
+    <VariantDemoView v-bind:variant="variant" />
+  </div>
 </template>
 
 <style scoped>
@@ -29,5 +34,8 @@ function toUpperCaseFirstLetter(string: string) {
 }
 :deep(strong, h1, h2) {
   font-weight: bold;
+}
+.demo-container {
+  padding: 1rem;
 }
 </style>

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -17,7 +17,7 @@ const variantExists = computed(() => getVariantList().includes(props.variant));
 <template>
   <main>
     <div v-if="!variantExists">Sorry, variant not found.</div>
-    <div v-if="variantExists" class="grid-page-layout">
+    <div v-if="variantExists" class="grid-page-layout rules-page">
       <div>
         <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
         <p v-if="!rulesDescription">Under Construction</p>
@@ -36,7 +36,7 @@ main {
   font-family: "helvetica", "arial", "sans-serif";
 }
 
-.grid-page-layout {
+.grid-page-layout.rules-page {
   max-width: none;
   overflow-x: scroll;
   grid-template-columns: minmax(45ch, 90ch) 1fr;

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -5,26 +5,19 @@ import {
 } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import VariantDemoView from "./VariantDemoView.vue";
+import { toUpperCaseFirstLetter } from "@/utils/format-utils";
 
 const props = defineProps<{ variant: string }>();
 
 const rulesDescription = computed(() => getRulesDescription(props.variant));
 
 const variantExists = computed(() => getVariantList().includes(props.variant));
-
-function toUpperCaseFirstLetter(string: string) {
-  if (string.length === 0) {
-    return "";
-  }
-
-  return string[0].toUpperCase() + string.slice(1);
-}
 </script>
 
 <template>
   <main>
     <div v-if="!variantExists">Sorry, variant not found.</div>
-    <div v-if="variantExists" class="grid-page-layout">
+    <div v-if="variantExists" class="grid-page-layout large-grid">
       <div>
         <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
         <p v-if="!rulesDescription">Under Construction</p>
@@ -45,6 +38,7 @@ main {
 
 .grid-page-layout {
   max-width: none;
+  overflow-x: scroll;
 }
 
 :deep(strong, h1, h2) {

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -17,7 +17,7 @@ const variantExists = computed(() => getVariantList().includes(props.variant));
 <template>
   <main>
     <div v-if="!variantExists">Sorry, variant not found.</div>
-    <div v-if="variantExists" class="grid-page-layout large-grid">
+    <div v-if="variantExists" class="grid-page-layout">
       <div>
         <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
         <p v-if="!rulesDescription">Under Construction</p>
@@ -39,6 +39,7 @@ main {
 .grid-page-layout {
   max-width: none;
   overflow-x: scroll;
+  grid-template-columns: minmax(45ch, 90ch) 1fr;
 }
 
 :deep(strong, h1, h2) {

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -25,7 +25,7 @@ const variantExists = computed(() => getVariantList().includes(props.variant));
       </div>
       <div>
         <h1>Demo</h1>
-        <VariantDemoView v-bind:variant="variant" />
+        <VariantDemoView :variant="variant" />
       </div>
     </div>
   </main>

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { getRulesDescription } from "@ogfcommunity/variants-shared";
+import {
+  getRulesDescription,
+  getVariantList,
+} from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import VariantDemoView from "./VariantDemoView.vue";
 
 const props = defineProps<{ variant: string }>();
 
 const rulesDescription = computed(() => getRulesDescription(props.variant));
+
+const variantExists = computed(() => getVariantList().includes(props.variant));
 
 function toUpperCaseFirstLetter(string: string) {
   if (string.length === 0) {
@@ -18,26 +23,30 @@ function toUpperCaseFirstLetter(string: string) {
 
 <template>
   <main>
-    <div class="grid-page-layout">
+    <div v-if="!variantExists">Sorry, variant not found.</div>
+    <div v-if="variantExists" class="grid-page-layout">
       <div>
-        <div class="rules-page">
-          <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
-          <p v-if="!rulesDescription">Under Construction</p>
-          <div v-if="rulesDescription" v-html="rulesDescription"></div>
-        </div>
-        <div>
-          <h1>Demo</h1>
-          <VariantDemoView v-bind:variant="variant" />
-        </div>
+        <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
+        <p v-if="!rulesDescription">Under Construction</p>
+        <div v-if="rulesDescription" v-html="rulesDescription"></div>
+      </div>
+      <div>
+        <h1>Demo</h1>
+        <VariantDemoView v-bind:variant="variant" />
       </div>
     </div>
   </main>
 </template>
 
 <style scoped>
-.rules-page {
+main {
   font-family: "helvetica", "arial", "sans-serif";
 }
+
+.grid-page-layout {
+  max-width: none;
+}
+
 :deep(strong, h1, h2) {
   font-weight: bold;
 }


### PR DESCRIPTION
This adds a new view that is linked to in the NavBar and has links to the rules page for variants with a (detailed) rules description.
Also I've added the demo board to the rules view as proposed in https://github.com/govariantsteam/govariants/issues/112
I wasn't able to make sure that the demo board fits, so I made its container scrollable on overflow.

### Rules List

![grafik](https://github.com/user-attachments/assets/85a401e5-ae46-4f67-a6db-ce413568dcc1)

![grafik](https://github.com/user-attachments/assets/a33090fd-c8f3-4ab5-9648-70c0e87e7649)

![grafik](https://github.com/user-attachments/assets/f6919006-c6bc-439d-b3b1-cc7d6c0454df)

### Rules Page

![grafik](https://github.com/user-attachments/assets/6bb506a7-96dc-4936-bfd3-ccfc256c527f)

![grafik](https://github.com/user-attachments/assets/60311ac3-8eb0-4175-af15-65d672439608)
