### PR TITLE
Generalised pyramid counting

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,5 +28,7 @@ export * from "./variants/s_fractional";
 export { count_binary_ones } from "./variants/thue_morse";
 export { sFractionalMoveColors } from "./variants/s_fractional";
 export { type LighthouseState } from "./variants/lighthouse/lighthouse";
+export { type PyramidConfig } from "./variants/pyramid";
+export { generalizedPyramid } from "./lib/graph-utils";
 
 export const SITE_NAME = "Go Variants";

--- a/packages/shared/src/lib/__tests__/graph-utils.tests.ts
+++ b/packages/shared/src/lib/__tests__/graph-utils.tests.ts
@@ -1,0 +1,58 @@
+import {
+  allPairsShortestPaths,
+  eccentricity,
+  generalizedPyramid,
+} from "../graph-utils";
+
+test("allPairsShortestPaths", () => {
+  // adjacency list of a 5x5 rectangular grid.
+  // vertices enumerated left-right, top-bottom.
+  const graph_5x5_adjacency = [
+    [1, 5],
+    [0, 2, 6],
+    [1, 3, 7],
+    [2, 4, 8],
+    [3, 9],
+    [0, 6, 10],
+    [1, 5, 7, 11],
+    [2, 6, 8, 12],
+    [3, 7, 9, 13],
+    [4, 8, 14],
+    [5, 11, 15],
+    [6, 10, 12, 16],
+    [7, 11, 13, 17],
+    [8, 12, 14, 18],
+    [9, 13, 19],
+    [10, 16, 20],
+    [11, 15, 17, 21],
+    [12, 16, 18, 22],
+    [13, 17, 19, 23],
+    [14, 18, 24],
+    [15, 21],
+    [20, 16, 22],
+    [21, 17, 23],
+    [22, 18, 24],
+    [19, 23],
+  ];
+
+  const dists = allPairsShortestPaths(graph_5x5_adjacency);
+  expect(dists).toBeTruthy();
+  expect(dists).toHaveLength(25);
+  expect(dists[0]).toEqual([
+    0, 1, 2, 3, 4, 1, 2, 3, 4, 5, 2, 3, 4, 5, 6, 3, 4, 5, 6, 7, 4, 5, 6, 7, 8,
+  ]);
+
+  const ecc = eccentricity(graph_5x5_adjacency);
+  expect(ecc).toBeTruthy();
+  expect(ecc).toHaveLength(25);
+  expect(ecc).toEqual([
+    8, 7, 6, 7, 8, 7, 6, 5, 6, 7, 6, 5, 4, 5, 6, 7, 6, 5, 6, 7, 8, 7, 6, 7, 8,
+  ]);
+
+  const pyr = generalizedPyramid(graph_5x5_adjacency);
+  expect(pyr).toBeTruthy();
+  expect(pyr).toHaveLength(25);
+  expect(pyr).toEqual([
+    1, 2, 3, 2, 1, 2, 3, 4, 3, 2, 3, 4, 5, 4, 3, 2, 3, 4, 3, 2, 1, 2, 3, 2, 1,
+  ]);
+});

