### PR TITLE
Variants improvements

### DIFF
--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -73,3 +73,16 @@ export function groupBy<T, K>(arr: T[], selector: (v: T) => K): [K, T[]][] {
       .entries(),
   ];
 }
+
+export function map2d<TSource, TDestination>(
+  arr: TSource[][],
+  map: (
+    entry: TSource,
+    row_index: number,
+    column_index: number,
+  ) => TDestination,
+): TDestination[][] {
+  return arr.map((row, row_index) =>
+    row.map((entry, column_index) => map(entry, row_index, column_index)),
+  );
+}

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -73,16 +73,3 @@ export function groupBy<T, K>(arr: T[], selector: (v: T) => K): [K, T[]][] {
       .entries(),
   ];
 }
-
-export function map2d<TSource, TDestination>(
-  arr: TSource[][],
-  map: (
-    entry: TSource,
-    row_index: number,
-    column_index: number,
-  ) => TDestination,
-): TDestination[][] {
-  return arr.map((row, row_index) =>
-    row.map((entry, column_index) => map(entry, row_index, column_index)),
-  );
-}

--- a/packages/shared/src/variant.ts
+++ b/packages/shared/src/variant.ts
@@ -17,7 +17,8 @@ export interface Variant<
 > {
   /** The class that implements AbstractGame and manages the state of an ongoing game */
   gameClass: new (config: ConfigT) => AbstractGame;
-  /** Short description of the Variant (shown to players in-game) */
+  /** Short description of the Variant (displayed in the game creation form and on page
+   * /variants/<variant>/rules if rulesDescription is undefined) */
   description: string;
   /**
    * Long description of the variant.  Supports markdown syntax.

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -23,6 +23,7 @@ import {
 import { Variant } from "../variant";
 import { SgfRecorder } from "../lib/sgf_recorder";
 import { DefaultBoardState, MulticolorStone } from "../lib/board_types";
+import { map2d } from "../lib/utils";
 
 export enum Color {
   EMPTY = 0,
@@ -349,7 +350,6 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
     move: string,
     player: number,
   ): T {
-    console.log(config, state, move, player);
     if (player !== 0 && player !== 1) {
       console.error(
         `Baduk.movePreview was called with player = ${player}, but only 0 and 1 are expected.`,
@@ -371,13 +371,14 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
     }
 
     const playerColor = player === 0 ? Color.BLACK : Color.WHITE;
-    const boardWithPreview = state.board.map((row, row_idx) =>
-      row.map((fieldColor, col_idx) => {
+    const boardWithPreview = map2d(
+      state.board,
+      (fieldColor, row_idx, col_idx) => {
         if (row_idx === coordinate.y && col_idx === coordinate.x) {
           return playerColor;
         }
         return fieldColor;
-      }),
+      },
     );
 
     return {

--- a/packages/shared/src/variants/baduk.ts
+++ b/packages/shared/src/variants/baduk.ts
@@ -23,7 +23,6 @@ import {
 import { Variant } from "../variant";
 import { SgfRecorder } from "../lib/sgf_recorder";
 import { DefaultBoardState, MulticolorStone } from "../lib/board_types";
-import { map2d } from "../lib/utils";
 
 export enum Color {
   EMPTY = 0,
@@ -357,28 +356,29 @@ export class Baduk extends AbstractGame<NewBadukConfig, BadukState> {
       return state;
     }
 
-    let coordinate: Coordinate;
+    let moveCoordinate: Coordinate;
     if (isGridBadukConfig(config)) {
       if (!isSgfRepr(move)) {
         return state;
       }
-      coordinate = Coordinate.fromSgfRepr(move);
+      moveCoordinate = Coordinate.fromSgfRepr(move);
     } else {
       if (isNaN(Number(move))) {
         return state;
       }
-      coordinate = new Coordinate(Number(move), 0);
+      moveCoordinate = new Coordinate(Number(move), 0);
     }
 
     const playerColor = player === 0 ? Color.BLACK : Color.WHITE;
-    const boardWithPreview = map2d(
+    const boardWithPreview = mapBoard(
       state.board,
-      (fieldColor, row_idx, col_idx) => {
-        if (row_idx === coordinate.y && col_idx === coordinate.x) {
+      (fieldColor, coordinate) => {
+        if (moveCoordinate.equals(coordinate)) {
           return playerColor;
         }
         return fieldColor;
       },
+      "2d",
     );
 
     return {

--- a/packages/shared/src/variants/chess.ts
+++ b/packages/shared/src/variants/chess.ts
@@ -49,12 +49,24 @@ export class ChessGame extends AbstractGame<object, ChessState> {
   defaultConfig(): object {
     return {};
   }
+
+  static movePreview(
+    _config: object,
+    state: ChessState,
+    move: string,
+    _player: number,
+  ): ChessState {
+    const game = new Chess(state.fen);
+    game.move(move);
+    return { fen: game.fen() };
+  }
 }
 
-export const chessVariant: Variant = {
+export const chessVariant: Variant<object, ChessState> = {
   gameClass: ChessGame,
   description:
     "Baduk with different types of stones\n the goal is to capture a specific stone",
   time_handling: "sequential",
   defaultConfig: Object,
+  movePreview: ChessGame.movePreview,
 };

--- a/packages/shared/src/variants/lighthouse/lighthouse.ts
+++ b/packages/shared/src/variants/lighthouse/lighthouse.ts
@@ -8,6 +8,7 @@ import { Coordinate, CoordinateLike, isSgfRepr } from "../../lib/coordinate";
 import { Grid } from "../../lib/grid";
 import { examineGroup, getGroup, getOuterBorder } from "../../lib/group_utils";
 import { SuperKoDetector } from "../../lib/ko_detector";
+import { map2d } from "../../lib/utils";
 import { lighthouseRules } from "../../templates/lighthouse_rules";
 import { Variant } from "../../variant";
 import { Baduk, Color } from "../baduk";
@@ -310,14 +311,12 @@ export class Lighthouse extends AbstractGame<
     const color = player === 0 ? Color.BLACK : Color.WHITE;
 
     return {
-      board: state.board.map((row, row_idx) =>
-        row.map((field, col_idx) => ({
-          lastKnownInformation: field.lastKnownInformation,
-          visibleColor: coordinate.equals({ x: col_idx, y: row_idx })
-            ? color
-            : field.visibleColor,
-        })),
-      ),
+      board: map2d(state.board, (field, row_idx, col_idx) => ({
+        lastKnownInformation: field.lastKnownInformation,
+        visibleColor: coordinate.equals({ x: col_idx, y: row_idx })
+          ? color
+          : field.visibleColor,
+      })),
     };
   }
 }

--- a/packages/shared/src/variants/lighthouse/lighthouse.ts
+++ b/packages/shared/src/variants/lighthouse/lighthouse.ts
@@ -8,11 +8,10 @@ import { Coordinate, CoordinateLike, isSgfRepr } from "../../lib/coordinate";
 import { Grid } from "../../lib/grid";
 import { examineGroup, getGroup, getOuterBorder } from "../../lib/group_utils";
 import { SuperKoDetector } from "../../lib/ko_detector";
-import { map2d } from "../../lib/utils";
 import { lighthouseRules } from "../../templates/lighthouse_rules";
 import { Variant } from "../../variant";
 import { Baduk, Color } from "../baduk";
-import { NewGridBadukConfig } from "../baduk_utils";
+import { mapBoard, NewGridBadukConfig } from "../baduk_utils";
 import {
   binaryPlayerNr,
   VisibleField,
@@ -307,16 +306,20 @@ export class Lighthouse extends AbstractGame<
       return state;
     }
 
-    const coordinate = Coordinate.fromSgfRepr(move);
+    const moveCoordinate = Coordinate.fromSgfRepr(move);
     const color = player === 0 ? Color.BLACK : Color.WHITE;
 
     return {
-      board: map2d(state.board, (field, row_idx, col_idx) => ({
-        lastKnownInformation: field.lastKnownInformation,
-        visibleColor: coordinate.equals({ x: col_idx, y: row_idx })
-          ? color
-          : field.visibleColor,
-      })),
+      board: mapBoard(
+        state.board,
+        (field, coordinate) => ({
+          lastKnownInformation: field.lastKnownInformation,
+          visibleColor: moveCoordinate.equals(coordinate)
+            ? color
+            : field.visibleColor,
+        }),
+        "2d",
+      ),
     };
   }
 }

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -1,7 +1,7 @@
 import { AbstractGame } from "../abstract_game";
-import { Coordinate } from "../lib/coordinate";
+import { Coordinate, isSgfRepr } from "../lib/coordinate";
 import { Grid } from "../lib/grid";
-import { MovesType } from "../lib/utils";
+import { map2d, MovesType } from "../lib/utils";
 import { parallel_rules } from "../templates/parallel_rules";
 import { Variant } from "../variant";
 
@@ -235,6 +235,29 @@ export class ParallelGo extends AbstractGame<
       group.stones.forEach((pos) => this.board.set(pos, []));
     });
   }
+
+  static movePreview(
+    _: ParallelGoConfig,
+    state: ParallelGoState,
+    move: string,
+    player: number,
+  ): ParallelGoState {
+    if (!isSgfRepr(move)) {
+      return state;
+    }
+
+    const coordinate = Coordinate.fromSgfRepr(move);
+
+    return {
+      ...state,
+      board: map2d(state.board, (entry, row_index, column_index) =>
+        coordinate.equals({ x: column_index, y: row_index })
+          ? [player]
+          : [...entry],
+      ),
+      staged: {},
+    };
+  }
 }
 
 interface Group {
@@ -243,7 +266,7 @@ interface Group {
   contains_staged: boolean;
 }
 
-export const parallelVariant: Variant<ParallelGoConfig> = {
+export const parallelVariant: Variant<ParallelGoConfig, ParallelGoState> = {
   gameClass: ParallelGo,
   description: "Multiplayer Baduk with parallel moves",
   time_handling: "parallel",
@@ -256,4 +279,35 @@ export const parallelVariant: Variant<ParallelGoConfig> = {
       collision_handling: "merge",
     };
   },
+  movePreview: ParallelGo.movePreview,
+  getPlayerColors: (config, player) => [
+    config.num_players === 2
+      ? ["black", "white"][player]
+      : colors_for_parallel[player],
+  ],
 };
+
+export const colors_for_parallel = [
+  "#e6194B",
+  "#3cb44b",
+  "#ffe119",
+  "#4363d8",
+  "#f58231",
+  "#911eb4",
+  "#42d4f4",
+  "#f032e6",
+  "#bfef45",
+  "#fabed4",
+  "#469990",
+  "#dcbeff",
+  "#9A6324",
+  "#fffac8",
+  "#800000",
+  "#aaffc3",
+  "#808000",
+  "#ffd8b1",
+  "#000075",
+  "#a9a9a9",
+  "#ffffff",
+  "#000000",
+];

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -287,6 +287,7 @@ export const parallelVariant: Variant<ParallelGoConfig, ParallelGoState> = {
   ],
 };
 
+// https://sashamaps.net/docs/resources/20-colors/
 export const colors_for_parallel = [
   "#e6194B",
   "#3cb44b",

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -1,9 +1,10 @@
 import { AbstractGame } from "../abstract_game";
 import { Coordinate, isSgfRepr } from "../lib/coordinate";
 import { Grid } from "../lib/grid";
-import { map2d, MovesType } from "../lib/utils";
+import { MovesType } from "../lib/utils";
 import { parallel_rules } from "../templates/parallel_rules";
 import { Variant } from "../variant";
+import { mapBoard } from "./baduk_utils";
 
 export interface ParallelGoConfig {
   width: number;
@@ -246,14 +247,15 @@ export class ParallelGo extends AbstractGame<
       return state;
     }
 
-    const coordinate = Coordinate.fromSgfRepr(move);
+    const moveCoordinate = Coordinate.fromSgfRepr(move);
 
     return {
       ...state,
-      board: map2d(state.board, (entry, row_index, column_index) =>
-        coordinate.equals({ x: column_index, y: row_index })
-          ? [player]
-          : [...entry],
+      board: mapBoard(
+        state.board,
+        (entry, coordinate) =>
+          moveCoordinate.equals(coordinate) ? [player] : [...entry],
+        "2d",
       ),
       staged: {},
     };

--- a/packages/shared/src/variants/s_fractional.ts
+++ b/packages/shared/src/variants/s_fractional.ts
@@ -24,7 +24,6 @@ import {
   MulticolorStone,
 } from "../lib/board_types";
 import { examineGroup } from "../lib/group_utils";
-import { map2d } from "../lib/utils";
 
 declare type Color = string;
 declare type PlacementColors = Color[] & ([Color, Color] | []);
@@ -349,27 +348,28 @@ export class SFractional extends AbstractGame<
       return state;
     }
 
-    let coordinate: Coordinate;
+    let moveCoordinate: Coordinate;
     if (isGridBadukConfig(config)) {
       if (!isSgfRepr(move)) {
         return state;
       }
-      coordinate = Coordinate.fromSgfRepr(move);
+      moveCoordinate = Coordinate.fromSgfRepr(move);
     } else {
       if (isNaN(Number(move))) {
         return state;
       }
-      coordinate = new Coordinate(Number(move), 0);
+      moveCoordinate = new Coordinate(Number(move), 0);
     }
 
-    const boardWithPreview = map2d(
+    const boardWithPreview = mapBoard(
       state.board,
-      (fieldColors, row_idx, col_idx) => {
-        if (coordinate.equals({ x: col_idx, y: row_idx })) {
+      (fieldColors, coordinate) => {
+        if (moveCoordinate.equals(coordinate)) {
           return sFractionalMoveColors(state.round, config);
         }
         return fieldColors;
       },
+      "2d",
     );
 
     return {

--- a/packages/vue-client/src/components/boards/ParallelGoBoard.vue
+++ b/packages/vue-client/src/components/boards/ParallelGoBoard.vue
@@ -1,5 +1,8 @@
 <script lang="ts">
-import type { MovesType } from "@ogfcommunity/variants-shared";
+import {
+  type MovesType,
+  colors_for_parallel,
+} from "@ogfcommunity/variants-shared";
 
 type Stone = { colors: string[]; annotation?: "CR" };
 
@@ -46,32 +49,7 @@ function isKoStone(colors: number[]) {
 
 // https://sashamaps.net/docs/resources/20-colors/
 const distinct_colors =
-  props.config.num_players === 2
-    ? ["black", "white"]
-    : [
-        "#e6194B",
-        "#3cb44b",
-        "#ffe119",
-        "#4363d8",
-        "#f58231",
-        "#911eb4",
-        "#42d4f4",
-        "#f032e6",
-        "#bfef45",
-        "#fabed4",
-        "#469990",
-        "#dcbeff",
-        "#9A6324",
-        "#fffac8",
-        "#800000",
-        "#aaffc3",
-        "#808000",
-        "#ffd8b1",
-        "#000075",
-        "#a9a9a9",
-        "#ffffff",
-        "#000000",
-      ];
+  props.config.num_players === 2 ? ["black", "white"] : colors_for_parallel;
 
 const emit = defineEmits<{
   (e: "move", pos: string): void;

--- a/packages/vue-client/src/components/boards/ParallelGoBoard.vue
+++ b/packages/vue-client/src/components/boards/ParallelGoBoard.vue
@@ -47,7 +47,6 @@ function isKoStone(colors: number[]) {
   return colors.length === 1 && colors[0] === -1;
 }
 
-// https://sashamaps.net/docs/resources/20-colors/
 const distinct_colors =
   props.config.num_players === 2 ? ["black", "white"] : colors_for_parallel;
 


### PR DESCRIPTION
This is a follow-up to https://github.com/govariantsteam/govariants/pull/458 where I intend to add move preview implementations.
Also adds a utils function `map2d` which I found useful to simplify the move preview functions, and adds `getPlayerColors` to parallel variant.