### PR TITLE
[fractional] only include unstaged players in nextToPlay

### DIFF
--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -8,6 +8,15 @@ import { BoardPattern } from "../../lib/abstractBoard/boardFactory";
 import { Variant } from "../../variant";
 import { fractionalRulesDescription } from "../../templates/fractional_rules";
 
+function getNullIndexes(arr: unknown[]) {
+  return arr.reduce((indexes: number[], element, index) => {
+    if (element == null) {
+      indexes.push(index);
+    }
+    return indexes;
+  }, []);
+}
+
 export type Color =
   | "black"
   | "white"
@@ -128,9 +137,7 @@ export class Fractional extends AbstractBaduk<
   }
 
   nextToPlay(): number[] {
-    return this.phase === "gameover"
-      ? []
-      : [...Array(this.config.players.length).keys()];
+    return this.phase === "gameover" ? [] : getNullIndexes(this.stagedMoves);
   }
 
   numPlayers(): number {


### PR DESCRIPTION
Currently, we list every player in `nextToPlay` because, technically, all players may move.  I propose we exclude staged players since they are not required to play again in the round.  Motivation: I believe this will be useful in [Forums game](https://www.govariants.com/game/670952d842e74078c7a967fe) where players have often not realized they were holding up the round.

If this change is agreeable, I'm happy to follow up and update all the parallel variants.

## Testing

Manually, I tried a fractional game, and observed:

a) players are still able to edit their moves for the duration of the round
b) only unstaged players are listed in the "Players to move" component

https://github.com/user-attachments/assets/c5eb156f-8eae-4c35-881d-76a4e18fa5c9

