### PR TITLE
admin edit game record

### DIFF
--- a/packages/vue-client/src/components/GameView/EditGameRecord.vue
+++ b/packages/vue-client/src/components/GameView/EditGameRecord.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { ref, watchEffect } from "vue";
+import * as requests from "@/requests";
+
+const props = defineProps<{ gameId: string }>();
+const gameRecord = ref();
+watchEffect(async () => {
+  await requests
+    .get(`/gameRecord/${props.gameId}`)
+    .then((result) => {
+      gameRecord.value = JSON.stringify(result, undefined, 2);
+      setAreaHeight();
+    })
+    .catch(alert);
+});
+
+async function upload(): Promise<void> {
+  await requests
+    .put(`/gameRecord/${props.gameId}`, JSON.parse(gameRecord.value))
+    .catch(alert);
+}
+
+function setAreaHeight(): void {
+  // wait once so scroll height adapts
+  window.setTimeout(() => {
+    const e = document.querySelector("#admin-game-edit") as HTMLElement | null;
+    if (!e) return;
+    e.style.height = "";
+    e.style.height = e.scrollHeight + "px";
+  });
+}
+</script>
+
+<template>
+  <div class="admin-controls">
+    <h1>Admin Controls</h1>
+    <textarea v-model="gameRecord" id="admin-game-edit"></textarea>
+    <button v-on:click="upload">upload game record</button>
+  </div>
+</template>
+
+<style lang="css" scoped>
+.admin-controls {
+  width: 100%;
+  textarea {
+    width: 100%;
+  }
+}
+</style>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -22,6 +22,7 @@ import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 import DownloadSGF from "@/components/GameView/DownloadSGF.vue";
 import { getPlayingTable } from "@/playing_table_map";
+import EditGameRecord from "@/components/GameView/EditGameRecord.vue";
 
 const props = defineProps<{ gameId: string }>();
 
@@ -298,6 +299,8 @@ const createTimeControlPreview = (
           <label for="admin">Admin Mode</label>
         </div>
       </div>
+
+      <EditGameRecord :game-id="gameId" v-if="adminMode"></EditGameRecord>
     </div>
   </main>
 </template>


### PR DESCRIPTION
issue: #226 
# Proposed changes
- add admin-only endpoints for fetching and updating a game record
- on client display textarea in GameView when in admin mode

# Notes
I realise that updating a game record in this way is very error prone. We should avoid it as much as possible.
Actually I built this before I had the idea for #410 . But this was still useful for testing #410 , so I thought I should at least put it up for debate.