--- a/packages/shared/src/lib/graph-utils.ts
+++ b/packages/shared/src/lib/graph-utils.ts
@@ -52,17 +52,19 @@ export function eccentricity(graph_adjacency: number[][]): number[] {
  * Time complexity O(n^3)
  *
  * Returns an array A with A[i] being the generalized pyramid value of vertex i,
- * or A[i] = 1 when the number of vertices is > 1000.
+ * or undefined when the number of vertices is > 1000.
  *
  * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
  */
-export function generalizedPyramid(graph_adjacency: number[][]): number[] {
+export function generalizedPyramid(
+  graph_adjacency: number[][],
+): number[] | undefined {
   const vertexThreshold = 1000;
   if (graph_adjacency.length > vertexThreshold) {
     console.warn(
       `did not compute generalized pyramid weights because ${graph_adjacency.length} is too many vertices. The max is ${vertexThreshold}`,
     );
-    return graph_adjacency.map(() => 1);
+    return undefined;
   }
 
   const _eccentricity = eccentricity(graph_adjacency);

--- a/packages/shared/src/lib/graph-utils.ts
+++ b/packages/shared/src/lib/graph-utils.ts
@@ -8,11 +8,15 @@
  *
  * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
  */
-function allPairsShortestPaths(graph_adjacency: number[][]): number[][] {
+export function allPairsShortestPaths(graph_adjacency: number[][]): number[][] {
   const n = graph_adjacency.length;
-  const distMatrix = graph_adjacency.map((neighbors) =>
+  const distMatrix = graph_adjacency.map((neighbors, vertex_idx) =>
     graph_adjacency.map((_, idx) =>
-      neighbors.includes(idx) ? 1 : Number.POSITIVE_INFINITY,
+      vertex_idx === idx
+        ? 0
+        : neighbors.includes(idx)
+          ? 1
+          : Number.POSITIVE_INFINITY,
     ),
   );
 
@@ -37,7 +41,7 @@ function allPairsShortestPaths(graph_adjacency: number[][]): number[][] {
  *
  * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
  */
-function eccentricity(graph_adjacency: number[][]): number[] {
+export function eccentricity(graph_adjacency: number[][]): number[] {
   return allPairsShortestPaths(graph_adjacency).map((vertex_adjacency) =>
     Math.max(...vertex_adjacency.filter((n) => Number.isFinite(n))),
   );

--- a/packages/shared/src/lib/graph-utils.ts
+++ b/packages/shared/src/lib/graph-utils.ts
@@ -42,8 +42,8 @@ export function allPairsShortestPaths(graph_adjacency: number[][]): number[][] {
  * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
  */
 export function eccentricity(graph_adjacency: number[][]): number[] {
-  return allPairsShortestPaths(graph_adjacency).map((vertex_adjacency) =>
-    Math.max(...vertex_adjacency.filter((n) => Number.isFinite(n))),
+  return allPairsShortestPaths(graph_adjacency).map((vertex_distances) =>
+    Math.max(...vertex_distances.filter((n) => Number.isFinite(n))),
   );
 }
 
@@ -57,9 +57,10 @@ export function eccentricity(graph_adjacency: number[][]): number[] {
  * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
  */
 export function generalizedPyramid(graph_adjacency: number[][]): number[] {
-  if (graph_adjacency.length > 1000) {
+  const vertexThreshold = 1000;
+  if (graph_adjacency.length > vertexThreshold) {
     console.warn(
-      `did not compute all pairs shortest paths, because ${graph_adjacency.length} is too many vertices.`,
+      `did not compute generalized pyramid weights because ${graph_adjacency.length} is too many vertices. The max is ${vertexThreshold}`,
     );
     return graph_adjacency.map(() => 1);
   }

--- a/packages/shared/src/lib/graph.utils.ts
+++ b/packages/shared/src/lib/graph.utils.ts
@@ -1,0 +1,39 @@
+import { SerializedGraph } from "./graph";
+
+/**
+ * Calculates minimum distances for all vertex pairs with the algorithm by Floyd and Warshall.
+ * Time complexity O(n^3)
+ *
+ * @param graph_adjacency - The graph adjacency list as given by Graph.export.
+ * Returns the matrix of minimum distances (which can contain positive infinity
+ * for disconnected graphs). DistMatrix[i][j] gives the minimum distance from
+ * vertex i to vertex j.
+ */
+export function allPairsShortestPaths(
+  graph_adjacency: SerializedGraph<unknown>["adjacency_array"],
+): number[][] {
+  const n = graph_adjacency.length;
+  const distMatrix = graph_adjacency.map((neighbors) =>
+    graph_adjacency.map((_, idx) =>
+      neighbors.includes(idx) ? 1 : Number.POSITIVE_INFINITY,
+    ),
+  );
+
+  // if (n > 1000) {
+  //   console.warn(
+  //     `did not compute all pairs shortest paths, because ${n} is too many vertices.`,
+  //   );
+  //   return graph_adjacency.map(_ => graph_adjacency.map(_ => 1));
+  // }
+
+  for (let i = 0; i < n; i++)
+    for (let j = 0; j < n; j++)
+      for (let k = 0; k < n; k++) {
+        distMatrix[j][k] = Math.min(
+          distMatrix[j][k],
+          distMatrix[j][i] + distMatrix[i][k],
+        );
+      }
+
+  return distMatrix;
+}

--- a/packages/shared/src/lib/graph.utils.ts
+++ b/packages/shared/src/lib/graph.utils.ts
@@ -1,30 +1,20 @@
-import { SerializedGraph } from "./graph";
-
 /**
  * Calculates minimum distances for all vertex pairs with the algorithm by Floyd and Warshall.
  * Time complexity O(n^3)
  *
- * @param graph_adjacency - The graph adjacency list as given by Graph.export.
- * Returns the matrix of minimum distances (which can contain positive infinity
- * for disconnected graphs). DistMatrix[i][j] gives the minimum distance from
+ * Returns the matrix of minimum distances M (which can contain positive infinity
+ * for disconnected graphs), i.e. M[i][j] is the minimum distance from
  * vertex i to vertex j.
+ *
+ * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
  */
-export function allPairsShortestPaths(
-  graph_adjacency: SerializedGraph<unknown>["adjacency_array"],
-): number[][] {
+function allPairsShortestPaths(graph_adjacency: number[][]): number[][] {
   const n = graph_adjacency.length;
   const distMatrix = graph_adjacency.map((neighbors) =>
     graph_adjacency.map((_, idx) =>
       neighbors.includes(idx) ? 1 : Number.POSITIVE_INFINITY,
     ),
   );
-
-  // if (n > 1000) {
-  //   console.warn(
-  //     `did not compute all pairs shortest paths, because ${n} is too many vertices.`,
-  //   );
-  //   return graph_adjacency.map(_ => graph_adjacency.map(_ => 1));
-  // }
 
   for (let i = 0; i < n; i++)
     for (let j = 0; j < n; j++)
@@ -36,4 +26,41 @@ export function allPairsShortestPaths(
       }
 
   return distMatrix;
+}
+
+/**
+ * Calculates the eccentricity for all vertices, which is the maximum distance
+ * to another vertex.
+ * Time complexity O(n^3)
+ *
+ * Returns an array A with A[i] being the eccentricity of vertex i.
+ *
+ * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
+ */
+function eccentricity(graph_adjacency: number[][]): number[] {
+  return allPairsShortestPaths(graph_adjacency).map((vertex_adjacency) =>
+    Math.max(...vertex_adjacency.filter((n) => Number.isFinite(n))),
+  );
+}
+
+/**
+ * Calculates the generalized pyramid values for all vertices.
+ * Time complexity O(n^3)
+ *
+ * Returns an array A with A[i] being the generalized pyramid value of vertex i,
+ * or A[i] = 1 when the number of vertices is > 1000.
+ *
+ * @param graph_adjacency - The vertex adjacency list as given by Graph.export.
+ */
+export function generalizedPyramid(graph_adjacency: number[][]): number[] {
+  if (graph_adjacency.length > 1000) {
+    console.warn(
+      `did not compute all pairs shortest paths, because ${graph_adjacency.length} is too many vertices.`,
+    );
+    return graph_adjacency.map(() => 1);
+  }
+
+  const _eccentricity = eccentricity(graph_adjacency);
+  const diameter = Math.max(..._eccentricity);
+  return _eccentricity.map((e) => 1 + diameter - e);
 }

--- a/packages/shared/src/templates/pyramid_rules.ts
+++ b/packages/shared/src/templates/pyramid_rules.ts
@@ -7,4 +7,6 @@ The point value of an intersection is equal to one plus the minimum distance to 
 For the automated scoring to be correct, all dead stones need to be captured manually.
 # Credit
 [https://forums.online-go.com/t/pyramid-go/36944](https://forums.online-go.com/t/pyramid-go/36944)
+# Pyramid on Graph boards
+On graph boards pyramid scoring can be generalized as follows. A node v has value 1 + d + e(v), where d is the diameter of the graph, and e(v) is the eccentricity of v. These definitions can be found at [https://en.wikipedia.org/wiki/Distance_(graph_theory)](https://en.wikipedia.org/wiki/Distance_(graph_theory))
 `;

--- a/packages/shared/src/templates/pyramid_rules.ts
+++ b/packages/shared/src/templates/pyramid_rules.ts
@@ -8,5 +8,5 @@ For the automated scoring to be correct, all dead stones need to be captured man
 # Credit
 [https://forums.online-go.com/t/pyramid-go/36944](https://forums.online-go.com/t/pyramid-go/36944)
 # Pyramid on Graph boards
-On graph boards pyramid scoring can be generalized as follows. A node v has value 1 + d + e(v), where d is the diameter of the graph, and e(v) is the eccentricity of v. These definitions can be found at [https://en.wikipedia.org/wiki/Distance_(graph_theory)](https://en.wikipedia.org/wiki/Distance_(graph_theory))
+On graph boards pyramid scoring can be generalized as follows. A node v has value 1 + d - e(v), where d is the diameter of the graph, and e(v) is the eccentricity of v. These definitions can be found at [https://en.wikipedia.org/wiki/Distance_(graph_theory)](https://en.wikipedia.org/wiki/Distance_(graph_theory))
 `;

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -1,25 +1,55 @@
-import { Baduk, BadukState, Color, GridBaduk, gridBadukVariant } from "./baduk";
+import { Baduk, BadukBoard, BadukState, badukVariant, Color } from "./baduk";
 import { Grid } from "../lib/grid";
-import { GridBadukConfig, NewBadukConfig } from "./baduk_utils";
+import {
+  isGridBadukConfig,
+  isLegacyBadukConfig,
+  LegacyBadukConfig,
+  NewBadukConfig,
+  NewGridBadukConfig,
+} from "./baduk_utils";
 import { pyramidRuleDescription } from "../templates/pyramid_rules";
 import { DefaultBoardState, MulticolorStone } from "../lib/board_types";
 import { weightedMean, RGBColor } from "../lib/color-utils";
+import { GraphWrapper } from "../lib/graph";
+import {
+  BoardPattern,
+  createBoard,
+  createGraph,
+  Intersection,
+} from "../lib/abstractBoard";
+import { Variant } from "../variant";
+import { getWidthAndHeight } from "./baduk_utils";
 
-export class PyramidGo extends GridBaduk {
-  private weights: Grid<number>;
-  declare board: Grid<Color>;
-  declare score_board?: Grid<Color>;
+export type PyramidConfig = NewBadukConfig & { weights?: number[] };
 
-  constructor(config: GridBadukConfig) {
+export class PyramidGo extends Baduk {
+  private weights: BadukBoard<number>;
+
+  constructor(config: PyramidConfig | LegacyBadukConfig) {
     super(config);
 
     // Note: config may be undefined, but this.config is
     // defined after the AbstractGame constructor is called.
-    const { width, height } = this.config.board;
+    if (isLegacyBadukConfig(config) || isGridBadukConfig(config)) {
+      const { width, height } = getWidthAndHeight(config);
 
-    this.weights = new Grid(width, height)
-      .fill(0)
-      .map((_, { x, y }) => Math.min(x + 1, y + 1, width - x, height - y));
+      // If/when we support custom weights, then we should check if they are set here.
+
+      this.weights = new Grid(width, height)
+        .fill(0)
+        .map((_, { x, y }) => Math.min(x + 1, y + 1, width - x, height - y));
+    } else {
+      if (!config.weights) {
+        throw new Error("weights are required for graph boards.");
+      }
+
+      // TODO: validate weights
+
+      const graph = createGraph(createBoard(config.board, Intersection), null);
+      this.weights = new GraphWrapper(
+        graph.map((_, idx) => config.weights![idx]),
+      );
+    }
   }
 
   get result(): string {
@@ -39,29 +69,42 @@ export class PyramidGo extends GridBaduk {
 
   private pointsForColor(c: Color) {
     if (this.score_board === undefined) return 0;
-    return this.score_board
-      .map((color, index) =>
-        color === c ? (this.weights.at(index) as number) : 0,
-      )
-      .reduce((x, y) => x + y, 0);
+    let points = 0;
+    this.score_board.forEach(
+      (color, index) =>
+        (points += color === c ? (this.weights.at(index) as number) : 0),
+    );
+    return points;
   }
 
-  static uiTransform<ConfigT extends NewBadukConfig = NewBadukConfig>(
-    config: ConfigT,
-    gamestate: BadukState,
-  ): { config: ConfigT; gamestate: DefaultBoardState } {
-    const width = gamestate.board.length;
-    const height = gamestate.board.at(0)?.length ?? 0;
+  static defaultConfig(): NewGridBadukConfig {
+    return {
+      komi: 6.5,
+      board: {
+        type: BoardPattern.Grid,
+        width: 19,
+        height: 19,
+      },
+    };
+  }
+}
+
+function pyramidUiTransform(
+  config: PyramidConfig,
+  gamestate: BadukState,
+): { config: PyramidConfig; gamestate: DefaultBoardState } {
+  const light_brown = new RGBColor(220, 179, 92);
+  const dark_brown = new RGBColor(133, 62, 26);
+  const badukTransformed = Baduk.uiTransform(config, gamestate);
+
+  if (isGridBadukConfig(config)) {
+    const { width, height } = getWidthAndHeight(config);
     const maxValue = 1 + Math.floor(Math.min(width, height) / 2);
 
-    function valueOf(x: number, y: number): number {
+    const valueOf = (x: number, y: number): number => {
       return Math.min(x + 1, y + 1, width - x, height - y);
-    }
+    };
 
-    const light_brown = new RGBColor(220, 179, 92);
-    const dark_brown = new RGBColor(133, 62, 26);
-
-    const badukTransformed = Baduk.uiTransform(config, gamestate);
     badukTransformed.gamestate.board = (
       badukTransformed.gamestate.board as MulticolorStone[][]
     ).map((row, x) =>
@@ -78,13 +121,34 @@ export class PyramidGo extends GridBaduk {
 
     return badukTransformed;
   }
+
+  if (!config.weights) {
+    console.error("weights must be set for graph boards!");
+    return { config, gamestate: { board: [] } };
+  }
+
+  const maxValue = Math.max(...config.weights);
+
+  badukTransformed.gamestate.board = (
+    badukTransformed.gamestate.board as MulticolorStone[]
+  ).map((multicolorStone, y) => ({
+    ...multicolorStone,
+    background_color: weightedMean(
+      light_brown,
+      1 - config.weights![y] / maxValue,
+      dark_brown,
+      config.weights![y] / maxValue,
+    ).toString(),
+  }));
+
+  return badukTransformed;
 }
 
-export const pyramidVariant: typeof gridBadukVariant = {
-  ...gridBadukVariant,
+export const pyramidVariant: Variant<PyramidConfig, BadukState> = {
+  ...badukVariant,
   gameClass: PyramidGo,
   description:
     "Baduk with pyramid scoring\n Center is worth most points, edge the least",
   rulesDescription: pyramidRuleDescription,
-  uiTransform: PyramidGo.uiTransform,
+  uiTransform: pyramidUiTransform,
 };

--- a/packages/shared/src/variants/pyramid.ts
+++ b/packages/shared/src/variants/pyramid.ts
@@ -107,8 +107,8 @@ function pyramidUiTransform(
 
     badukTransformed.gamestate.board = (
       badukTransformed.gamestate.board as MulticolorStone[][]
-    ).map((row, x) =>
-      row.map((multicolorStone, y) => ({
+    ).map((row, y) =>
+      row.map((multicolorStone, x) => ({
         ...multicolorStone,
         background_color: weightedMean(
           light_brown,
@@ -131,15 +131,17 @@ function pyramidUiTransform(
 
   badukTransformed.gamestate.board = (
     badukTransformed.gamestate.board as MulticolorStone[]
-  ).map((multicolorStone, y) => ({
-    ...multicolorStone,
-    background_color: weightedMean(
-      light_brown,
-      1 - config.weights![y] / maxValue,
-      dark_brown,
-      config.weights![y] / maxValue,
-    ).toString(),
-  }));
+  ).map((multicolorStone, x) => {
+    return {
+      ...multicolorStone,
+      background_color: weightedMean(
+        light_brown,
+        1 - config.weights![x] / maxValue,
+        dark_brown,
+        config.weights![x] / maxValue,
+      ).toString(),
+    };
+  });
 
   return badukTransformed;
 }

--- a/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import {
+  createBoard,
+  createGraph,
+  Intersection,
+  NewBadukConfig,
+  generalizedPyramid,
+  PyramidConfig,
+} from "@ogfcommunity/variants-shared";
+import BadukConfigForm from "./BadukConfigForm.vue";
+
+defineProps<{
+  initialConfig: NewBadukConfig;
+}>();
+
+const emit = defineEmits<{
+  (e: "configChanged", config: PyramidConfig): void;
+}>();
+
+function emitConfigChange(config: NewBadukConfig) {
+  const graph = createGraph(createBoard(config.board, Intersection), null);
+  const weights = generalizedPyramid(graph.export().adjacency_array);
+  console.log(weights);
+
+  emit("configChanged", { ...config, weights: weights });
+}
+</script>
+
+<template>
+  <BadukConfigForm
+    @config-changed="emitConfigChange($event)"
+    :initial-config="$props.initialConfig"
+  />
+</template>

--- a/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
@@ -18,11 +18,15 @@ const emit = defineEmits<{
 }>();
 
 function emitConfigChange(config: NewBadukConfig) {
-  const graph = createGraph(createBoard(config.board, Intersection), null);
-  const weights = generalizedPyramid(graph.export().adjacency_array);
-  console.log(weights);
-
-  emit("configChanged", { ...config, weights: weights });
+  emit("configChanged", {
+    ...config,
+    ...(config.board.type !== "grid" && {
+      weights: generalizedPyramid(
+        createGraph(createBoard(config.board, Intersection), null).export()
+          .adjacency_array,
+      ),
+    }),
+  });
 }
 </script>
 

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -118,7 +118,7 @@ const viewBox = computed(() => {
           v-if="
             props.board?.at(index)?.background_color && voronoiDiagram[index]
           "
-          :points="getPolygonPointsString(voronoiDiagram[index])"
+          :points="getPolygonPointsString(voronoiDiagram[index]!)"
           :fill="props.board.at(index)!.background_color"
         />
       </template>

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -31,12 +31,14 @@ const voronoiDiagram = computed(() => {
     y: vector.position.Y,
   }));
 
-  return new Voronoi().compute(sites, {
+  const diagram = new Voronoi().compute(sites, {
     xl: viewBox.value.minX - 0.5,
     xr: viewBox.value.minX + viewBox.value.width + 0.5,
     yt: viewBox.value.minY - 0.5,
     yb: viewBox.value.minY + viewBox.value.height + 0.5,
   });
+
+  return sites.map((site) => diagram.cells.find((cell) => cell.site === site)!);
 });
 
 function getPolygonPointsString(cell: Cell): string {
@@ -100,7 +102,7 @@ const viewBox = computed(() => {
       <template v-for="(_, index) in intersections" :key="index">
         <polygon
           v-if="props.board?.at(index)?.background_color"
-          :points="getPolygonPointsString(voronoiDiagram.cells[index])"
+          :points="getPolygonPointsString(voronoiDiagram[index])"
           :fill="props.board.at(index)!.background_color"
         />
       </template>

--- a/packages/vue-client/src/config_form_map.ts
+++ b/packages/vue-client/src/config_form_map.ts
@@ -4,6 +4,7 @@ import ParalleGoConfigForm from "@/components/GameCreation/ParallelGoConfigForm.
 import DriftGoConfigFormVue from "./components/GameCreation/DriftGoConfigForm.vue";
 import GridBadukConfigForm from "./components/GameCreation/GridBadukConfigForm.vue";
 import SFractionalConfigForm from "./components/GameCreation/SFractionalConfigForm.vue";
+import PyramidConfigForm from "./components/GameCreation/PyramidConfigForm.vue";
 
 export const config_form_map: {
   [variant: string]: Component<{ initialConfig: object }>;
@@ -13,7 +14,7 @@ export const config_form_map: {
   parallel: ParalleGoConfigForm,
   capture: BadukConfigForm,
   tetris: BadukConfigForm,
-  pyramid: GridBadukConfigForm,
+  pyramid: PyramidConfigForm,
   "thue-morse": BadukConfigForm,
   freeze: BadukConfigForm,
   keima: GridBadukConfigForm,


### PR DESCRIPTION
# Proposed Changes
- Add graph utils including a function to calculate generalised pyramid weights
- Refactor variant Pyramid s.t. it supports graph boards (grid board uses the classical weights schema)
- Weights are calculated once on client and stored in config
- Fix a bug of voronoi diagram

# Note
- I noticed that the voronoi calculations sometimes crash, e.g. with sunflower board. I'll try to fix that.

![grafik](https://github.com/user-attachments/assets/72be1154-23ca-4936-8d72-3d789febc4ae)
