### PR TITLE
add board preview, expandable pocket component

### DIFF
--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
@@ -7,10 +7,13 @@ import RhombitrihexagonalBoardConfigForm from "./RhombitrihexagonalBoardConfigFo
 import CircularBoardConfigForm from "./CircularBoardConfigForm.vue";
 import TrihexagonalConfigForm from "./TrihexagonalConfigForm.vue";
 import SierpinskyBoardConfigForm from "./SierpinskyBoardConfigForm.vue";
+import BoardPreview from "@/components/boards/BoardPreview.vue";
+import ExpandablePocket from "@/utils/ExpandablePocket.vue";
 
 const _props = defineProps<{ gridOnly?: boolean }>();
 
 const board_type: Ref<string> = ref(BoardPattern.Grid);
+const boardConfig: Ref<BoardConfig | undefined> = ref();
 
 // TODO: respect initial board config as defined by variant
 // TODO: Add BoardPattern -> (Label, Component) mapping to enable use of v-for
@@ -20,6 +23,7 @@ const emit = defineEmits<{
 }>();
 
 function emitConfigChange(config: BoardConfig) {
+  boardConfig.value = config;
   emit("configChanged", config);
 }
 </script>
@@ -63,5 +67,8 @@ function emitConfigChange(config: BoardConfig) {
       v-if="board_type === BoardPattern.Sierpinsky"
       @config-changed="emitConfigChange"
     />
+    <ExpandablePocket label="Board preview">
+      <BoardPreview v-if="boardConfig" :config="boardConfig"></BoardPreview>
+    </ExpandablePocket>
   </div>
 </template>

--- a/packages/vue-client/src/components/boards/BoardPreview.vue
+++ b/packages/vue-client/src/components/boards/BoardPreview.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import {
+  BoardConfig,
+  createBoard,
+  createGraph,
+  Intersection,
+} from "@ogfcommunity/variants-shared";
+import { computed } from "vue";
+
+const props = defineProps<{
+  config: BoardConfig;
+}>();
+
+const isGrid = computed(() => props.config.type === "grid");
+
+// grid
+
+const width = computed(() =>
+  props.config.type === "grid" ? props.config.width : null,
+);
+const height = computed(() =>
+  props.config.type === "grid" ? props.config.height : null,
+);
+
+// graph
+
+const intersections = computed(() => createBoard(props.config, Intersection));
+const graph = computed(() => createGraph(intersections.value, null));
+const viewBox = computed(() => {
+  const xPositions = intersections.value.map((i) => i.position.X);
+  const yPositions = intersections.value.map((i) => i.position.Y);
+  const minX = Math.min(...xPositions);
+  const minY = Math.min(...yPositions);
+  const width = Math.max(...xPositions) - Math.min(...xPositions);
+  const height = Math.max(...yPositions) - Math.min(...yPositions);
+  return {
+    minX: minX,
+    minY: minY,
+    width: width,
+    height: height,
+  };
+});
+</script>
+
+<template>
+  <!-- grid  -->
+  <svg
+    v-if="isGrid"
+    class="board-preview"
+    xmlns="http://www.w3.org/2000/svg"
+    v-bind:viewBox="`-1 -1 ${width! + 1} ${height! + 1}`"
+    style="background-color: #dcb35c"
+  >
+    <g>
+      <line
+        v-for="x in width"
+        :key="x"
+        v-bind:x1="x - 1"
+        v-bind:x2="x - 1"
+        v-bind:y1="0"
+        v-bind:y2="height! - 1"
+        color="pink"
+        stroke="pink"
+        stroke-width="0.02"
+      />
+
+      <line
+        v-for="y in height"
+        :key="y"
+        v-bind:x1="0"
+        v-bind:x2="width! - 1"
+        v-bind:y1="y - 1"
+        v-bind:y2="y - 1"
+        stroke="pink"
+        stroke-width="0.02"
+      />
+    </g>
+  </svg>
+
+  <!-- graph  -->
+  <svg
+    v-if="!isGrid"
+    class="board-preview"
+    xmlns="http://www.w3.org/2000/svg"
+    v-bind:viewBox="`${viewBox.minX - 1} ${viewBox.minY - 1} ${
+      viewBox.width + 2
+    } ${viewBox.height + 2}`"
+    style="background-color: #dcb35c"
+  >
+    <g>
+      <template v-for="(intersection, index) in intersections" :key="index">
+        <line
+          v-for="neighbour_index in graph
+            .neighbors(index)
+            .filter((n) => n < index)"
+          :key="neighbour_index"
+          v-bind:x1="intersection.position.X"
+          v-bind:x2="intersections[neighbour_index].position.X"
+          v-bind:y1="intersection.position.Y"
+          v-bind:y2="intersections[neighbour_index].position.Y"
+        ></line>
+      </template>
+    </g>
+  </svg>
+</template>
+
+<style scoped>
+line {
+  stroke: black;
+  stroke-width: 0.02;
+  stroke-linecap: round;
+}
+.board-preview {
+  width: 300px;
+  height: 300px;
+}
+</style>

--- a/packages/vue-client/src/utils/ExpandablePocket.vue
+++ b/packages/vue-client/src/utils/ExpandablePocket.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faChevronUp, faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { ref } from "vue";
+
+library.add(faChevronUp, faChevronDown);
+
+const props = defineProps<{ label: string; initialExpanded?: boolean }>();
+
+const isExpanded = ref(props.initialExpanded ?? false);
+
+const toggleExpansion = () => {
+  isExpanded.value = !isExpanded.value;
+};
+</script>
+
+<template>
+  <div class="expandable-container">
+    <text> {{ props.label }} </text>
+    <button type="button" @click="toggleExpansion()" class="expand-button">
+      <font-awesome-icon v-if="isExpanded" icon="fa-solid fa-chevron-up" />
+      <font-awesome-icon v-if="!isExpanded" icon="fa-solid fa-chevron-down" />
+    </button>
+  </div>
+  <slot v-if="isExpanded"></slot>
+</template>
+
+<style scoped>
+.expandable-container {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  .expand-button {
+    flex: 0;
+  }
+}
+</style>


### PR DESCRIPTION
issue: #187 

Adds a board preview component, alongside a component "expandable pocket" which can be used to expand / collapse arbitrary content.

![grafik](https://github.com/user-attachments/assets/3fca4458-b3d6-4220-a9f9-c8442757baf6)
