### PR TITLE
Add Notifications title on mobile

### DIFF
--- a/packages/vue-client/src/components/NotificationsNav.vue
+++ b/packages/vue-client/src/components/NotificationsNav.vue
@@ -29,7 +29,9 @@ watchEffect(async () => {
   <RouterLink
     class="navElement"
     to="/notifications"
-    aria-label="Notifications"
+    :aria-label="`Notifications${
+      notificationCount ? `, ${notificationCount} unread` : ''
+    }`"
     title="Notifications"
   >
     <div class="icon-wrapper">


### PR DESCRIPTION
I notice the notification symbol looks a bit lonely in the context of the hamburger menu

<img width="180" height="400" alt="Screen Shot 2026-02-06 at 10 29 29" src="https://github.com/user-attachments/assets/ef09ed28-f104-4f45-af83-9de0084edfda" />


This PR adds "Notifications" to it, and also adds some accessibility for when the label is not shown (aria-label, tooltip)

<img width="180" height="400" alt="Screen Shot 2026-02-06 at 10 19 28" src="https://github.com/user-attachments/assets/687cfac8-ef62-449e-bde0-4238d8c2f7ad" />
<img width="180" height="400" alt="Screen Shot 2026-02-06 at 10 18 47" src="https://github.com/user-attachments/assets/d66d28bf-8a57-41fd-b53f-5ba7fe86abd6" />

---

This isn't necessarily the best fix.  For instance, OGS and other social media sites keep the notification bell in the top bar regardless of layout - we might want to follow suite.