### PR TITLE
Add admin mode to games page, and allow admins to kick users

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -116,7 +116,7 @@ router.post("/games/:gameId/move", async (req, res) => {
 });
 
 router.post("/games/:gameId/sit/:seat", async (req, res) => {
-  const user = req.user as User | undefined;
+  const user = req.user as UserResponse | undefined;
 
   try {
     const players: User[] = await takeSeat(
@@ -135,12 +135,12 @@ router.post("/games/:gameId/sit/:seat", async (req, res) => {
 
 router.post("/games/:gameId/leave/:seat", async (req, res) => {
   // TODO: make sure this is set to a valid id once we have user auth
-  const user_id = (req.user as User)?.id;
+  const user = req.user as UserResponse | undefined;
 
   const players: User[] = await leaveSeat(
     req.params.gameId,
     Number(req.params.seat),
-    user_id,
+    user,
   );
 
   io().emit(`game/${req.params.gameId}/seats`, players);

--- a/packages/vue-client/src/components/GameView/SeatComponent.vue
+++ b/packages/vue-client/src/components/GameView/SeatComponent.vue
@@ -10,6 +10,7 @@ import PlayerSymbol from "./PlayerSymbol.vue";
 
 const props = defineProps<{
   user_id?: string;
+  admin_mode?: boolean;
   occupant?: User;
   player_n: number;
   selected?: number;
@@ -67,6 +68,13 @@ const time_config = computed(
         >
           Leave Seat
         </button>
+        <button
+          v-if="hasLeaveCallback && occupant.id !== user_id && admin_mode"
+          class="btn-danger"
+          @click.stop="$emit('leave')"
+        >
+          Kick
+        </button>
       </div>
     </div>
     <PlayerSymbol
@@ -118,5 +126,12 @@ const time_config = computed(
   button {
     margin-left: 0.5rem;
   }
+}
+
+/* stolen from bootstrap */
+.btn-danger {
+  color: #fff;
+  background-color: #d9534f;
+  border-color: #d43f3a;
 }
 </style>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -46,6 +46,9 @@ const user = useCurrentUser();
 const playing_as = ref<undefined | number>(undefined);
 const displayed_round = computed(() => view_round.value ?? current_round.value);
 const time_control = ref<ITimeControlBase | null>(null);
+// Admins probably don't want to do admin stuff most of the time.  Let's hide
+// admin interface behind a toggle.
+const adminMode = ref<boolean>(false);
 
 function setNewState(stateResponse: GameStateResponse): void {
   const { timeControl: timeControl, ...state } = stateResponse;
@@ -254,6 +257,7 @@ const createTimeControlPreview = (
           <div v-for="(player, idx) in players" :key="idx">
             <SeatComponent
               :user_id="user?.id"
+              :admin_mode="adminMode"
               :occupant="player"
               :player_n="idx"
               @sit="sit(idx)"
@@ -288,6 +292,10 @@ const createTimeControlPreview = (
           style="font-weight: bold; font-size: 24pt"
         >
           Result: {{ game_state?.result }}
+        </div>
+        <div v-if="user?.role === 'admin'">
+          <input type="checkbox" v-model="adminMode" id="admin" />
+          <label for="admin">Admin Mode</label>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This adds a little toggle on the games page for admins that allows them to use special powers. It's off-by-default, so admins can enjoy games as normal users.  This PR also adds the power to kick a user from their seat.

![Screenshot of admin mode](https://github.com/user-attachments/assets/7be908dc-2ded-4204-8442-23a94159ea1b)

https://github.com/user-attachments/assets/2c7cd98b-c80e-487d-af68-ea66066309f1
