### PR TITLE
fix display bug in quantum

### DIFF
--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -56,16 +56,22 @@ function board_with_quantum_stones(
     // difference in index.
     if (boardShape === "2d") {
       pos = pos as CoordinateLike;
-      (multicolor_stone_board as MulticolorStone[][])[pos.y][pos.x].colors.push(
-        "green",
+      addGreenIfOccupied(
+        (multicolor_stone_board as MulticolorStone[][])[pos.y][pos.x].colors,
       );
     } else {
-      (multicolor_stone_board as MulticolorStone[])[pos as number].colors.push(
-        "green",
+      addGreenIfOccupied(
+        (multicolor_stone_board as MulticolorStone[])[pos as number].colors,
       );
     }
   });
   return { board: multicolor_stone_board };
+}
+
+function addGreenIfOccupied(positionColors: string[]): void {
+  if (positionColors.length > 0) {
+    positionColors.push("green");
+  }
 }
 
 const board_0 = computed(() => {


### PR DESCRIPTION
fixes #358 

Reason for the bug is that previously empty intersection was represented as undefined, now by empty array, and we used to call `colors?.push("green")` which used to only add green when the position is already occupied. So I added a function that does this for the new representation.