### PR TITLE
shallow copy config to allow variants to mutate it

### DIFF
--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -46,6 +46,12 @@ const game = computed(() =>
 );
 const displayed_round = computed(() => view_round.value ?? moves.length);
 
+function cloneConfig(config: object): object {
+  // here we use this on a vue proxy object,
+  // and structuredClone doesn't work on those.
+  return JSON.parse(JSON.stringify(config));
+}
+
 function getGame(
   variant: string,
   config: object,
@@ -53,7 +59,7 @@ function getGame(
   viewRound: number | null,
   playingAs?: number,
 ) {
-  const game_obj = makeGameObject(variant, { ...config });
+  const game_obj = makeGameObject(variant, cloneConfig(config));
 
   let state: object | null = null;
   for (let i = 0; i < moves.length; i++) {
@@ -82,7 +88,7 @@ function getGame(
 const specialMoves = computed(() =>
   !props.variant || !config.value
     ? {}
-    : makeGameObject(props.variant, config.value).specialMoves(),
+    : makeGameObject(props.variant, cloneConfig(config.value)).specialMoves(),
 );
 const variantGameView = computed(() => getPlayingTable(props.variant));
 const variantDescriptionShort = computed(() => getDescription(props.variant));

--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -48,12 +48,12 @@ const displayed_round = computed(() => view_round.value ?? moves.length);
 
 function getGame(
   variant: string,
-  config: unknown,
+  config: object,
   moves: Array<MovesType>,
   viewRound: number | null,
   playingAs?: number,
 ) {
-  const game_obj = makeGameObject(variant, config);
+  const game_obj = makeGameObject(variant, { ...config });
 
   let state: object | null = null;
   for (let i = 0; i < moves.length; i++) {


### PR DESCRIPTION
Prevent an infinite loop that happens when variants mutate their config.

This is not a problem in GameView, because there we get the game state via server requests.