### PR TITLE
Upgrade vue lint rules to the recommended ruleset

### DIFF
--- a/packages/vue-client/.eslintrc.cjs
+++ b/packages/vue-client/.eslintrc.cjs
@@ -4,12 +4,27 @@ require("@rushstack/eslint-patch/modern-module-resolution");
 module.exports = {
   root: true,
   extends: [
-    "plugin:vue/vue3-essential",
+    "plugin:vue/vue3-recommended", // TODO(#448): Switch to 'vue3-recommended-error' (upgrade to 10.7.0 required)
     "eslint:recommended",
     "@vue/eslint-config-typescript/recommended",
     "@vue/eslint-config-prettier",
   ],
   rules: {
+    // Override vue3-recommended's html-self-closing to set void elements to "always"
+    // instead of "never". This prevents conflicts with Prettier, which formats
+    // void elements as self-closing (e.g., <br /> instead of <br>).
+    "vue/html-self-closing": [
+      "error",
+      {
+        html: {
+          void: "always",
+          normal: "always",
+          component: "always",
+        },
+        svg: "always",
+        math: "always",
+      },
+    ],
     "prettier/prettier": ["error", { endOfLine: "auto" }],
     "@typescript-eslint/no-unused-vars": [
       "error",
@@ -36,5 +51,11 @@ module.exports = {
       },
     ],
     eqeqeq: ["error", "smart"],
+
+    // TODO(#448): Temporarily disabled vue3-recommended rules require manual fixes
+    "vue/prop-name-casing": "off", // 19 issues
+    "vue/no-template-shadow": "off", // 1 issue
+    "vue/require-default-prop": "off", // 2 issues
+    "vue/no-v-html": "off", // 1 issue
   },
 };

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -37,7 +37,7 @@ const toggleMenuFn = (event: MouseEvent) => {
     <button class="navHamburgerContainer navElement" @click="toggleMenuFn">
       <font-awesome-icon icon="fa-solid fa-bars" class="navHamburgerMenu" />
     </button>
-    <div class="navContent" v-bind:class="{ closedMenu: is_menu_closed }">
+    <div class="navContent" :class="{ closedMenu: is_menu_closed }">
       <div>
         <RouterLink class="navElement" to="/"
           ><font-awesome-icon

--- a/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
@@ -26,12 +26,12 @@ function setBoardConfig(boardConfig: BoardConfig): void {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <BoardConfigForm
+      :grid-only="$props.gridOnly"
       @config-changed="setBoardConfig($event)"
-      v-bind:grid-only="$props.gridOnly"
     />
     <label>Komi</label>
-    <input type="number" step="0.5" v-model="config.komi" />
+    <input v-model="config.komi" type="number" step="0.5" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
@@ -81,10 +81,7 @@ function emitConfigChange(config: BoardConfig) {
     />
     <ExpandablePocket label="Board preview">
       <div class="event-blocker">
-        <DefaultBoard
-          v-if="boardConfig"
-          :config="{ board: boardConfig }"
-        ></DefaultBoard>
+        <DefaultBoard v-if="boardConfig" :config="{ board: boardConfig }" />
       </div>
     </ExpandablePocket>
   </div>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/CircularBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/CircularBoardConfigForm.vue
@@ -26,10 +26,10 @@ if (!props.initialConfig) {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>Nodes per Ring</label>
-    <input type="number" min="3" v-model="config.nodesPerRing" />
+    <input v-model="config.nodesPerRing" type="number" min="3" />
     <label>Number of Rings</label>
-    <input type="number" min="3" v-model="config.rings" />
+    <input v-model="config.rings" type="number" min="3" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/CustomBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/CustomBoardConfigForm.vue
@@ -57,7 +57,7 @@ if (!props.initialConfig) {
     <textarea
       v-model="configStr"
       @input="(event) => onTextChanged((event.target as HTMLInputElement).value)"
-    ></textarea>
+    />
   </form>
   <div class="error">{{ error }}</div>
 </template>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridBoardConfigForm.vue
@@ -26,11 +26,11 @@ if (!props.initialConfig) {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
-    <div class=""></div>
+  <form class="config-form-column" @change="emitConfigChange">
+    <div class="" />
     <label>Width</label>
-    <input type="number" min="1" v-model="config.width" />
+    <input v-model="config.width" type="number" min="1" />
     <label>Height</label>
-    <input type="number" min="1" v-model="config.height" />
+    <input v-model="config.height" type="number" min="1" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridWithHolesBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridWithHolesBoardConfigForm.vue
@@ -61,10 +61,10 @@ if (!props.initialConfig) {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>
       Bitmap
-      <textarea v-model="bitmapString"></textarea>
+      <textarea v-model="bitmapString" />
     </label>
     <div v-if="configError">{{ configError }}</div>
   </form>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/RhombitrihexagonalBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/RhombitrihexagonalBoardConfigForm.vue
@@ -25,8 +25,8 @@ if (!props.initialConfig) {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>Size</label>
-    <input type="number" min="1" max="6" v-model="config.size" />
+    <input v-model="config.size" type="number" min="1" max="6" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/SierpinskyBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/SierpinskyBoardConfigForm.vue
@@ -25,8 +25,8 @@ if (!props.initialConfig) {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>Size</label>
-    <input type="number" min="1" max="6" v-model="config.size" />
+    <input v-model="config.size" type="number" min="1" max="6" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/SunflowerBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/SunflowerBoardConfigForm.vue
@@ -28,8 +28,8 @@ if (!props.initialConfig) {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>Size</label>
-    <input type="number" min="1" v-model="config.size" />
+    <input v-model="config.size" type="number" min="1" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/TrihexagonalConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/TrihexagonalConfigForm.vue
@@ -25,8 +25,8 @@ if (!props.initialConfig) {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>Size</label>
-    <input type="number" min="1" v-model="config.size" />
+    <input v-model="config.size" type="number" min="1" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/CubeBadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/CubeBadukConfigForm.vue
@@ -39,7 +39,7 @@ watch([faceSize, komi], emitConfigChange);
     </select>
 
     <label>Komi</label>
-    <input type="number" step="0.5" v-model.number="komi" />
+    <input v-model.number="komi" type="number" step="0.5" />
   </form>
 </template>
 

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -23,16 +23,16 @@ function emitConfigChange() {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>Width</label>
-    <input type="number" min="1" v-model="config.board.width" />
+    <input v-model="config.board.width" type="number" min="1" />
     <label>Height</label>
-    <input type="number" min="1" v-model="config.board.height" />
+    <input v-model="config.board.height" type="number" min="1" />
     <label>Komi</label>
-    <input type="number" step="0.5" v-model="config.komi" />
+    <input v-model="config.komi" type="number" step="0.5" />
     <label>X-Shift</label>
-    <input type="number" step="1" v-model="config.xShift" />
+    <input v-model="config.xShift" type="number" step="1" />
     <label>Y-Shift</label>
-    <input type="number" step="1" v-model="config.yShift" />
+    <input v-model="config.yShift" type="number" step="1" />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
+++ b/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
@@ -100,23 +100,23 @@ const hasTimeConfigForm = computed(
     <h3>Config</h3>
     <template v-if="variantConfigForm">
       <component
-        v-bind:is="variantConfigForm"
-        v-bind:initialConfig="getDefaultConfig(variant)"
-        v-on:configChanged="setConfig"
+        :is="variantConfigForm"
+        :initial-config="getDefaultConfig(variant)"
+        @config-changed="setConfig"
       />
       <TimeControlConfigForm
         v-if="hasTimeConfigForm"
-        v-on:config-changed="setTimeControlConfig"
+        @config-changed="setTimeControlConfig"
       />
-      <button v-on:click="createGame" class="large-button">Create Game</button>
+      <button class="large-button" @click="createGame">Create Game</button>
     </template>
     <template v-else>
-      <textarea v-model="configString"></textarea>
+      <textarea v-model="configString" />
       <TimeControlConfigForm
         v-if="hasTimeConfigForm"
-        v-on:config-changed="setTimeControlConfig"
+        @config-changed="setTimeControlConfig"
       />
-      <button v-on:click="parseConfigThenCreateGame" class="large-button">
+      <button class="large-button" @click="parseConfigThenCreateGame">
         Create Game
       </button>
     </template>

--- a/packages/vue-client/src/components/GameCreation/GridBadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/GridBadukConfigForm.vue
@@ -20,8 +20,8 @@ function emitConfigChange(config: NewBadukConfig) {
 
 <template>
   <BadukConfigForm
-    v-bind:initial-config="$props.initialConfig"
-    v-bind:grid-only="true"
+    :initial-config="$props.initialConfig"
+    :grid-only="true"
     @config-changed="emitConfigChange"
   />
 </template>

--- a/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
@@ -14,13 +14,13 @@ function emitConfigChange() {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <label>Width</label>
-    <input type="number" min="1" v-model="config.width" />
+    <input v-model="config.width" type="number" min="1" />
     <label>Height</label>
-    <input type="number" min="1" v-model="config.height" />
+    <input v-model="config.height" type="number" min="1" />
     <label>Number of players</label>
-    <input type="number" min="1" v-model="config.num_players" />
+    <input v-model="config.num_players" type="number" min="1" />
     <label>Collision Handling</label>
     <select v-model="config.collision_handling">
       <option :value="'merge'">Merge</option>

--- a/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
@@ -32,7 +32,7 @@ function emitConfigChange(config: NewBadukConfig) {
 
 <template>
   <BadukConfigForm
-    @config-changed="emitConfigChange($event)"
     :initial-config="$props.initialConfig"
+    @config-changed="emitConfigChange($event)"
   />
 </template>

--- a/packages/vue-client/src/components/GameCreation/RengoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/RengoConfigForm.vue
@@ -68,14 +68,14 @@ function emitConfigChange() {
     <form @change="emitConfigChange">
       <template v-for="(_, index) in teamSizes" :key="index">
         <label>Size of team {{ index }}</label>
-        <input type="number" min="1" v-model="teamSizes[index]" />
+        <input v-model="teamSizes[index]" type="number" min="1" />
       </template>
 
       <component
-        v-if="variantConfigForm"
         :is="variantConfigForm"
-        :initialConfig="getDefaultConfig(subVariant)"
-        v-on:configChanged="setSubConfig"
+        v-if="variantConfigForm"
+        :initial-config="getDefaultConfig(subVariant)"
+        @config-changed="setSubConfig"
       />
     </form>
   </div>

--- a/packages/vue-client/src/components/GameCreation/SFractionalConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/SFractionalConfigForm.vue
@@ -41,35 +41,35 @@ function removeSecondaryColor(): void {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <BoardConfigForm @config-changed="setBoardConfig($event)" />
     <label>Komi</label>
-    <input type="number" step="0.5" v-model="config.komi" />
+    <input v-model="config.komi" type="number" step="0.5" />
 
     <div class="row">
       <label class="grow">Secondary Colors</label>
       <button
         class="no-flex"
         type="button"
-        v-on:click="addSecondaryColor()"
         :disabled="config.secondary_colors.length >= maxNrOfSecondaryColors"
+        @click="addSecondaryColor()"
       >
         +
       </button>
       <button
         class="no-flex"
         type="button"
-        v-on:click="removeSecondaryColor()"
         :disabled="config.secondary_colors.length <= 1"
+        @click="removeSecondaryColor()"
       >
         -
       </button>
     </div>
     <input
-      type="color"
       v-for="(_, index) in config.secondary_colors"
       :key="index"
       v-model="config.secondary_colors[index]"
+      type="color"
     />
   </form>
 </template>

--- a/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
@@ -76,7 +76,7 @@ function emitConfigChange() {
 </script>
 
 <template>
-  <form @change="emitConfigChange" class="config-form-column">
+  <form class="config-form-column" @change="emitConfigChange">
     <h3>Time Control</h3>
     <select v-model="typeRef">
       <option :value="null">Unlimited Time</option>
@@ -88,22 +88,22 @@ function emitConfigChange() {
     </select>
     <template v-if="typeRef !== null">
       <label>Main Time (s)</label>
-      <input type="number" v-model="mainTimeS" />
+      <input v-model="mainTimeS" type="number" />
     </template>
     <template v-if="typeRef === TimeControlType.Fischer">
       <label>Increment</label>
-      <input type="number" v-model="fischerIncrementS" />
+      <input v-model="fischerIncrementS" type="number" />
       <div class="fischerCappedToggle">
         <label for="cappedToggle">Max</label>
-        <input id="cappedToggle" type="checkbox" v-model="fischerCapped" />
+        <input id="cappedToggle" v-model="fischerCapped" type="checkbox" />
       </div>
-      <input v-if="fischerCapped" type="number" v-model="fischerMaxS" />
+      <input v-if="fischerCapped" v-model="fischerMaxS" type="number" />
     </template>
     <template v-if="typeRef && shouldShowPeriodTime(typeRef)">
       <label>Number of Periods</label>
-      <input type="number" v-model="numPeriods" />
+      <input v-model="numPeriods" type="number" />
       <label>Period time</label>
-      <input type="number" v-model="periodTimeS" />
+      <input v-model="periodTimeS" type="number" />
     </template>
   </form>
 </template>

--- a/packages/vue-client/src/components/GameList.vue
+++ b/packages/vue-client/src/components/GameList.vue
@@ -40,7 +40,7 @@ function setFilter(gamesFilter: GamesFilter) {
 </script>
 
 <template>
-  <GamesFilterForm v-on:filter-change="setFilter"></GamesFilterForm>
+  <GamesFilterForm @filter-change="setFilter" />
   <hr />
   <ul>
     <template v-for="game in games" :key="game.id">
@@ -66,9 +66,9 @@ function setFilter(gamesFilter: GamesFilter) {
       </template>
     </template>
   </ul>
-  <button @click="first()" :disabled="offset === 0">First</button>
-  <button @click="previous()" :disabled="offset === 0">Previous</button>
-  <button @click="next()" :disabled="games?.length !== count">Next</button>
+  <button :disabled="offset === 0" @click="first()">First</button>
+  <button :disabled="offset === 0" @click="previous()">Previous</button>
+  <button :disabled="games?.length !== count" @click="next()">Next</button>
   <label>
     Show:
     <select v-model="count">

--- a/packages/vue-client/src/components/GameListItem.vue
+++ b/packages/vue-client/src/components/GameListItem.vue
@@ -17,13 +17,13 @@ const variantGameView = computed(() => getBoard(props.game.variant));
 
 <template>
   <li class="game-list-item">
-    <RouterLink v-bind:to="{ name: 'game', params: { gameId: props.game.id } }">
+    <RouterLink :to="{ name: 'game', params: { gameId: props.game.id } }">
       <div class="event-blocker">
         <component
+          :is="variantGameView"
           v-if="variantGameView"
-          v-bind:is="variantGameView"
-          v-bind:gamestate="transformedGameData.gamestate"
-          v-bind:config="transformedGameData.config"
+          :gamestate="transformedGameData.gamestate"
+          :config="transformedGameData.config"
         />
       </div>
       <div class="variant-text">{{ props.game.variant }}</div>

--- a/packages/vue-client/src/components/GameListItemFallback.vue
+++ b/packages/vue-client/src/components/GameListItemFallback.vue
@@ -4,7 +4,7 @@ const props = defineProps<{ variant: string; gameId: string; error: string }>();
 
 <template>
   <li class="game-list-item">
-    <RouterLink v-bind:to="{ name: 'game', params: { gameId: props.gameId } }">
+    <RouterLink :to="{ name: 'game', params: { gameId: props.gameId } }">
       <div class="error">{{ error }}</div>
       <div class="variant-text">{{ props.variant }}</div>
     </RouterLink>

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -93,7 +93,7 @@ function tick(onThePlaySince: Date): void {
 
 <template>
   <!--This class is referenced in SeatComponent-->
-  <div v-bind:class="{ 'alert-timer': isAlertMode }">
+  <div :class="{ 'alert-timer': isAlertMode }">
     {{ formattedTime }}
   </div>
 </template>

--- a/packages/vue-client/src/components/GameView/PlayerSymbol.vue
+++ b/packages/vue-client/src/components/GameView/PlayerSymbol.vue
@@ -17,14 +17,8 @@ const colors = computed(() =>
 </script>
 
 <template>
-  <svg v-bind:viewBox="`0 0 2 2`">
-    <TaegeukStone
-      v-if="colors"
-      :colors="colors"
-      :r="1"
-      :cx="1"
-      :cy="1"
-    ></TaegeukStone>
+  <svg :viewBox="`0 0 2 2`">
+    <TaegeukStone v-if="colors" :colors="colors" :r="1" :cx="1" :cy="1" />
   </svg>
 </template>
 

--- a/packages/vue-client/src/components/GameView/SeatComponent.vue
+++ b/packages/vue-client/src/components/GameView/SeatComponent.vue
@@ -47,8 +47,8 @@ const isSelected = computed(() => props.selected === props.player_n);
       <div class="timer-and-button">
         <GameTimer
           v-if="time_control && time_config"
-          v-bind:time_control="time_control"
-          v-bind:time_config="time_config"
+          :time_control="time_control"
+          :time_config="time_config"
           :is_seat_selected="false"
         />
         <button v-if="user_id" @click.stop="$emit('sit')">Take Seat</button>
@@ -61,8 +61,8 @@ const isSelected = computed(() => props.selected === props.player_n);
       <div class="timer-and-button">
         <GameTimer
           v-if="time_control && time_config"
-          v-bind:time_control="time_control"
-          v-bind:time_config="time_config"
+          :time_control="time_control"
+          :time_config="time_config"
           :is_seat_selected="isSelected"
         />
         <button
@@ -80,11 +80,7 @@ const isSelected = computed(() => props.selected === props.player_n);
         </button>
       </div>
     </div>
-    <PlayerSymbol
-      v-bind:variant="variant"
-      v-bind:player_nr="player_n"
-      v-bind:config="config"
-    ></PlayerSymbol>
+    <PlayerSymbol :variant="variant" :player_nr="player_n" :config="config" />
   </div>
 </template>
 

--- a/packages/vue-client/src/components/GamesFilterForm.vue
+++ b/packages/vue-client/src/components/GamesFilterForm.vue
@@ -27,7 +27,7 @@ const filter = computed(() => {
 
 <template>
   <h3>Filter games</h3>
-  <form @change="emitFilter" class="gamesFilterForm">
+  <form class="gamesFilterForm" @change="emitFilter">
     <select v-model="selectedVariant">
       <option value="">All variants</option>
       <option v-for="variant in variants" :key="variant">
@@ -37,7 +37,7 @@ const filter = computed(() => {
 
     <div v-if="user" class="myGamesToggle">
       <label for="onlyMyGamesToggle">games that I play </label>
-      <input id="onlyMyGamesToggle" type="checkbox" v-model="onlyMyGames" />
+      <input id="onlyMyGamesToggle" v-model="onlyMyGames" type="checkbox" />
     </div>
   </form>
 </template>

--- a/packages/vue-client/src/components/MoveSequenceDisplay.vue
+++ b/packages/vue-client/src/components/MoveSequenceDisplay.vue
@@ -26,8 +26,8 @@ const colors_range = computed(() => {
     <font-awesome-icon icon="fa-solid fa-arrow-right" />
     <svg
       v-for="(colors, index) of colors_range"
-      v-bind:key="index"
-      v-bind:viewBox="`0 0 2 2`"
+      :key="index"
+      :viewBox="`0 0 2 2`"
       class="stone_preview"
     >
       <TaegeukStone v-if="colors" :colors="colors" :r="1" :cx="1" :cy="1" />

--- a/packages/vue-client/src/components/PlayingTable/CubeTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/CubeTable.vue
@@ -48,7 +48,7 @@ const displayPower = computed(() => {
       :next-to-play="$props.nextToPlay"
       :power="power"
       :debug-graphics="debugGraphics"
-      v-on:move="move"
+      @move="move"
     />
     <div class="controls">
       <label for="power-slider" class="control-label">
@@ -69,7 +69,7 @@ const displayPower = computed(() => {
       </div>
       <div class="checkbox-control">
         <label>
-          <input type="checkbox" v-model="debugGraphics" />
+          <input v-model="debugGraphics" type="checkbox" />
           Debug Graphics
         </label>
       </div>

--- a/packages/vue-client/src/components/PlayingTable/PolymorphicPlayingTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/PolymorphicPlayingTable.vue
@@ -32,11 +32,11 @@ const transformedGameData = computed(() =>
 
 <template>
   <component
-    v-if="variantPlayingTable"
     :is="variantPlayingTable"
+    v-if="variantPlayingTable"
     :gamestate="transformedGameData.gamestate"
     :config="transformedGameData.config"
     :displayed_round="props.displayed_round"
-    v-on:move="emitMove"
+    @move="emitMove"
   />
 </template>

--- a/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
@@ -29,7 +29,7 @@ function move(move: string) {
   <DefaultBoard
     :gamestate="$props.gamestate"
     :config="$props.config"
-    v-on:move="move"
+    @move="move"
   />
   <div class="center_aligner">
     <MoveSequenceDisplay

--- a/packages/vue-client/src/components/PlayingTable/ThueMorseTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/ThueMorseTable.vue
@@ -29,7 +29,7 @@ function move(move: string) {
   <DefaultBoard
     :gamestate="$props.gamestate"
     :config="$props.config"
-    v-on:move="move"
+    @move="move"
   />
   <div class="center_aligner">
     <MoveSequenceDisplay

--- a/packages/vue-client/src/components/TaegeukStone.vue
+++ b/packages/vue-client/src/components/TaegeukStone.vue
@@ -45,19 +45,19 @@ const angle_degrees = computed(() => {
 
 <template>
   <circle
-    v-bind:cx="props.cx"
-    v-bind:cy="props.cy"
-    v-bind:r="props.r"
     v-if="colors.length === 1"
-    v-bind:fill="colors[0]"
+    :cx="props.cx"
+    :cy="props.cy"
+    :r="props.r"
+    :fill="colors[0]"
   />
-  <g v-else v-bind:transform="`translate(${props.cx} ${props.cy})`">
+  <g v-else :transform="`translate(${props.cx} ${props.cy})`">
     <path
       v-for="(color, idx) in colors"
-      v-bind:key="idx"
-      v-bind:fill="color"
-      v-bind:d="section_path"
-      v-bind:transform="`rotate(${angle_degrees * idx} 0 0)`"
+      :key="idx"
+      :fill="color"
+      :d="section_path"
+      :transform="`rotate(${angle_degrees * idx} 0 0)`"
     />
   </g>
 </template>

--- a/packages/vue-client/src/components/UserNav.vue
+++ b/packages/vue-client/src/components/UserNav.vue
@@ -15,12 +15,12 @@ store.update();
 </script>
 
 <template>
-  <RouterLink class="navElement" v-if="!user" to="/login"
+  <RouterLink v-if="!user" class="navElement" to="/login"
     ><font-awesome-icon icon="fa-solid fa-right-to-bracket" class="icon" />Log
     in</RouterLink
   >
   <template v-else>
-    <RouterLink class="navElement" v-if="user.role === 'admin'" to="/admin"
+    <RouterLink v-if="user.role === 'admin'" class="navElement" to="/admin"
       ><font-awesome-icon
         icon="fa-solid fa-user-shield"
         class="icon"
@@ -35,8 +35,8 @@ store.update();
     </RouterLink>
     <button
       class="navElement logoutButton"
-      v-on:click="store.logout()"
       click="Log out"
+      @click="store.logout()"
     >
       <font-awesome-icon icon="fa-solid fa-right-from-bracket" class="icon" />
       Log out

--- a/packages/vue-client/src/components/boards/CubeBoard.vue
+++ b/packages/vue-client/src/components/boards/CubeBoard.vue
@@ -927,7 +927,7 @@ watch(
 
 <template>
   <div ref="containerRef" class="cube-board-container">
-    <canvas ref="canvasRef" class="cube-board-canvas"></canvas>
+    <canvas ref="canvasRef" class="cube-board-canvas" />
   </div>
 </template>
 

--- a/packages/vue-client/src/components/boards/DefaultBoard.vue
+++ b/packages/vue-client/src/components/boards/DefaultBoard.vue
@@ -41,8 +41,8 @@ function positionClicked(pos: Coordinate | number) {
     v-else
     :board="props.gamestate?.board as ((MulticolorStone | null)[] | undefined)"
     :board_config="$props.config.board"
-    @click="positionClicked"
     :background_color="props.gamestate?.backgroundColor"
     :score_board="props.gamestate?.score_board as ((string[] | null)[] | undefined)"
+    @click="positionClicked"
   />
 </template>

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -99,8 +99,8 @@ const stagedMove = computed(() =>
         />
         <circle
           v-if="$props.gamestate.lastMoves.includes(index)"
-          v-bind:cx="intersection.position.X"
-          v-bind:cy="intersection.position.Y"
+          :cx="intersection.position.X"
+          :cy="intersection.position.Y"
           r="0.3"
           stroke="#dbdbdb"
           stroke-width="0.05"
@@ -109,10 +109,10 @@ const stagedMove = computed(() =>
         <circle
           v-if="!$props.gamestate.boardState.at(index)"
           class="click-placeholder"
-          v-on:click="intersectionClicked(index)"
-          v-bind:cx="intersection.position.X"
-          v-bind:cy="intersection.position.Y"
+          :cx="intersection.position.X"
+          :cy="intersection.position.Y"
           r="0.47"
+          @click="intersectionClicked(index)"
         />
       </g>
     </g>

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -101,15 +101,15 @@ const viewBox = computed(() => {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    v-bind:viewBox="`${viewBox.minX - 1} ${viewBox.minY - 1} ${
-      viewBox.width + 2
-    } ${viewBox.height + 2}`"
+    :viewBox="`${viewBox.minX - 1} ${viewBox.minY - 1} ${viewBox.width + 2} ${
+      viewBox.height + 2
+    }`"
   >
     <rect
-      v-bind:x="viewBox.minX - 0.5"
-      v-bind:y="viewBox.minY - 0.5"
-      v-bind:width="viewBox.width + 1"
-      v-bind:height="viewBox.height + 1"
+      :x="viewBox.minX - 0.5"
+      :y="viewBox.minY - 0.5"
+      :width="viewBox.width + 1"
+      :height="viewBox.height + 1"
       :fill="background_color ?? '#dcb35c'"
     />
     <g>
@@ -131,10 +131,10 @@ const viewBox = computed(() => {
           .filter((n) => n < index)"
         :key="neighbour_index"
         class="grid"
-        v-bind:x1="intersection.position.X"
-        v-bind:x2="intersections[neighbour_index].position.X"
-        v-bind:y1="intersection.position.Y"
-        v-bind:y2="intersections[neighbour_index].position.Y"
+        :x1="intersection.position.X"
+        :x2="intersections[neighbour_index].position.X"
+        :y1="intersection.position.Y"
+        :y2="intersections[neighbour_index].position.Y"
       />
     </g>
     <g v-for="(intersection, index) in intersections" :key="index">
@@ -174,18 +174,18 @@ const viewBox = computed(() => {
       <template v-for="(intersection, index) in intersections" :key="index">
         <rect
           v-if="!props.board?.at(index)?.disable_move"
-          @click="positionClicked(index)"
-          @mouseover="positionHovered(index)"
           :x="intersection.position.X - 0.5"
           :y="intersection.position.Y - 0.5"
           width="1"
           height="1"
           :fill="hovered == index ? 'pink' : 'transparent'"
           opacity="0.5"
+          @click="positionClicked(index)"
+          @mouseover="positionHovered(index)"
         />
       </template>
     </g>
-    <g></g>
+    <g />
   </svg>
 </template>
 

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -42,7 +42,7 @@ function positionHovered(pos: Coordinate) {
   <svg
     class="board"
     xmlns="http://www.w3.org/2000/svg"
-    v-bind:viewBox="`-1 -1 ${width + 1} ${height + 1}`"
+    :viewBox="`-1 -1 ${width + 1} ${height + 1}`"
   >
     <rect
       x="-0.5"
@@ -62,16 +62,16 @@ function positionHovered(pos: Coordinate) {
         width="1"
         height="1"
         :fill="props.board![pos.y][pos.x]!.background_color"
-      ></rect>
+      />
     </g>
     <g>
       <line
         v-for="x in width"
         :key="x"
-        v-bind:x1="x - 1"
-        v-bind:x2="x - 1"
-        v-bind:y1="0"
-        v-bind:y2="height - 1"
+        :x1="x - 1"
+        :x2="x - 1"
+        :y1="0"
+        :y2="height - 1"
         color="pink"
         stroke="pink"
         stroke-width="0.02"
@@ -80,10 +80,10 @@ function positionHovered(pos: Coordinate) {
       <line
         v-for="y in height"
         :key="y"
-        v-bind:x1="0"
-        v-bind:x2="width - 1"
-        v-bind:y1="y - 1"
-        v-bind:y2="y - 1"
+        :x1="0"
+        :x2="width - 1"
+        :y1="y - 1"
+        :y2="y - 1"
         stroke="pink"
         stroke-width="0.02"
       />
@@ -123,7 +123,7 @@ function positionHovered(pos: Coordinate) {
     <g v-if="score_board">
       <ScoreMark
         v-for="(pos, index) in positions.filter((pos) => score_board![pos.y][pos.x] !== null)"
-        v-bind:key="index"
+        :key="index"
         :colors="score_board![pos.y][pos.x]!"
         :cx="pos.x"
         :cy="pos.y"
@@ -135,8 +135,6 @@ function positionHovered(pos: Coordinate) {
           (pos) => !props.board?.at(pos.y)?.at(pos.x)?.disable_move,
         )"
         :key="`${pos.x},${pos.y}`"
-        @click="positionClicked(pos)"
-        @mouseover="positionHovered(pos)"
         :x="pos.x - 0.5"
         :y="pos.y - 0.5"
         width="1"
@@ -145,9 +143,11 @@ function positionHovered(pos: Coordinate) {
           hovered.x === pos.x && hovered.y === pos.y ? 'pink' : 'transparent'
         "
         opacity="0.5"
+        @click="positionClicked(pos)"
+        @mouseover="positionHovered(pos)"
       />
     </g>
-    <g></g>
+    <g />
   </svg>
 </template>
 

--- a/packages/vue-client/src/components/boards/PolymorphicBoard.vue
+++ b/packages/vue-client/src/components/boards/PolymorphicBoard.vue
@@ -29,10 +29,10 @@ const transformedGameData = computed(() =>
 
 <template>
   <component
-    v-if="variantBoard"
     :is="variantBoard"
+    v-if="variantBoard"
     :gamestate="transformedGameData.gamestate"
     :config="transformedGameData.config"
-    v-on:move="emitMove"
+    @move="emitMove"
   />
 </template>

--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -93,14 +93,14 @@ const board_1 = computed(() => {
     <DefaultBoard
       :gamestate="board_0"
       :config="props.config"
-      v-on:move="emitMove"
+      @move="emitMove"
     />
   </div>
   <div style="width: 50%; height: min-content; display: inline-block">
     <DefaultBoard
       :gamestate="board_1"
       :config="props.config"
-      v-on:move="emitMove"
+      @move="emitMove"
     />
   </div>
 </template>

--- a/packages/vue-client/src/components/boards/ScoreMark.vue
+++ b/packages/vue-client/src/components/boards/ScoreMark.vue
@@ -16,23 +16,23 @@ const segmentHeight = computed(() => +(height / props.colors.length));
 
 <template>
   <rect
-    v-bind:x="cx - (width + stroke_width) / 2"
-    v-bind:y="cy - (height + stroke_width) / 2"
+    :x="cx - (width + stroke_width) / 2"
+    :y="cy - (height + stroke_width) / 2"
     stroke="gray"
-    v-bind:stroke-width="stroke_width"
-    v-bind:width="width + stroke_width"
-    v-bind:height="height + stroke_width"
+    :stroke-width="stroke_width"
+    :width="width + stroke_width"
+    :height="height + stroke_width"
     fill-opacity="0.0"
     opacity="0.6"
   />
   <rect
     v-for="(color, index) of colors"
-    v-bind:key="index"
-    v-bind:x="cx - width / 2"
-    v-bind:y="cy - height / 2 + segmentHeight * index"
-    v-bind:fill="color"
-    v-bind:width="width"
-    v-bind:height="segmentHeight"
+    :key="index"
+    :x="cx - width / 2"
+    :y="cy - height / 2 + segmentHeight * index"
+    :fill="color"
+    :width="width"
+    :height="segmentHeight"
     opacity="0.6"
   />
 </template>

--- a/packages/vue-client/src/utils/ExpandablePocket.vue
+++ b/packages/vue-client/src/utils/ExpandablePocket.vue
@@ -27,13 +27,13 @@ onMounted(() => {
 
 <template>
   <div class="expand-panel">
-    <button type="button" @click="toggleExpansion()" class="expand-button">
+    <button type="button" class="expand-button" @click="toggleExpansion()">
       <text> {{ props.label }} </text>
       <font-awesome-icon v-if="isExpanded" icon="fa-solid fa-chevron-up" />
       <font-awesome-icon v-if="!isExpanded" icon="fa-solid fa-chevron-down" />
     </button>
-    <div class="expand-content" :class="{ hidden: !isExpanded }" ref="content">
-      <slot></slot>
+    <div ref="content" class="expand-content" :class="{ hidden: !isExpanded }">
+      <slot />
     </div>
   </div>
 </template>

--- a/packages/vue-client/src/views/AdminView.vue
+++ b/packages/vue-client/src/views/AdminView.vue
@@ -60,7 +60,7 @@ async function sendTestEmail() {
             placeholder="recipient@example.com"
             :disabled="isSending"
           />
-          <button @click="sendTestEmail" :disabled="isSending">
+          <button :disabled="isSending" @click="sendTestEmail">
             {{ isSending ? "Sending..." : "Send Test Email" }}
           </button>
         </div>

--- a/packages/vue-client/src/views/ComponentView.vue
+++ b/packages/vue-client/src/views/ComponentView.vue
@@ -61,7 +61,7 @@ function update_board_state(pos: Coordinate) {
           :board="board_state"
           @click="update_board_state"
         />
-        <select name="colors" v-model="current_color">
+        <select v-model="current_color" name="colors">
           <option value="blue">Blue</option>
           <option value="red">Red</option>
           <option value="green">Green</option>
@@ -69,25 +69,25 @@ function update_board_state(pos: Coordinate) {
         </select>
         <svg height="600" width="600" viewBox="-300 -300 600 600">
           <TaegeukStone
-            v-bind:r="r"
-            v-bind:cx="cx"
-            v-bind:cy="cy"
-            v-bind:colors="distinct_colors.slice(0, num_colors)"
+            :r="r"
+            :cx="cx"
+            :cy="cy"
+            :colors="distinct_colors.slice(0, num_colors)"
           />
         </svg>
         <div>
           <label>Number of colors (1-20):</label>
-          <input type="number" v-model="num_colors" />
+          <input v-model="num_colors" type="number" />
         </div>
         <div>
           <label>Radius:</label>
-          <input type="number" v-model="r" />
+          <input v-model="r" type="number" />
         </div>
         <div>
           <label>cx:</label>
-          <input type="number" v-model="cx" />
+          <input v-model="cx" type="number" />
           <label>cy:</label>
-          <input type="number" v-model="cy" />
+          <input v-model="cy" type="number" />
         </div>
       </div>
     </div>

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -266,15 +266,15 @@ async function repairGame(): Promise<void> {
       <div>
         <!-- Left column -->
         <component
+          :is="variantGameView"
           v-if="variantGameView && transformedGameData"
-          v-bind:is="variantGameView"
-          v-bind:gamestate="transformedGameData.gamestate"
-          v-bind:config="transformedGameData.config"
-          v-bind:displayed_round="displayed_round"
-          v-bind:next-to-play="game_state?.next_to_play"
-          v-on:move="makeMove"
+          :gamestate="transformedGameData.gamestate"
+          :config="transformedGameData.config"
+          :displayed_round="displayed_round"
+          :next-to-play="game_state?.next_to_play"
+          @move="makeMove"
         />
-        <NavButtons :gameRound="current_round" v-model="view_round" />
+        <NavButtons v-model="view_round" :game-round="current_round" />
 
         <div id="variant-info">
           <div>
@@ -306,15 +306,15 @@ async function repairGame(): Promise<void> {
           <button
             class="icon-button subscribe-button"
             :disabled="!user"
-            v-on:click="isDialogOpen = true"
+            @click="isDialogOpen = true"
           >
             <FontAwesomeIcon icon="fa-solid fa-bell" />
           </button>
           <SubscriptionDialog
-            :gameId="props.gameId"
+            :game-id="props.gameId"
             :subscription="subscription"
             :is-open="isDialogOpen"
-            v-on:close="isDialogOpen = false"
+            @close="isDialogOpen = false"
           />
         </div>
         <div className="seat-list">
@@ -324,9 +324,6 @@ async function repairGame(): Promise<void> {
               :admin_mode="adminMode"
               :occupant="player"
               :player_n="idx"
-              @sit="sit(idx)"
-              @leave="leave(idx)"
-              @select="setPlayingAs(idx)"
               :selected="playing_as"
               :time_control="
                 time_control?.forPlayer[idx] ?? createTimeControlPreview(config)
@@ -336,6 +333,9 @@ async function repairGame(): Promise<void> {
               "
               :variant="variant"
               :config="config"
+              @sit="sit(idx)"
+              @leave="leave(idx)"
+              @select="setPlayingAs(idx)"
             />
           </div>
 
@@ -350,7 +350,7 @@ async function repairGame(): Promise<void> {
           </div>
         </div>
 
-        <DownloadSGF v-if="supportsSGF(variant)" :gameId="gameId" />
+        <DownloadSGF v-if="supportsSGF(variant)" :game-id="gameId" />
         <div
           v-if="game_state?.result"
           style="font-weight: bold; font-size: 24pt"
@@ -358,15 +358,11 @@ async function repairGame(): Promise<void> {
           Result: {{ game_state?.result }}
         </div>
         <div v-if="user?.role === 'admin'">
-          <input type="checkbox" v-model="adminMode" id="admin" />
+          <input id="admin" v-model="adminMode" type="checkbox" />
           <label for="admin">Admin Mode</label>
         </div>
       </div>
-      <button
-        class="repair-game-btn"
-        v-if="errorOccured"
-        v-on:click="repairGame"
-      >
+      <button v-if="errorOccured" class="repair-game-btn" @click="repairGame">
         repair game
       </button>
     </div>

--- a/packages/vue-client/src/views/LoginView.vue
+++ b/packages/vue-client/src/views/LoginView.vue
@@ -28,22 +28,22 @@ const submit = () =>
           <label for="username">Username</label>
           <input
             id="username"
+            v-model="username"
             name="username"
             type="text"
             autocomplete="username"
             required
-            v-model="username"
           />
         </div>
         <div>
           <label for="current-password">Password</label>
           <input
             id="current-password"
+            v-model="password"
             name="password"
             type="password"
             autocomplete="current-password"
             required
-            v-model="password"
           />
         </div>
         <div>
@@ -52,8 +52,8 @@ const submit = () =>
         <hr />
         <input
           type="button"
-          v-on:click="store.guestLogin()"
           value="Log in as guest"
+          @click="store.guestLogin()"
         />
         <div>
           Don't have an account?

--- a/packages/vue-client/src/views/NotificationsView.vue
+++ b/packages/vue-client/src/views/NotificationsView.vue
@@ -88,9 +88,9 @@ async function clear(gameId: string): Promise<unknown> {
 <template>
   <div class="notifications-page">
     <div
-      class="game-notifications-container"
       v-for="{ gameId, notifications, gameState } in notificationGroups"
       :key="gameId"
+      class="game-notifications-container"
     >
       <div class="board-container">
         <template v-if="isErrorResult(gameState)">
@@ -116,30 +116,30 @@ async function clear(gameId: string): Promise<unknown> {
         <button
           class="icon-button success-color"
           aria-label="mark as read"
-          v-on:click="markAsRead(gameId)"
+          @click="markAsRead(gameId)"
         >
           <FontAwesomeIcon icon="fa-solid fa-circle-check" />
         </button>
         <button
           class="icon-button alert-color"
           aria-label="clear"
-          v-on:click="clear(gameId)"
+          @click="clear(gameId)"
         >
           <FontAwesomeIcon icon="fa-solid fa-trash" />
         </button>
         <button
           class="icon-button grey-color"
           :disabled="!user"
-          v-on:click="isDialogOpen = true"
+          @click="isDialogOpen = true"
         >
           <FontAwesomeIcon icon="fa-solid fa-gear" />
         </button>
         <SubscriptionDialog
           v-if="!isErrorResult(gameState)"
-          :gameId="gameId"
+          :game-id="gameId"
           :subscription="gameState.subscription ?? []"
           :is-open="isDialogOpen"
-          v-on:close="isDialogOpen = false"
+          @close="isDialogOpen = false"
         />
       </div>
     </div>

--- a/packages/vue-client/src/views/RegisterView.vue
+++ b/packages/vue-client/src/views/RegisterView.vue
@@ -38,21 +38,21 @@ const submit = () =>
           <label for="username">Username</label>
           <input
             id="username"
+            v-model="username"
             name="username"
             type="text"
             autocomplete="username"
             required
-            v-model="username"
           />
         </div>
         <div>
           <label for="email">Email (optional)</label>
           <input
             id="email"
+            v-model="email"
             name="email"
             type="email"
             autocomplete="email"
-            v-model="email"
           />
           <div
             v-if="!isEmailValid"
@@ -65,11 +65,11 @@ const submit = () =>
           <label for="current-password">Password</label>
           <input
             id="current-password"
+            v-model="password"
             name="password"
             type="password"
             autocomplete="current-password"
             required
-            v-model="password"
           />
         </div>
         <div>

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -21,7 +21,7 @@ const variantExists = computed(() => getVariantList().includes(props.variant));
       <div>
         <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
         <p v-if="!rulesDescription">Under Construction</p>
-        <div v-if="rulesDescription" v-html="rulesDescription"></div>
+        <div v-if="rulesDescription" v-html="rulesDescription" />
       </div>
       <div>
         <h1>Demo</h1>

--- a/packages/vue-client/src/views/UserView.vue
+++ b/packages/vue-client/src/views/UserView.vue
@@ -144,8 +144,8 @@ async function launchDeleteUserDialog() {
             <label for="email">Email:</label>
             <input
               id="email"
-              type="email"
               v-model="newEmail"
+              type="email"
               placeholder="Enter email address (leave empty to unset)"
             />
             <div

--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -149,15 +149,15 @@ watch(
   <div class="grid-page-layout">
     <div>
       <component
+        :is="variantGameView"
         v-if="variantGameView && game.state"
-        v-bind:is="variantGameView"
-        v-bind:gamestate="transformedGameData.gamestate"
-        v-bind:config="transformedGameData.config"
-        v-bind:displayed_round="displayed_round"
-        v-bind:next-to-play="game.next_to_play"
-        v-on:move="makeMove"
+        :gamestate="transformedGameData.gamestate"
+        :config="transformedGameData.config"
+        :displayed_round="displayed_round"
+        :next-to-play="game.next_to_play"
+        @move="makeMove"
       />
-      <NavButtons v-model="view_round" :gameRound="game.round" />
+      <NavButtons v-model="view_round" :game-round="game.round" />
 
       <div id="variant-info">
         <div>
@@ -179,12 +179,12 @@ watch(
           :user_id="user?.id"
           :occupant="user || undefined"
           :player_n="idx"
-          @select="setPlayingAs(idx)"
           :selected="playing_as"
           :time_control="null"
           :is_players_turn="game.next_to_play?.includes(idx) ?? false"
           :variant="variant"
           :config="config"
+          @select="setPlayingAs(idx)"
         />
       </div>
 
@@ -201,9 +201,9 @@ watch(
       <PlayersToMove :next-to-play="game.next_to_play" />
 
       <component
-        v-bind:is="variantConfigForm"
-        v-bind:initialConfig="getDefaultConfig(variant)"
-        v-on:configChanged="onConfigChange"
+        :is="variantConfigForm"
+        :initial-config="getDefaultConfig(variant)"
+        @config-changed="onConfigChange"
       />
     </div>
 


### PR DESCRIPTION
replacement for #447 

- Change eslint extends from vue3-essential to vue3-recommended
- Add vue/html-self-closing rule to prevent conflicts with Prettier
- Auto-fix all auto-fixable issues (v-bind: -> :, v-on: -> @, attribute ordering, self-closing tags)
- Temporarily disable rules requiring manual fixes: prop-name-casing, no-template-shadow, require-default-prop, no-v-html