### PR TITLE
Use error version of the Vue lints (fixes #449)

### DIFF
--- a/packages/vue-client/eslint.config.mjs
+++ b/packages/vue-client/eslint.config.mjs
@@ -10,7 +10,7 @@ export default defineConfigWithVueTs(
     ignores: ["dist/", "coverage/"],
   },
 
-  pluginVue.configs["flat/recommended"],
+  pluginVue.configs["flat/recommended-error"],
   vueTsConfigs.recommended,
 
   {


### PR DESCRIPTION
Fixes #449 

Test: add a lint violation and see that eslint outputs an error

```
/.../govariants/packages/vue-client/src/components/PlayingTable/CubeTable.vue
  46:5  error  Elements in iteration expect to have 'v-bind:key' directives  vue/require-v-for-key

✖ 1 problem (1 error, 0 warnings)
```