### PR TITLE
Fixed self-capture!

### DIFF
--- a/packages/shared/src/variants/__tests__/super_tic_tac_go.test.ts
+++ b/packages/shared/src/variants/__tests__/super_tic_tac_go.test.ts
@@ -1,4 +1,4 @@
-import { SuperTicTacGo, Nonant } from "../super_tic_tac_go";
+import { SuperTicTacGo } from "../super_tic_tac_go";
 import { Color } from "../baduk";
 
 const B = Color.BLACK,
@@ -8,23 +8,13 @@ const B = Color.BLACK,
 test("Play a game", () => {
   const game = new SuperTicTacGo({ width: 9, height: 9, komi: 0 });
   expect(game.nextToPlay()).toEqual([0]);
-  expect(game.getLegalVertices().length).toEqual(81);
-  expect(() => game.getLegalNonant()).toThrow();
 
   game.playMove(0, "aa");
-  expect(game.getLegalVertices().length).toEqual(8);
   expect(game.nextToPlay()).toEqual([1]);
-  let nonant = new Nonant(0, 0);
-  expect(game.getLegalNonant()).toEqual(nonant);
   expect(() => game.playMove(1, "ee")).toThrow();
   game.playMove(1, "bb");
-  nonant = new Nonant(1, 1);
-  expect(game.getLegalNonant()).toEqual(nonant);
   expect(game.nextToPlay()).toEqual([0]);
-  expect(game.getLegalVertices().length).toEqual(9);
   game.playMove(0, "ee");
-  expect(game.getLegalNonant()).toEqual(nonant);
-  expect(game.getLegalVertices().length).toEqual(8);
 
   expect(game.exportState().board).toEqual([
     [B, _, _, _, _, _, _, _, _],


### PR DESCRIPTION
sttg now overrides `Baduk.playMoveInternal()` to handle self-capture moves. 

Removed tests for private methods, as well as the sttg method written specifically for testing. 