### PR TITLE
Update server and shared tsconfig target to es2022

### DIFF
--- a/packages/server/src/email/email.ts
+++ b/packages/server/src/email/email.ts
@@ -69,11 +69,11 @@ export async function sendEmail(
     });
   } catch (error) {
     console.error("Failed to send email:", error);
-    // eslint-disable-next-line preserve-caught-error -- cause is re-logged above
     throw new Error(
       `Failed to send email: ${
         error instanceof Error ? error.message : String(error)
       }`,
+      { cause: error },
     );
   }
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "node16",
     "esModuleInterop": true,
-    "target": "es6",
+    "target": "es2022",
     "noImplicitAny": true,
     "moduleResolution": "node16",
     "sourceMap": true,

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
 
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */


### PR DESCRIPTION
## Summary
- Updated `packages/server/tsconfig.json` target from `es6` to `es2022`
- Updated `packages/shared/tsconfig.json` target from `es2016` to `es2022`
- Removed `eslint-disable preserve-caught-error` in `email.ts` and used `Error({ cause })` natively

Fixes #478

## Test plan
- [x] `yarn build` — all packages build cleanly
- [x] `yarn test` — all 206 tests pass (shared: 176, server: 29, vue-client: 1)
- [x] `yarn start` — server and vite dev server start with 0 errors
- [x] Manual e2e verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)