### PR TITLE
Rules page improvements

### DIFF
--- a/packages/shared/src/templates/parallel_rules.ts
+++ b/packages/shared/src/templates/parallel_rules.ts
@@ -1,0 +1,10 @@
+export const parallel_rules = `
+Parallel is a multiplayer variant of Go where moves are played *in parallel*. During a round, all players submit a move. Only when all players have submitted are the moves revealed, and the next round starts.
+
+# Collision handling
+
+When two or more players submit a move at the same position, a *collision* occurs. There are different ways to handle a collision that can be configured at the game start.
+- Merge - A multicolored stone is placed, with the combined colors of the colliding players. For rules on multicolored stones, please refer to [https://www.govariants.com/variants/fractional/rules](https://www.govariants.com/variants/fractional/rules) or [https://www.govariants.com/variants/sfractional/rules](https://www.govariants.com/variants/sfractional/rules).
+- Pass - No stone is placed at the place of collision.
+- Ko - A temporary neutral stone occupies the place of collision for one round.
+`;

--- a/packages/shared/src/variant_map.ts
+++ b/packages/shared/src/variant_map.ts
@@ -123,15 +123,6 @@ export function uiTransform(variant: string, config: object, state: object) {
   return variant_object.uiTransform(config, state);
 }
 
-export function getVariantsWithRulesDescription(): string[] {
-  return Object.entries(variant_map)
-    .filter(
-      ([_name, variant]) =>
-        !variant.deprecated && variant.rulesDescription !== undefined,
-    )
-    .map(([name, _variant]) => name);
-}
-
 export function getTimeHandling(
   variant: string,
 ): "sequential" | "parallel" | "none" {

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -2,6 +2,7 @@ import { AbstractGame } from "../abstract_game";
 import { Coordinate } from "../lib/coordinate";
 import { Grid } from "../lib/grid";
 import { MovesType } from "../lib/utils";
+import { parallel_rules } from "../templates/parallel_rules";
 import { Variant } from "../variant";
 
 export interface ParallelGoConfig {
@@ -246,6 +247,7 @@ export const parallelVariant: Variant<ParallelGoConfig> = {
   gameClass: ParallelGo,
   description: "Multiplayer Baduk with parallel moves",
   time_handling: "parallel",
+  rulesDescription: parallel_rules,
   defaultConfig(): ParallelGoConfig {
     return {
       width: 19,

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -3,7 +3,6 @@ import {
   HasTimeControlConfig,
   timeControlMap,
   supportsSGF,
-  getDescription,
   uiTransform,
   NotificationType,
 } from "@ogfcommunity/variants-shared";
@@ -28,6 +27,7 @@ import SubscriptionDialog from "@/components/GameView/SubscriptionDialog.vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
+import { toUpperCaseFirstLetter } from "@/utils/format-utils";
 
 library.add(faBell);
 
@@ -49,7 +49,6 @@ const players = ref<User[]>();
 // while viewing history of game, maybe we should prevent player from making a move (accidentally)
 const view_round: Ref<number | null> = ref(null);
 const variantGameView = computed(() => getPlayingTable(variant.value));
-const variantDescriptionShort = computed(() => getDescription(variant.value));
 const user = useCurrentUser();
 const playing_as = ref<undefined | number>(undefined);
 const displayed_round = computed(() => view_round.value ?? current_round.value);
@@ -279,14 +278,9 @@ async function repairGame(): Promise<void> {
         <div id="variant-info">
           <div>
             <span class="info-label">Variant:</span>
-            <span class="info-attribute">
-              {{ variant ?? "unknown" }}
-            </span>
-          </div>
-
-          <div>
-            <span class="info-label">Description:</span>
-            <span class="info-attribute">{{ variantDescriptionShort }}</span>
+            <RouterLink :to="{ name: 'rules', params: { variant: variant } }">{{
+              toUpperCaseFirstLetter(variant)
+            }}</RouterLink>
           </div>
 
           <div v-if="creator">

--- a/packages/vue-client/src/views/RulesListView.vue
+++ b/packages/vue-client/src/views/RulesListView.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { toUpperCaseFirstLetter } from "@/utils/format-utils";
-import { getVariantsWithRulesDescription } from "@ogfcommunity/variants-shared";
+import { getVariantList } from "@ogfcommunity/variants-shared";
 import { RouterLink } from "vue-router";
-
-const variantsWithRulesDescription = getVariantsWithRulesDescription();
 </script>
 
 <template>
@@ -11,7 +9,7 @@ const variantsWithRulesDescription = getVariantsWithRulesDescription();
     <h1>Rule Descriptions</h1>
     <div class="rule-links-container">
       <RouterLink
-        v-for="variant in variantsWithRulesDescription"
+        v-for="variant in getVariantList()"
         :key="variant"
         class="rules-link"
         :to="{ name: 'rules', params: { variant: variant } }"

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  getDescription,
   getRulesDescription,
   getVariantList,
 } from "@ogfcommunity/variants-shared";
@@ -20,7 +21,9 @@ const variantExists = computed(() => getVariantList().includes(props.variant));
     <div v-if="variantExists" class="grid-page-layout rules-page">
       <div>
         <h1>{{ toUpperCaseFirstLetter(props.variant) }} Variant Rules</h1>
-        <p v-if="!rulesDescription">Under Construction</p>
+        <p v-if="!rulesDescription" class="description-container">
+          {{ getDescription(variant) }}
+        </p>
         <div v-if="rulesDescription" v-html="rulesDescription" />
       </div>
       <div>
@@ -40,6 +43,10 @@ main {
   max-width: none;
   overflow-x: scroll;
   grid-template-columns: minmax(45ch, 90ch) 1fr;
+}
+
+.description-container {
+  white-space: pre-line;
 }
 
 :deep(strong, h1, h2) {


### PR DESCRIPTION
# Changes
- On rules page default to the short description. Link all variant rules & demo pages (as all variants have a short description).
- In game view, rather than displaying the short description, we link to the respective rules page.
- Add detailed rules description for parallel.

In particular, this makes it so the demo board component is linked on the main page for all variants.