### PR TITLE
Align board styles across Fractional, Grid, and Graph boards

### DIFF
--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -4,10 +4,18 @@ import {
   type FractionalConfig,
   type FractionalState,
   Intersection,
+  getHoshi,
 } from "@ogfcommunity/variants-shared";
 import { createGraph } from "@ogfcommunity/variants-shared";
 import { computed } from "vue";
 import TaegeukStone from "../TaegeukStone.vue";
+import IntersectionAnnotation from "../IntersectionAnnotation.vue";
+import {
+  STONE_RADIUS,
+  LINE_WIDTH,
+  BOARD_COLOR,
+  STAR_POINT_RADIUS,
+} from "./board_constants";
 
 const props = defineProps<{
   config: FractionalConfig;
@@ -43,6 +51,14 @@ const boardRect = computed(
   },
 );
 const board = computed(() => createGraph(intersections.value, null));
+
+const hoshi = computed(() => {
+  const b = props.config.board;
+  if (b.type === "grid") {
+    return getHoshi(b.width, b.height);
+  }
+  return [];
+});
 
 const viewBox = computed(() => {
   // viewBox is slightly larger than board
@@ -88,6 +104,15 @@ const stagedMove = computed(() =>
         />
       </g>
     </g>
+    <g>
+      <circle
+        v-for="{ x, y } in hoshi"
+        :key="`${x},${y}`"
+        :cx="x"
+        :cy="y"
+        :r="STAR_POINT_RADIUS"
+      />
+    </g>
     <g class="stones">
       <g v-for="(intersection, index) in intersections" :key="index">
         <TaegeukStone
@@ -95,23 +120,21 @@ const stagedMove = computed(() =>
           :colors="[...$props.gamestate.boardState.at(index)]"
           :cx="intersection.position.X"
           :cy="intersection.position.Y"
-          :r="0.47"
+          :r="STONE_RADIUS"
         />
-        <circle
+        <IntersectionAnnotation
           v-if="$props.gamestate.lastMoves.includes(index)"
           :cx="intersection.position.X"
           :cy="intersection.position.Y"
-          r="0.3"
-          stroke="#dbdbdb"
-          stroke-width="0.05"
-          class="last-move-indicator"
+          :r="STONE_RADIUS"
+          annotation="CR"
         />
         <circle
           v-if="!$props.gamestate.boardState.at(index)"
           class="click-placeholder"
           :cx="intersection.position.X"
           :cy="intersection.position.Y"
-          r="0.47"
+          :r="STONE_RADIUS"
           @click="intersectionClicked(index)"
         />
       </g>
@@ -121,27 +144,23 @@ const stagedMove = computed(() =>
       :colors="stagedMove.colors"
       :cx="stagedMove.intersection.position.X"
       :cy="stagedMove.intersection.position.Y"
-      :r="0.47"
+      :r="STONE_RADIUS"
     />
   </svg>
 </template>
 
 <style scoped>
 .board .background {
-  fill: #dcb35c;
+  fill: v-bind(BOARD_COLOR);
 }
 
 line {
   stroke: black;
-  stroke-width: 0.05;
+  stroke-width: v-bind(LINE_WIDTH);
   stroke-linecap: round;
 }
 
 .click-placeholder {
   opacity: 0;
-}
-
-.last-move-indicator {
-  mix-blend-mode: difference;
 }
 </style>

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -11,6 +11,7 @@ import {
 } from "@ogfcommunity/variants-shared";
 import ScoreMark from "./ScoreMark.vue";
 import { Voronoi, Site, Cell } from "voronoijs";
+import { STONE_RADIUS, LINE_WIDTH, BOARD_COLOR } from "./board_constants";
 
 const props = defineProps<{
   board?: (MulticolorStone | null)[];
@@ -110,7 +111,7 @@ const viewBox = computed(() => {
       :y="viewBox.minY - 0.5"
       :width="viewBox.width + 1"
       :height="viewBox.height + 1"
-      :fill="background_color ?? '#dcb35c'"
+      :fill="background_color ?? BOARD_COLOR"
     />
     <g>
       <template v-for="(_, index) in intersections" :key="index">
@@ -142,7 +143,7 @@ const viewBox = computed(() => {
         :key="`${index}: ${intersection.position.X},${intersection.position.Y}`"
         :cx="intersection.position.X"
         :cy="intersection.position.Y"
-        :r="0.48"
+        :r="STONE_RADIUS"
         :colors="props.board?.at(index)?.colors ?? []"
         @click="positionClicked(index)"
         @mouseover="positionHovered(index)"
@@ -155,7 +156,7 @@ const viewBox = computed(() => {
           :key="index"
           :cx="intersection.position.X"
           :cy="intersection.position.Y"
-          :r="0.48"
+          :r="STONE_RADIUS"
           :annotation="props.board.at(index)?.annotation!"
         />
       </template>
@@ -192,7 +193,7 @@ const viewBox = computed(() => {
 <style scoped>
 line {
   stroke: black;
-  stroke-width: 0.02;
+  stroke-width: v-bind(LINE_WIDTH);
   stroke-linecap: round;
 }
 </style>

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -8,6 +8,12 @@ import {
   MulticolorStone,
 } from "@ogfcommunity/variants-shared";
 import { positionsGetter } from "./board_utils";
+import {
+  STONE_RADIUS,
+  LINE_WIDTH,
+  BOARD_COLOR,
+  STAR_POINT_RADIUS,
+} from "./board_constants";
 import ScoreMark from "./ScoreMark.vue";
 
 const props = defineProps<{
@@ -49,7 +55,7 @@ function positionHovered(pos: Coordinate) {
       y="-0.5"
       :width="width"
       :height="height"
-      :fill="background_color ?? '#dcb35c'"
+      :fill="background_color ?? BOARD_COLOR"
     />
     <g v-if="props.board">
       <rect
@@ -72,9 +78,6 @@ function positionHovered(pos: Coordinate) {
         :x2="x - 1"
         :y1="0"
         :y2="height - 1"
-        color="pink"
-        stroke="pink"
-        stroke-width="0.02"
       />
 
       <line
@@ -84,8 +87,6 @@ function positionHovered(pos: Coordinate) {
         :x2="width - 1"
         :y1="y - 1"
         :y2="y - 1"
-        stroke="pink"
-        stroke-width="0.02"
       />
 
       <circle
@@ -93,7 +94,7 @@ function positionHovered(pos: Coordinate) {
         :key="`${x},${y}`"
         :cx="x"
         :cy="y"
-        r="0.12"
+        :r="STAR_POINT_RADIUS"
       />
     </g>
     <g v-if="props.board">
@@ -104,7 +105,7 @@ function positionHovered(pos: Coordinate) {
         :key="`${pos.x},${pos.y}`"
         :cx="pos.x"
         :cy="pos.y"
-        :r="0.48"
+        :r="STONE_RADIUS"
         :colors="props.board[pos.y][pos.x]?.colors ?? []"
       />
     </g>
@@ -116,7 +117,7 @@ function positionHovered(pos: Coordinate) {
         :key="`${x},${y}`"
         :cx="x"
         :cy="y"
-        :r="0.48"
+        :r="STONE_RADIUS"
         :annotation="props.board[y][x]?.annotation!"
       />
     </g>
@@ -154,7 +155,7 @@ function positionHovered(pos: Coordinate) {
 <style scoped>
 line {
   stroke: black;
-  stroke-width: 0.02;
+  stroke-width: v-bind(LINE_WIDTH);
   stroke-linecap: round;
 }
 </style>

--- a/packages/vue-client/src/components/boards/board_constants.ts
+++ b/packages/vue-client/src/components/boards/board_constants.ts
@@ -1,0 +1,7 @@
+/** Shared visual constants for board components.
+ * Keep all board renderings consistent by using these values. */
+
+export const STONE_RADIUS = 0.48;
+export const LINE_WIDTH = 0.02;
+export const BOARD_COLOR = "#dcb35c";
+export const STAR_POINT_RADIUS = 0.12;


### PR DESCRIPTION
## Summary
- Extract shared visual constants (`STONE_RADIUS`, `LINE_WIDTH`, `BOARD_COLOR`, `STAR_POINT_RADIUS`) into `board_constants.ts` so all three board components stay consistent
- Update FractionalBoard: stone radius 0.47→0.48, line weight 0.05→0.02, replace custom last-move circle with `IntersectionAnnotation`, add star points via `getHoshi`
- Remove dead `stroke="pink"` / `color="pink"` attributes from MulticolorGridBoard

Closes #137

## Test plan
just a visual check

<img width="665" height="690" alt="Screenshot 2026-03-25 at 9 30 40 PM" src="https://github.com/user-attachments/assets/fede9795-8eb3-4432-a810-0343842b7c98" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)