### PR TITLE
Linter rule for imports

### DIFF
--- a/packages/server/.eslintrc.cjs
+++ b/packages/server/.eslintrc.cjs
@@ -22,13 +22,12 @@ module.exports = {
       "error",
       {
         patterns: [
-          "@ogfcommunity/variants-shared/src/*",
-          "**/shared/**",
-          "shared/**",
-        ],
-        paths: [
           {
-            name: "shared",
+            group: [
+              "@ogfcommunity/variants-shared/src/*",
+              "/shared/",
+              "shared/**",
+            ],
             message:
               "Import the shared package using the package alias: import {X} from '@ogfcommunity/variants-shared' (not via a relative path).",
           },

--- a/packages/vue-client/.eslintrc.cjs
+++ b/packages/vue-client/.eslintrc.cjs
@@ -23,13 +23,12 @@ module.exports = {
       "error",
       {
         patterns: [
-          "@ogfcommunity/variants-shared/src/*",
-          "**/shared/**",
-          "shared/**",
-        ],
-        paths: [
           {
-            name: "shared",
+            group: [
+              "@ogfcommunity/variants-shared/src/*",
+              "/shared/",
+              "shared/**",
+            ],
             message:
               "Import the shared package using the package alias: import {X} from '@ogfcommunity/variants-shared' (not via a relative path).",
           },


### PR DESCRIPTION
Attempt to make linter rules more restrictive, so we catch wrong imports, by adding restricted patterns.