### PR TITLE
Fix husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+yarn lint
+yarn test

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start:server": "yarn workspace @ogfcommunity/variants-server run start",
     "start:client": "yarn workspace @ogfcommunity/variants-vue-client run start",
     "start:shared": "yarn workspace @ogfcommunity/variants-shared run start",
-    "new-variant": "node  ./scripts/create-new-app.js"
+    "new-variant": "node  ./scripts/create-new-app.js",
+    "postinstall": "husky"
   },
   "workspaces": {
     "packages": [
@@ -24,5 +25,8 @@
   "prettier": {
     "trailingComma": "all",
     "endOfLine": "lf"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "trailingComma": "all",
     "endOfLine": "lf"
   },
-  "devDependencies": {
+  "dependencies": {
     "husky": "^9.1.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1094,6 +1094,8 @@ __metadata:
 "@ogfcommunity/variants-monorepo@workspace:.":
   version: 0.0.0-use.local
   resolution: "@ogfcommunity/variants-monorepo@workspace:."
+  dependencies:
+    husky: ^9.1.7
   languageName: unknown
   linkType: soft
 
@@ -4492,6 +4494,15 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: b87fd89fce72391625271454e70f67fe405277415b48bcc0117ca73d31fa23a4241787afdc8d67f5a116cf37258c052f59ea82daffa72364d61351423848e3b8
+  languageName: node
+  linkType: hard
+
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It seems like postinstall is getting run on the heroku server (which includes the husky installation).  Since heroku prunes devDependencies, this fails. We can either move it out of postinstall, or just add it as a full dep.  This PR adds it to dependencies (we've done similar for other devDependencies)