### PR TITLE
Repair game

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -9,6 +9,7 @@ import {
   takeSeat,
   leaveSeat,
   getGameState,
+  repairGame,
 } from "./games";
 import {
   checkUsername,
@@ -309,6 +310,16 @@ router.get("/games/:gameId/state", async (req, res) => {
     const game = await getGame(req.params.gameId);
     const stateResponse = await getGameState(game, seat, round);
     res.send(stateResponse);
+  } catch (e) {
+    res.status(500);
+    res.json(e.message);
+  }
+});
+
+router.post("/game/:gameId/repair", checkCSRFToken, async (req, res) => {
+  try {
+    await repairGame(req.params.gameId);
+    res.send({});
   } catch (e) {
     res.status(500);
     res.json(e.message);

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -22,6 +22,7 @@ import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 import DownloadSGF from "@/components/GameView/DownloadSGF.vue";
 import { getPlayingTable } from "@/playing_table_map";
+import Swal from "sweetalert2";
 
 const props = defineProps<{ gameId: string }>();
 
@@ -222,16 +223,23 @@ const createTimeControlPreview = (
   return null;
 };
 async function repairGame(): Promise<void> {
-  await requests
-    .post(`/game/${props.gameId}/repair`)
-    .catch(alert)
-    .then(() => location.reload());
+  await Swal.fire({
+    title: "Repair game",
+    text: "This action may delete moves in order to restore a game state without errors. If the game has time control, this may have unknown consequences.",
+    showCancelButton: true,
+  }).then((result) => {
+    if (result.isConfirmed) {
+      return requests
+        .post(`/game/${props.gameId}/repair`)
+        .catch(alert)
+        .then(() => location.reload());
+    }
+  });
 }
 </script>
 
 <template>
   <main>
-    <button v-if="errorOccured" v-on:click="repairGame">repair game</button>
     <div class="grid-page-layout">
       <div>
         <!-- Left column -->
@@ -309,6 +317,13 @@ async function repairGame(): Promise<void> {
           <label for="admin">Admin Mode</label>
         </div>
       </div>
+      <button
+        class="repair-game-btn"
+        v-if="errorOccured"
+        v-on:click="repairGame"
+      >
+        repair game
+      </button>
     </div>
   </main>
 </template>
@@ -333,5 +348,11 @@ async function repairGame(): Promise<void> {
   .info-attribute {
     white-space: pre-wrap;
   }
+}
+
+.repair-game-btn {
+  background-color: var(--color-warn);
+  height: 64px;
+  font-size: large;
 }
 </style>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -49,6 +49,7 @@ const time_control = ref<ITimeControlBase | null>(null);
 // Admins probably don't want to do admin stuff most of the time.  Let's hide
 // admin interface behind a toggle.
 const adminMode = ref<boolean>(false);
+const errorOccured = ref<boolean>(false);
 
 function setNewState(stateResponse: GameStateResponse): void {
   const { timeControl: timeControl, ...state } = stateResponse;
@@ -107,7 +108,10 @@ watchEffect(async () => {
       players.value = result.players;
       setNewState(result.stateResponse);
     })
-    .catch(alert);
+    .catch((err) => {
+      errorOccured.value = true;
+      alert(err);
+    });
 });
 
 const sit = (seat: number) => {
@@ -217,10 +221,17 @@ const createTimeControlPreview = (
   }
   return null;
 };
+async function repairGame(): Promise<void> {
+  await requests
+    .post(`/game/${props.gameId}/repair`)
+    .catch(alert)
+    .then(() => location.reload());
+}
 </script>
 
 <template>
   <main>
+    <button v-if="errorOccured" v-on:click="repairGame">repair game</button>
     <div class="grid-page-layout">
       <div>
         <!-- Left column -->


### PR DESCRIPTION
issue: #226 
# Proposed Changes
- Add backend functionality to remove a minimum number of moves at the end of a game in order to restore a state that throws no errors. (does not restore time control, and so it may not work well for games with time control) This is accessable for all users, and I believe that's ok because it does not affect games that are not broken.
- If GameView is in an error state, display a button that triggers the game repair.