### PR TITLE
Update parallel.ts to exclude unstaged players from nextToMove()

### DIFF
--- a/packages/shared/src/lib/__tests__/utils.test.ts
+++ b/packages/shared/src/lib/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { getOnlyMove } from "../utils";
+import { getNullIndices, getOnlyMove } from "../utils";
 
 const MOVE_STRING = "test";
 
@@ -17,4 +17,8 @@ test("getOnlyMove - more than one move", () => {
 
 test("getOnlyMove - no moves", () => {
   expect(() => getOnlyMove({})).toThrow("No players specified!");
+});
+
+test("getNullIndices", () => {
+  expect(getNullIndices([1, null, "foo", undefined])).toEqual([1, 3]);
 });

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -19,11 +19,6 @@ export function getOnlyMove(moves: MovesType): {
   return { player, move: moves[player] };
 }
 
-export type Participation = {
-  playerNr: number;
-  dropOutAtRound: number | null;
-};
-
 export function gamesFilterToUrlParams(filter: GamesFilter): string {
   return (
     (filter.user_id ? `&user_id=${encodeURIComponent(filter.user_id)}` : "") +

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -53,3 +53,12 @@ export function assertRectangular2DArrayOf<T>(
 
   return array2D as T[][];
 }
+
+export function getNullIndices(arr: unknown[]) {
+  return arr.reduce((indexes: number[], element, index) => {
+    if (element == null) {
+      indexes.push(index);
+    }
+    return indexes;
+  }, []);
+}

--- a/packages/shared/src/variants/fractional/fractional.ts
+++ b/packages/shared/src/variants/fractional/fractional.ts
@@ -7,15 +7,7 @@ import { FractionalStone } from "./fractionalStone";
 import { BoardPattern } from "../../lib/abstractBoard/boardFactory";
 import { Variant } from "../../variant";
 import { fractionalRulesDescription } from "../../templates/fractional_rules";
-
-function getNullIndexes(arr: unknown[]) {
-  return arr.reduce((indexes: number[], element, index) => {
-    if (element == null) {
-      indexes.push(index);
-    }
-    return indexes;
-  }, []);
-}
+import { getNullIndices } from "../../lib/utils";
 
 export type Color =
   | "black"
@@ -137,7 +129,7 @@ export class Fractional extends AbstractBaduk<
   }
 
   nextToPlay(): number[] {
-    return this.phase === "gameover" ? [] : getNullIndexes(this.stagedMoves);
+    return this.phase === "gameover" ? [] : getNullIndices(this.stagedMoves);
   }
 
   numPlayers(): number {

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -80,7 +80,7 @@ export class ParallelGo extends AbstractGame<
     }
 
     if (move === "resign" || move === "timeout") {
-      this.participants = this.participants.filter((val) => val != player);
+      this.participants = this.participants.filter((val) => val !== player);
 
       if (this.participants.length < 2) {
         if (this.participants.length === 1) {


### PR DESCRIPTION
- `Indexes` -> `Indices`, move `getNullIndices()` into utils
    - Tbh I thought we had more than 2 parallel variants, hence the move to utils. 
- `parallel` to take the same `nextToMove` approach as `fractional` (see #381)

Tested:

- unit tests caught a lot!
- manually checked the parallel variant

