### PR TITLE
Leverage Express 5 async error handling

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -41,6 +41,7 @@ import {
 import { io } from "./socket_io";
 import { checkCSRFToken, generateCSRFToken } from "./csrf_guard";
 import { sendEmail } from "./email";
+import { HttpError } from "./http-error";
 import {
   clearNotifications,
   getUserNotifications,
@@ -53,52 +54,43 @@ export const router = express.Router();
 // Set up express routes
 
 router.get("/game/:gameId/sgf", async (req, res) => {
-  try {
-    const game = await getGame(req.params.gameId);
+  const game = await getGame(req.params.gameId);
 
-    const game_obj = makeGameObject(game.variant, game.config);
+  const game_obj = makeGameObject(game.variant, game.config);
 
-    game.moves.forEach((moves) => {
-      const { player, move } = getOnlyMove(moves);
-      game_obj.playMove(player, move);
+  game.moves.forEach((moves) => {
+    const { player, move } = getOnlyMove(moves);
+    game_obj.playMove(player, move);
+  });
+
+  if (game_obj.getSGF() === "") {
+    throw new Error(`SGF not supported for variant ${game.variant}`);
+  } else if (game_obj.getSGF() === "non-rectangular") {
+    throw new Error("SGF for non rectangular boards is not possible");
+  } else {
+    res.set({
+      "Content-Disposition": `attachment; filename="game_${req.params.gameId}.sgf"`,
     });
-
-    if (game_obj.getSGF() === "") {
-      throw new Error(`SGF not supported for variant ${game.variant}`);
-    } else if (game_obj.getSGF() === "non-rectangular") {
-      throw new Error("SGF for non rectangular boards is not possible");
-    } else {
-      res.set({
-        "Content-Disposition": `attachment; filename="game_${req.params.gameId}.sgf"`,
-      });
-      res.set("Content-Type", "text/plain");
-      res.send(game_obj.getSGF());
-    }
-  } catch (e) {
-    res.status(500).json({ error: e.message });
+    res.set("Content-Type", "text/plain");
+    res.send(game_obj.getSGF());
   }
 });
 
 router.get("/games", async (req, res) => {
-  try {
-    const filter: GamesFilter = {
-      user_id: req.query.user_id?.toString(),
-      variant: req.query.variant?.toString(),
-    };
+  const filter: GamesFilter = {
+    user_id: req.query.user_id?.toString(),
+    variant: req.query.variant?.toString(),
+  };
 
-    const games: GameResponse[] = await getGames(
-      Number(req.query.count),
-      Number(req.query.offset),
-      filter,
-    );
-    const gameStates = games.map((game) =>
-      tryComputeState(game, req.user as User | undefined),
-    );
-    res.send(gameStates || 0);
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  const games: GameResponse[] = await getGames(
+    Number(req.query.count),
+    Number(req.query.offset),
+    filter,
+  );
+  const gameStates = games.map((game) =>
+    tryComputeState(game, req.user as User | undefined),
+  );
+  res.send(gameStates || 0);
 });
 
 router.post("/games", checkCSRFToken, async (req, res) => {
@@ -106,35 +98,20 @@ router.post("/games", checkCSRFToken, async (req, res) => {
 
   if (!req.user) {
     // unauthorized
-    res.status(401);
-    res.json("To create a game, please register an account.");
+    res.status(401).json("To create a game, please register an account.");
     return;
   }
 
-  try {
-    const user = req.user as User;
-    const game: GameResponse = await createGame(
-      data.variant,
-      data.config,
-      user,
-    );
-    res.send(game);
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  const user = req.user as User;
+  const game: GameResponse = await createGame(data.variant, data.config, user);
+  res.send(game);
 });
 
 router.post("/games/:gameId/move", checkCSRFToken, async (req, res) => {
   const move: MovesType = req.body;
   const user_id = (req.user as User)?.id;
 
-  try {
-    res.send(await playMove(req.params.gameId, move, user_id));
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  res.send(await playMove(req.params.gameId, move, user_id));
 });
 
 router.post("/games/:gameId/sit/:seat", checkCSRFToken, async (req, res) => {
@@ -150,8 +127,7 @@ router.post("/games/:gameId/sit/:seat", checkCSRFToken, async (req, res) => {
     io().emit(`game/${req.params.gameId}/seats`, players);
     res.send(players);
   } catch (e) {
-    res.status(409);
-    res.json(e.message);
+    throw new HttpError(409, e instanceof Error ? e.message : String(e));
   }
 });
 
@@ -177,12 +153,7 @@ router.post("/register", async (req, res, next) => {
     return;
   }
 
-  try {
-    checkUsername(username);
-  } catch (e) {
-    res.status(500).json(e);
-    return;
-  }
+  checkUsername(username);
 
   await createUserWithUsernameAndPassword(username, password, email);
   passport.authenticate("local", make_auth_cb(req, res))(req, res, next);
@@ -190,125 +161,95 @@ router.post("/register", async (req, res, next) => {
 
 router.put("/users/:userId/role", checkCSRFToken, async (req, res) => {
   const { role } = req.body;
-  try {
-    if (!req.user || (req.user as UserResponse).role !== "admin") {
-      // unauthorized
-      res.status(401);
-      res.json("Only Admins may set user roles.");
-      return;
-    }
 
-    if (!["admin"].includes(role)) {
-      throw new Error(`Invalid role: ${role}`);
-    }
-
-    const userToUpdate = await getUser(req.params.userId);
-
-    if (userToUpdate.login_type !== "persistent") {
-      throw new Error(
-        `Cannot assign role "${role}" to user with "${userToUpdate.login_type}" type.`,
-      );
-    }
-
-    await setUserRole(req.params.userId, role);
-
-    userToUpdate.role = role;
-    res.send(userToUpdate);
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
+  if (!req.user || (req.user as UserResponse).role !== "admin") {
+    res.status(401).json("Only Admins may set user roles.");
+    return;
   }
+
+  if (!["admin"].includes(role)) {
+    throw new Error(`Invalid role: ${role}`);
+  }
+
+  const userToUpdate = await getUser(req.params.userId);
+
+  if (userToUpdate.login_type !== "persistent") {
+    throw new Error(
+      `Cannot assign role "${role}" to user with "${userToUpdate.login_type}" type.`,
+    );
+  }
+
+  await setUserRole(req.params.userId, role);
+
+  userToUpdate.role = role;
+  res.send(userToUpdate);
 });
 
 router.get("/users/:userId/email", checkCSRFToken, async (req, res) => {
-  try {
-    if (!req.user) {
-      res.status(401);
-      res.json("You must be logged in to view email.");
-      return;
-    }
-
-    const currentUser = req.user as UserResponse;
-
-    // Users can only view their own email (unless they're an admin)
-    if (currentUser.id !== req.params.userId && currentUser.role !== "admin") {
-      res.status(403);
-      res.json("You can only view your own email.");
-      return;
-    }
-
-    const email = await getUserEmail(req.params.userId);
-    res.json({ email: email || null });
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
+  if (!req.user) {
+    res.status(401).json("You must be logged in to view email.");
+    return;
   }
+
+  const currentUser = req.user as UserResponse;
+
+  // Users can only view their own email (unless they're an admin)
+  if (currentUser.id !== req.params.userId && currentUser.role !== "admin") {
+    res.status(403).json("You can only view your own email.");
+    return;
+  }
+
+  const email = await getUserEmail(req.params.userId);
+  res.json({ email: email || null });
 });
 
 router.put("/users/:userId/email", checkCSRFToken, async (req, res) => {
   const { email } = req.body;
-  try {
-    if (!req.user) {
-      res.status(401);
-      res.json("You must be logged in to update email.");
-      return;
-    }
 
-    const currentUser = req.user as UserResponse;
-
-    // Users can only update their own email (unless they're an admin)
-    if (currentUser.id !== req.params.userId && currentUser.role !== "admin") {
-      res.status(403);
-      res.json("You can only update your own email.");
-      return;
-    }
-
-    const userToUpdate = await getUser(req.params.userId);
-
-    if (userToUpdate.login_type !== "persistent") {
-      throw new Error(
-        `Cannot set email for user with "${userToUpdate.login_type}" type.`,
-      );
-    }
-
-    await setUserEmail(req.params.userId, email);
-
-    res.json({ success: true, email });
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
+  if (!req.user) {
+    res.status(401).json("You must be logged in to update email.");
+    return;
   }
+
+  const currentUser = req.user as UserResponse;
+
+  // Users can only update their own email (unless they're an admin)
+  if (currentUser.id !== req.params.userId && currentUser.role !== "admin") {
+    res.status(403).json("You can only update your own email.");
+    return;
+  }
+
+  const userToUpdate = await getUser(req.params.userId);
+
+  if (userToUpdate.login_type !== "persistent") {
+    throw new Error(
+      `Cannot set email for user with "${userToUpdate.login_type}" type.`,
+    );
+  }
+
+  await setUserEmail(req.params.userId, email);
+
+  res.json({ success: true, email });
 });
 
 router.get("/users/:userId", async (req, res) => {
-  try {
-    const user = await getUser(req.params.userId);
-    if (!user) {
-      res.status(404);
-      res.json("User does not exist");
-    }
-    res.send(user);
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
+  const user = await getUser(req.params.userId);
+  if (!user) {
+    res.status(404).json("User does not exist");
+    return;
   }
+  res.send(user);
 });
 
 router.delete("/users/:userId", checkCSRFToken, async (req, res) => {
   if ((req.user as UserResponse).role !== "admin") {
-    res.status(401);
-    res.json("You are not authorized to delete users");
+    res.status(401).json("You are not authorized to delete users");
     return;
   }
 
-  try {
-    // TODO: we should probably make deleteUser async so that we can report DB errors to the API caller
-    deleteUser(req.params.userId);
-    res.json("success");
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  // TODO: we should probably make deleteUser async so that we can report DB errors to the API caller
+  deleteUser(req.params.userId);
+  res.json("success");
 });
 
 function make_auth_cb(
@@ -366,77 +307,55 @@ router.get("/logout", async function (req, res) {
 });
 
 router.get("/games/:gameId/state/initial", async (req, res) => {
-  try {
-    const game = await getGame(req.params.gameId);
-    const stateResponse = getGameState(game, null, null);
-    const result: GameInitialResponse = {
-      variant: game.variant,
-      config: game.config,
-      id: game.id,
-      players: game.players,
-      creator: game.creator,
-      ...stateResponse,
-    };
-    if (req.user && game.subscriptions) {
-      result.subscription = game.subscriptions[(req.user as User).id] ?? [];
-    }
-    res.send(result);
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
+  const game = await getGame(req.params.gameId);
+  const stateResponse = getGameState(game, null, null);
+  const result: GameInitialResponse = {
+    variant: game.variant,
+    config: game.config,
+    id: game.id,
+    players: game.players,
+    creator: game.creator,
+    ...stateResponse,
+  };
+  if (req.user && game.subscriptions) {
+    result.subscription = game.subscriptions[(req.user as User).id] ?? [];
   }
+  res.send(result);
 });
 
 router.get("/games/:gameId/state", async (req, res) => {
-  try {
-    const seat = req.query.seat === "" ? null : Number(req.query.seat);
-    const round = req.query.round === "" ? null : Number(req.query.round);
-    const game = await getGame(req.params.gameId);
-    const stateResponse = getGameState(game, seat, round);
-    res.send(stateResponse);
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  const seat = req.query.seat === "" ? null : Number(req.query.seat);
+  const round = req.query.round === "" ? null : Number(req.query.round);
+  const game = await getGame(req.params.gameId);
+  const stateResponse = getGameState(game, seat, round);
+  res.send(stateResponse);
 });
 
 router.post("/game/:gameId/repair", checkCSRFToken, async (req, res) => {
-  try {
-    await repairGame(req.params.gameId);
-    res.send({});
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  await repairGame(req.params.gameId);
+  res.send({});
 });
 
 router.post("/admin/test-email", checkCSRFToken, async (req, res) => {
-  try {
-    if (!req.user || (req.user as UserResponse).role !== "admin") {
-      res.status(401);
-      res.json("Only admins may send test emails.");
-      return;
-    }
-
-    const { to } = req.body;
-    if (!to) {
-      res.status(400);
-      res.json("Email address is required.");
-      return;
-    }
-
-    await sendEmail(
-      "GoVariants Test Email",
-      to,
-      "Test Email\n\nThis is a test email from GoVariants. If you received this, your email configuration is working correctly!",
-      "<h1>Test Email</h1><p>This is a test email from GoVariants. If you received this, your email configuration is working correctly!</p>",
-    );
-
-    res.json({ success: true, message: "Test email sent successfully." });
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
+  if (!req.user || (req.user as UserResponse).role !== "admin") {
+    res.status(401).json("Only admins may send test emails.");
+    return;
   }
+
+  const { to } = req.body;
+  if (!to) {
+    res.status(400).json("Email address is required.");
+    return;
+  }
+
+  await sendEmail(
+    "GoVariants Test Email",
+    to,
+    "Test Email\n\nThis is a test email from GoVariants. If you received this, your email configuration is working correctly!",
+    "<h1>Test Email</h1><p>This is a test email from GoVariants. If you received this, your email configuration is working correctly!</p>",
+  );
+
+  res.json({ success: true, message: "Test email sent successfully." });
 });
 
 router.get("/notifications/count", checkCSRFToken, async (req, res) => {
@@ -445,14 +364,9 @@ router.get("/notifications/count", checkCSRFToken, async (req, res) => {
     return;
   }
 
-  try {
-    res.send({
-      count: await getUserNotificationsCount((req.user as User).id),
-    });
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  res.send({
+    count: await getUserNotificationsCount((req.user as User).id),
+  });
 });
 
 router.get("/notifications", checkCSRFToken, async (req, res) => {
@@ -461,62 +375,49 @@ router.get("/notifications", checkCSRFToken, async (req, res) => {
     return;
   }
 
-  try {
-    const userNotifications = await getUserNotifications((req.user as User).id);
-    const groups = groupBy(userNotifications, (n) => n.gameId);
-    const gameIds = groups.map(([gameId, _]) => gameId);
-    const gameStates = (await getGamesById([...gameIds])).map((game) =>
-      tryComputeState(game, req.user as User),
-    );
-    const combined: NotificationsResponse[] = groups.map(
-      ([gameId, notifications]) => ({
-        gameId: gameId,
-        notifications: notifications,
-        gameState: gameStates.find((x) => x.id === gameId),
-      }),
-    );
-    res.send(combined);
-  } catch (e) {
-    res.status(500);
-    res.json(e.message);
-  }
+  const userNotifications = await getUserNotifications((req.user as User).id);
+  const groups = groupBy(userNotifications, (n) => n.gameId);
+  const gameIds = groups.map(([gameId, _]) => gameId);
+  const gameStates = (await getGamesById([...gameIds])).map((game) =>
+    tryComputeState(game, req.user as User),
+  );
+  const combined: NotificationsResponse[] = groups.map(
+    ([gameId, notifications]) => ({
+      gameId: gameId,
+      notifications: notifications,
+      gameState: gameStates.find((x) => x.id === gameId),
+    }),
+  );
+  res.send(combined);
 });
 
 router.post("/game/:gameId/subscribe", checkCSRFToken, async (req, res) => {
-  try {
-    const { notificationTypes } = req.body;
-    validateNotificationTypeArray(notificationTypes);
-    const userId = (req.user as User).id;
+  const { notificationTypes } = req.body;
+  validateNotificationTypeArray(notificationTypes);
+  const userId = (req.user as User).id;
 
-    const success = await subscribeToGameNotifications(
-      req.params.gameId,
-      userId,
-      notificationTypes,
-    );
+  const success = await subscribeToGameNotifications(
+    req.params.gameId,
+    userId,
+    notificationTypes,
+  );
 
-    if (success) {
-      res.status(200);
-    } else {
-      res.status(500);
-    }
-    res.send({ success: true });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
+  if (success) {
+    res.status(200);
+  } else {
+    res.status(500);
   }
+  res.send({ success: true });
 });
 
 router.post(
   "/notifications/:gameId/mark-as-read",
   checkCSRFToken,
   async (req, res) => {
-    try {
-      const userId = (req.user as User).id;
+    const userId = (req.user as User).id;
 
-      await markAsRead(userId, req.params.gameId);
-      res.send({});
-    } catch (error) {
-      res.status(500).json({ error: error.message });
-    }
+    await markAsRead(userId, req.params.gameId);
+    res.send({});
   },
 );
 
@@ -524,13 +425,9 @@ router.post(
   "/notifications/:gameId/clear",
   checkCSRFToken,
   async (req, res) => {
-    try {
-      const userId = (req.user as User).id;
+    const userId = (req.user as User).id;
 
-      await clearNotifications(userId, req.params.gameId);
-      res.send({});
-    } catch (error) {
-      res.status(500).json({ error: error.message });
-    }
+    await clearNotifications(userId, req.params.gameId);
+    res.send({});
   },
 );

--- a/packages/server/src/http-error.ts
+++ b/packages/server/src/http-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Custom error class for HTTP errors.
+ * Express 5 automatically catches rejected promises in async handlers
+ * and forwards them to the error-handling middleware. Throw an HttpError
+ * when you need a specific HTTP status code; otherwise a plain Error
+ * will result in a 500.
+ */
+export class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.status = status;
+  }
+}

--- a/packages/server/src/users.ts
+++ b/packages/server/src/users.ts
@@ -228,10 +228,10 @@ export function deleteUser(user_id: string) {
 
 export function checkUsername(username: string): void {
   if (!/^.{4,20}$/.test(username)) {
-    throw "Username must be between 4 and 20 characters long.";
+    throw new Error("Username must be between 4 and 20 characters long.");
   }
   if (!/^[a-zA-Z0-9]*$/.test(username)) {
-    throw "Username can only have alphanumeric characters.";
+    throw new Error("Username can only have alphanumeric characters.");
   }
 }
 


### PR DESCRIPTION
TL;DR Over 100 lines removed from api.ts!

## Leverage Express 5 async error handling

Express 5 automatically catches rejected promises in `async` route handlers and forwards them to error-handling middleware. This means we no longer need to wrap every route body in `try/catch` just to send a 500 response.

### Changes

- **Add `HttpError` class** (`packages/server/src/http-error.ts`) — a custom error with a `status` property for routes that need a specific HTTP status code (e.g. 409 Conflict on seat conflicts).

- **Add centralized error handler** (`packages/server/src/index.ts`) — a single Express error-handling middleware placed after all routes. It reads `HttpError.status` when available, defaults to 500, and responds with `res.status(status).json(message)`.

- **Remove boilerplate `try/catch` from 18 route handlers** (`packages/server/src/api.ts`) — routes now let errors propagate naturally to the centralized handler. Auth/validation guards that send specific status codes (401, 403, 404) remain as explicit early returns. The `sit/:seat` route now throws `HttpError(409, ...)` instead of manually setting `res.status(409)`.

- **Fix `checkUsername` to throw `Error` objects** (`packages/server/src/users.ts`) — previously threw bare strings, which don't have a `.message` property.

### Why

The old pattern required every async route to repeat the same `try { ... } catch (e) { res.status(500).json(e.message) }` boilerplate. Missing a `try/catch` would result in an unhandled promise rejection. With Express 5, forgetting to handle an error is safe by default — it just hits the centralized handler.

### Notes

- Routes that intentionally catch errors to send a **non-500** status still use `try/catch` + `throw new HttpError(...)` (only the `sit/:seat` route currently).
- The `logout` route uses callback-based `req.logout()` / `req.session.destroy()`, which Express 5 does **not** auto-catch — left unchanged.
- The response shape (`res.status(n).json(message)`) is unchanged, so the frontend `requestImpl` in `requests.ts` continues to work without modification.
- Tested: I temporarily added a fake route to the admin that always errors, confirmed the server doesn't crash