### PR TITLE
Make sure Board Preview text shows up in dark mode

### DIFF
--- a/packages/vue-client/src/utils/ExpandablePocket.vue
+++ b/packages/vue-client/src/utils/ExpandablePocket.vue
@@ -53,6 +53,7 @@ onMounted(() => {
     cursor: pointer;
     background-color: transparent;
     border-style: none;
+    color: var(--color-text);
   }
 
   .expand-content {


### PR DESCRIPTION
"Board Preview" is too dark to read in dark mode.


<img width="146" height="62" alt="Screenshot 2025-12-21 at 8 24 08 PM" src="https://github.com/user-attachments/assets/9ee3556a-701f-4b94-bdc1-43f983576a37" />

<img width="267" height="59" alt="Screenshot 2025-12-21 at 8 24 03 PM" src="https://github.com/user-attachments/assets/1e9cbf15-a058-4a53-8e35-5e98cca40fb3" />
