### PR TITLE
Solve move race condition, add games schema

### DIFF
--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -29,7 +29,6 @@ export type GameSchema = {
   config: object;
   players?: Array<User | undefined>;
   time_control?: ITimeControlBase;
-  lastMoveTime?: Date;
 };
 
 export function gamesCollection(): Collection<GameSchema> {
@@ -199,12 +198,9 @@ export async function handleMoveAndTime(
     .findOneAndUpdate(
       {
         _id: new ObjectId(game_id),
-        lastMoveTime: { $eq: game.lastMoveTime },
+        moves: { $size: game.moves.length },
       },
-      {
-        $push: { moves: moves },
-        $set: { time_control: timeControl, lastMoveTime: new Date() },
-      },
+      { $push: { moves: moves }, $set: { time_control: timeControl } },
     )
     .catch(console.log);
   if (!moveUpdateResult || !moveUpdateResult.lastErrorObject?.updatedExisting) {
@@ -406,6 +402,5 @@ function outwardFacingGame(db_game: WithId<GameSchema>): GameResponse {
     config,
     players: db_game.players,
     time_control: db_game.time_control,
-    lastMoveTime: db_game.lastMoveTime,
   };
 }

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -12,7 +12,7 @@ import {
   ITimeControlBase,
   UserResponse,
 } from "@ogfcommunity/variants-shared";
-import { ObjectId, WithId, Document, Filter } from "mongodb";
+import { ObjectId, WithId, Document, Filter, Collection } from "mongodb";
 import { getDb } from "./db";
 import { io } from "./socket_io";
 import { getTimeoutService } from "./index";
@@ -23,7 +23,16 @@ import {
 } from "./time-control/time-control";
 import { updateRatings, supportsRatings } from "./rating/rating";
 
-export function gamesCollection() {
+export type GameSchema = {
+  variant: string;
+  moves: MovesType[];
+  config: object;
+  players?: Array<User | undefined>;
+  time_control?: ITimeControlBase;
+  lastMoveTime?: Date;
+};
+
+export function gamesCollection(): Collection<GameSchema> {
   return getDb().db().collection("games");
 }
 
@@ -186,12 +195,21 @@ export async function handleMoveAndTime(
     }
   }
 
-  gamesCollection()
-    .updateOne(
-      { _id: new ObjectId(game_id) },
-      { $push: { moves: moves }, $set: { time_control: timeControl } },
+  const moveUpdateResult = await gamesCollection()
+    .findOneAndUpdate(
+      {
+        _id: new ObjectId(game_id),
+        lastMoveTime: { $eq: game.lastMoveTime },
+      },
+      {
+        $push: { moves: moves },
+        $set: { time_control: timeControl, lastMoveTime: new Date() },
+      },
     )
     .catch(console.log);
+  if (!moveUpdateResult || !moveUpdateResult.lastErrorObject?.updatedExisting) {
+    throw new Error("db update for adding move failed");
+  }
 
   game.moves.push(moves);
 
@@ -379,7 +397,7 @@ async function BACKFILL_addEmptyPlayersArray(game: GameResponse) {
   return players;
 }
 
-function outwardFacingGame(db_game: WithId<Document>): GameResponse {
+function outwardFacingGame(db_game: WithId<GameSchema>): GameResponse {
   const config = sanitizeConfig(db_game.variant, db_game.config);
   return {
     id: db_game._id.toString(),
@@ -388,5 +406,6 @@ function outwardFacingGame(db_game: WithId<Document>): GameResponse {
     config,
     players: db_game.players,
     time_control: db_game.time_control,
+    lastMoveTime: db_game.lastMoveTime,
   };
 }

--- a/packages/shared/src/api_types.ts
+++ b/packages/shared/src/api_types.ts
@@ -26,6 +26,7 @@ export interface GameResponse {
   config: { time_control?: ITimeControlConfig };
   players?: Array<User | undefined>;
   time_control?: ITimeControlBase;
+  lastMoveTime?: Date;
 }
 
 // We may add more roles like "moderator" or "bot" in the future

--- a/packages/shared/src/api_types.ts
+++ b/packages/shared/src/api_types.ts
@@ -26,7 +26,6 @@ export interface GameResponse {
   config: { time_control?: ITimeControlConfig };
   players?: Array<User | undefined>;
   time_control?: ITimeControlBase;
-  lastMoveTime?: Date;
 }
 
 // We may add more roles like "moderator" or "bot" in the future


### PR DESCRIPTION
This is a proposal for solving the race condition bug in #226 
We introduce a new field for game documents `lastMoveTime`, and rewrite the db update call s.t. it fails if this field changed in the meantime.
This has the following advantages:
- No usage of transaction (this would add some starting hurdle for devs, because they would need to make sure their local db instance is a replica set. Also makes the code more verbose, and as @benjaminpjones wrote, fundamentally transactions solve a different problem - atomicity for a set of db updates)
- In the scenario of two (almost) simultaneous calls to `playMove`, exactly one request throws an error.

Also adds a schema for games, because it was somehow necessary for this update call (plus makes things easier).

# Steps to test
add the following lines in `GameView` line 168
```
const test = {
  first: requests.post(`/games/${props.gameId}/move`, move).catch(alert),
  second: requests.post(`/games/${props.gameId}/move`, move).catch(alert),
};
```

