### PR TITLE
Allow admins to delete users

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -212,6 +212,23 @@ router.get("/users/:userId", async (req, res) => {
   }
 });
 
+router.delete("/users/:userId", async (req, res) => {
+  if ((req.user as UserResponse).role !== "admin") {
+    res.status(401);
+    res.json("You are not authorized to delete users");
+    return;
+  }
+
+  try {
+    // TODO: we should probably make deleteUser async so that we can report DB errors to the API caller
+    deleteUser(req.params.userId);
+    res.json("success");
+  } catch (e) {
+    res.status(500);
+    res.json(e.message);
+  }
+});
+
 function make_auth_cb(
   req: express.Request,
   res: express.Response,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -75,7 +75,9 @@ passport.deserializeUser<string>(function (id, callback) {
       if (user) {
         callback(null, user);
       } else {
-        callback(new Error(`No user with ID: ${id}`));
+        // This may be the case if a user has been deleted, but the user session persists.
+        // Sending null as the second argument invalidates the session.
+        callback(null, null);
       }
     })
     .catch((err) => {

--- a/packages/vue-client/package.json
+++ b/packages/vue-client/package.json
@@ -31,6 +31,7 @@
     "npm-run-all2": "^6.1.2",
     "pinia": "^2.1.4",
     "socket.io-client": "^4.8.1",
+    "sweetalert2": "^11.15.3",
     "vue": "^3.4.25",
     "vue-error-boundary": "^2.0.3",
     "vue-router": "^4.2.2",

--- a/packages/vue-client/src/requests.ts
+++ b/packages/vue-client/src/requests.ts
@@ -6,8 +6,15 @@ const SERVER_ORIGIN =
     : "http://localhost:3001";
 const SERVER_PATH_PREFIX = "/api";
 
-export async function get(path: string) {
-  const response = await fetch(SERVER_PATH_PREFIX + path);
+async function requestImpl(method: string, path: string, json?: object) {
+  const headers = new Headers();
+  headers.append("Origin", SERVER_ORIGIN); // TODO: Is this necessary?
+  headers.append("Content-Type", "application/json");
+  const response = await fetch(SERVER_PATH_PREFIX + path, {
+    method,
+    ...(json ? { body: JSON.stringify(json) } : null),
+    headers,
+  });
   const data = await response.json();
 
   if (!response.ok) {
@@ -20,25 +27,11 @@ export async function get(path: string) {
 // There's probably a way to get types into the APIs, but for now just have to
 // silence this warning.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function requestWithPayloadImpl(method: string, path: string, json: any) {
-  const headers = new Headers();
-  headers.append("Origin", SERVER_ORIGIN); // TODO: Is this necessary?
-  headers.append("Content-Type", "application/json");
-  const response = await fetch(SERVER_PATH_PREFIX + path, {
-    method,
-    body: JSON.stringify(json),
-    headers,
-  });
-  const data = await response.json();
+type NoPayloadRequest = (path: string) => Promise<any>;
 
-  if (!response.ok) {
-    throw new Error(data);
-  }
-
-  return data;
-}
-
-export const post = requestWithPayloadImpl.bind(undefined, "post");
-export const put = requestWithPayloadImpl.bind(undefined, "put");
+export const get: NoPayloadRequest = requestImpl.bind(undefined, "get");
+export const post = requestImpl.bind(undefined, "post");
+export const put = requestImpl.bind(undefined, "put");
+export const del: NoPayloadRequest = requestImpl.bind(undefined, "delete");
 
 export const socket = io(SERVER_ORIGIN);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1185,6 +1185,7 @@ __metadata:
     prettier: ^2.8.8
     rimraf: ^5.0.5
     socket.io-client: ^4.8.1
+    sweetalert2: ^11.15.3
     typescript: ^5.1.6
     vite: ^4.5.2
     vitest: ^0.32.4
@@ -7587,6 +7588,13 @@ __metadata:
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
   checksum: 53b1e247e68e05db7b3808b99b892bd36fb096e6fba213a06da7fab22045e97597db425c724f2bbd6c99a3c295e1e73f3e4de78592289f38431049e1277ca0ae
+  languageName: node
+  linkType: hard
+
+"sweetalert2@npm:^11.15.3":
+  version: 11.15.3
+  resolution: "sweetalert2@npm:11.15.3"
+  checksum: 8d75654fddd76ef5317b555a93e5f4648c74a0c19d95d9ecbf230e9640ce910bd29474d2b64e495ac886d2b3e087e1fe2d83ce3b0259f2ebac0a0f0bf8535f08
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Basically what the title says.  Additionally, I pulled in the [sweetalert2](https://sweetalert2.github.io) library.  This gives us ability to launch more advanced modals than `window.alert()`, which was necessary for the additional verification in the User deletion flow.

0) Log in as admin
1) Click "Delete User"

2) Enter user's name as a safeguard
![Screenshot_20241231_195147](https://github.com/user-attachments/assets/401b4eea-b25d-46d7-8ff6-7fcfbda40b49)
3a) On failure, inform the admin
![Screenshot_20241231_195215](https://github.com/user-attachments/assets/171b3ff7-3238-4034-adb2-a0dfae22062a)
3b) On success, inform the admin, then return home
![Screenshot_20241231_195239](https://github.com/user-attachments/assets/63b50536-8527-48bf-aaf6-93da16a224a2)


