### PR TITLE
Normalize game players: store IDs instead of embedded user objects

### DIFF
--- a/packages/server/migrations/20260328000000-normalize-game-players.js
+++ b/packages/server/migrations/20260328000000-normalize-game-players.js
@@ -42,6 +42,53 @@ module.exports = {
    * @returns {Promise<void>}
    */
   async down(db, client) {
-    // Cannot restore embedded user data from just IDs
+    await client.withSession((session) =>
+      session.withTransaction(async () => {
+        const games = await db
+          .collection("games")
+          .find({ players: { $elemMatch: { $type: "string" } } })
+          .toArray();
+
+        if (games.length === 0) return;
+
+        // Collect all unique player IDs
+        const allIds = new Set();
+        for (const game of games) {
+          for (const p of game.players) {
+            if (typeof p === "string") allIds.add(p);
+          }
+        }
+
+        // Fetch user documents
+        const { ObjectId } = require("mongodb");
+        const users = await db
+          .collection("users")
+          .find({ _id: { $in: [...allIds].map((id) => new ObjectId(id)) } })
+          .toArray();
+
+        const usersMap = new Map();
+        for (const u of users) {
+          usersMap.set(u._id.toString(), {
+            id: u._id.toString(),
+            username: u.username,
+            ranking: u.ranking,
+          });
+        }
+
+        await Promise.all(
+          games.map((game) => {
+            const restoredPlayers = game.players.map((p) => {
+              if (typeof p !== "string") return p;
+              return usersMap.get(p) ?? { id: p };
+            });
+
+            return db.collection("games").updateOne(
+              { _id: game._id },
+              { $set: { players: restoredPlayers } },
+            );
+          }),
+        );
+      }),
+    );
   },
 };

--- a/packages/server/migrations/20260328000000-normalize-game-players.js
+++ b/packages/server/migrations/20260328000000-normalize-game-players.js
@@ -12,26 +12,31 @@ module.exports = {
   async up(db, client) {
     await client.withSession((session) =>
       session.withTransaction(async () => {
+        const coll = db.collection("games");
+
         // Find games where at least one player entry is an object (not yet migrated)
-        const games = await db
-          .collection("games")
+        const games = await coll
           .find({ "players.id": { $exists: true } })
           .toArray();
 
-        if (games.length === 0) return;
+        if (games.length > 0) {
+          const ops = games.map((game) => ({
+            updateOne: {
+              filter: { _id: game._id },
+              update: {
+                $set: {
+                  players: game.players.map((p) =>
+                    p && typeof p === "object" && p.id ? p.id : p,
+                  ),
+                },
+              },
+            },
+          }));
+          await coll.bulkWrite(ops, { session });
+        }
 
-        await Promise.all(
-          games.map((game) => {
-            const normalizedPlayers = game.players.map((p) =>
-              p && typeof p === "object" && p.id ? p.id : p,
-            );
-
-            return db.collection("games").updateOne(
-              { _id: game._id },
-              { $set: { players: normalizedPlayers } },
-            );
-          }),
-        );
+        // Add index for the new query pattern (filter by user ID string in players array)
+        await coll.createIndex({ players: 1 }, { name: "game_players" });
       }),
     );
   },
@@ -44,8 +49,12 @@ module.exports = {
   async down(db, client) {
     await client.withSession((session) =>
       session.withTransaction(async () => {
-        const games = await db
-          .collection("games")
+        const coll = db.collection("games");
+
+        // Drop the index added in up()
+        await coll.dropIndex("game_players").catch(() => {});
+
+        const games = await coll
           .find({ players: { $elemMatch: { $type: "string" } } })
           .toArray();
 
@@ -59,7 +68,7 @@ module.exports = {
           }
         }
 
-        // Fetch user documents
+        // Fetch user documents (best effort — data may differ from original)
         const { ObjectId } = require("mongodb");
         const users = await db
           .collection("users")
@@ -75,19 +84,20 @@ module.exports = {
           });
         }
 
-        await Promise.all(
-          games.map((game) => {
-            const restoredPlayers = game.players.map((p) => {
-              if (typeof p !== "string") return p;
-              return usersMap.get(p) ?? { id: p };
-            });
-
-            return db.collection("games").updateOne(
-              { _id: game._id },
-              { $set: { players: restoredPlayers } },
-            );
-          }),
-        );
+        const ops = games.map((game) => ({
+          updateOne: {
+            filter: { _id: game._id },
+            update: {
+              $set: {
+                players: game.players.map((p) => {
+                  if (typeof p !== "string") return p;
+                  return usersMap.get(p) ?? { id: p };
+                }),
+              },
+            },
+          },
+        }));
+        await coll.bulkWrite(ops, { session });
       }),
     );
   },

--- a/packages/server/migrations/20260328000000-normalize-game-players.js
+++ b/packages/server/migrations/20260328000000-normalize-game-players.js
@@ -1,0 +1,47 @@
+module.exports = {
+  /**
+   * Convert players arrays from embedded user objects to user ID strings.
+   *
+   * Before: players: [{ id: "abc", username: "foo", ranking: {...} }, null]
+   * After:  players: ["abc", null]
+   *
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async up(db, client) {
+    await client.withSession((session) =>
+      session.withTransaction(async () => {
+        // Find games where at least one player entry is an object (not yet migrated)
+        const games = await db
+          .collection("games")
+          .find({ "players.id": { $exists: true } })
+          .toArray();
+
+        if (games.length === 0) return;
+
+        await Promise.all(
+          games.map((game) => {
+            const normalizedPlayers = game.players.map((p) =>
+              p && typeof p === "object" && p.id ? p.id : p,
+            );
+
+            return db.collection("games").updateOne(
+              { _id: game._id },
+              { $set: { players: normalizedPlayers } },
+            );
+          }),
+        );
+      }),
+    );
+  },
+
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async down(db, client) {
+    // Cannot restore embedded user data from just IDs
+  },
+};

--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -255,6 +255,73 @@ describe("API Endpoints", () => {
     });
   });
 
+  describe("POST /api/games/:gameId/sit/:seat", () => {
+    it("stores only user ID and returns hydrated player", async () => {
+      const db = await getTestDb();
+      const userResult = await db.collection("users").insertOne(
+        makeTestUser({
+          username: "seatuser",
+          ranking: { baduk: { rating: 1500, rd: 50, vol: 0.06 } },
+        }),
+      );
+      const userId = userResult.insertedId.toString();
+
+      const gameResult = await db
+        .collection("games")
+        .insertOne(makeTestGame({ players: [null, null] }));
+      const gameId = gameResult.insertedId.toString();
+
+      const authApp = createTestApp({
+        mockUser: {
+          id: userId,
+          username: "seatuser",
+          login_type: "persistent",
+        },
+      });
+
+      const response = await request(authApp)
+        .post(`/api/games/${gameId}/sit/0`)
+        .set("CSRF-Token", "test-csrf-token")
+        .expect(200);
+
+      // API returns hydrated User objects
+      expect(response.body[0]).toEqual(
+        expect.objectContaining({ id: userId, username: "seatuser" }),
+      );
+
+      // DB stores only the ID string
+      const dbGame = await db
+        .collection("games")
+        .findOne({ _id: gameResult.insertedId });
+      expect(dbGame.players[0]).toBe(userId);
+    });
+  });
+
+  describe("GET /api/games (user filter)", () => {
+    it("filters games by user ID in normalized players array", async () => {
+      const db = await getTestDb();
+      const userResult = await db.collection("users").insertOne(makeTestUser());
+      const userId = userResult.insertedId.toString();
+
+      // One game with the user seated, one without
+      await db
+        .collection("games")
+        .insertOne(makeTestGame({ players: [userId, null] }));
+      await db
+        .collection("games")
+        .insertOne(makeTestGame({ players: [null, null] }));
+
+      const response = await request(app)
+        .get(`/api/games?count=10&offset=0&user_id=${userId}`)
+        .expect(200);
+
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0].players[0]).toEqual(
+        expect.objectContaining({ id: userId, username: "testuser" }),
+      );
+    });
+  });
+
   describe("GET /api/users/:userId", () => {
     it("returns 404 for non-existent user", async () => {
       const response = await request(app)

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -136,12 +136,9 @@ export async function createGame(
 
   return {
     id: result.insertedId.toString(),
-    variant: game.variant,
-    moves: game.moves,
+    ...game,
     config: sanitizeConfig(game.variant, game.config),
     players: game.players?.map((): User | undefined => undefined),
-    time_control: game.time_control,
-    creator: game.creator,
   };
 }
 

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -26,6 +26,7 @@ import {
   ValidateTimeControlConfig,
 } from "./time-control/time-control";
 import { updateRatings, supportsRatings } from "./rating/rating";
+import { getUsersByIds } from "./users";
 import {
   initUserNotifications,
   notifyOfGameEnd,
@@ -37,7 +38,8 @@ export type GameSchema = {
   variant: string;
   moves: MovesType[];
   config: object;
-  players?: Array<User | undefined>;
+  /** Stored as user ID strings in the database. Hydrated to User objects on read. */
+  players?: Array<string | null>;
   time_control?: ITimeControlBase;
   creator?: User;
   subscriptions?: GameSubscriptions;
@@ -59,26 +61,26 @@ export async function getGames(
 ): Promise<GameResponse[]> {
   const dbFilter: Filter<Document> = {};
   if (filter && filter.user_id) {
-    dbFilter["players.id"] = filter.user_id;
+    dbFilter["players"] = filter.user_id;
   }
   if (filter && filter.variant) {
     dbFilter["variant"] = filter.variant;
   }
 
-  const games = gamesCollection()
+  const db_games = await gamesCollection()
     .find(dbFilter)
     .sort({ _id: -1 })
     .skip(offset || 0)
     .limit(Math.min(count || 10, 100))
     .toArray();
-  return (await games).map(outwardFacingGame);
+  return hydrateGames(db_games);
 }
 
 export async function getGamesWithTimeControl(): Promise<GameResponse[]> {
-  const games = gamesCollection()
+  const db_games = await gamesCollection()
     .find({ time_control: { $ne: null } })
     .toArray();
-  return (await games).map(outwardFacingGame);
+  return hydrateGames(db_games);
 }
 
 export async function getGame(id: string): Promise<GameResponse> {
@@ -90,7 +92,7 @@ export async function getGame(id: string): Promise<GameResponse> {
     throw new Error("Game not found");
   }
 
-  const game = outwardFacingGame(db_game);
+  const [game] = await hydrateGames([db_game]);
   const playerClocks = Object.values(game.time_control?.forPlayer ?? {});
   // bpj 2024-04-04: changed playerClock.remainingTimeMS to playerClock.clockState
   // in order to support more complex clock states such as byo-yomi
@@ -132,10 +134,7 @@ export async function createGame(
     throw new Error("Failed to create game.");
   }
 
-  return {
-    id: result.insertedId.toString(),
-    ...game,
-  };
+  return getGame(result.insertedId.toString());
 }
 
 export async function playMove(
@@ -298,7 +297,7 @@ async function updateSeat(
   game_id: string,
   seat: number,
   user: UserResponse,
-  new_user: User | undefined,
+  new_user_id: string | null,
 ) {
   const game = await getGame(game_id);
 
@@ -312,25 +311,25 @@ async function updateSeat(
     throw new Error("Seat taken!");
   }
 
-  game.players[seat] = new_user;
-
   await gamesCollection().updateOne(
     { _id: new ObjectId(game_id) },
-    { $set: { [`players.${seat}`]: new_user } },
+    { $set: { [`players.${seat}`]: new_user_id } },
   );
   await notifyOfSeatChange(
     game.subscriptions ?? {},
     game_id,
     seat,
     user.username,
-    new_user !== undefined,
+    new_user_id !== null,
   );
 
-  return game.players;
+  // Re-fetch the game to return hydrated players
+  const updated = await getGame(game_id);
+  return updated.players;
 }
 
 export function takeSeat(game_id: string, seat: number, user: UserResponse) {
-  return updateSeat(game_id, seat, user, user);
+  return updateSeat(game_id, seat, user, user.id);
 }
 
 export async function leaveSeat(
@@ -338,7 +337,7 @@ export async function leaveSeat(
   seat: number,
   user: UserResponse,
 ) {
-  return updateSeat(game_id, seat, user, undefined);
+  return updateSeat(game_id, seat, user, null);
 }
 
 export function getGameState(
@@ -427,27 +426,46 @@ export async function subscribeToGameNotifications(
 }
 
 export async function getGamesById(ids: string[]): Promise<GameResponse[]> {
-  return (
-    await gamesCollection()
-      .find({
-        _id: { $in: ids.map((id) => new ObjectId(id)) },
-      })
-      .toArray()
-  ).map(outwardFacingGame);
+  const db_games = await gamesCollection()
+    .find({
+      _id: { $in: ids.map((id) => new ObjectId(id)) },
+    })
+    .toArray();
+  return hydrateGames(db_games);
 }
 
-function outwardFacingGame(db_game: WithId<GameSchema>): GameResponse {
-  const config = sanitizeConfig(db_game.variant, db_game.config);
-  return {
-    id: db_game._id.toString(),
-    variant: db_game.variant,
-    moves: db_game.moves,
-    config,
-    players: db_game.players,
-    time_control: db_game.time_control,
-    creator: db_game.creator,
-    subscriptions: db_game.subscriptions,
-  };
+/**
+ * Hydrate a list of DB games into GameResponse objects,
+ * batch-fetching user data for all player IDs.
+ */
+async function hydrateGames(
+  db_games: WithId<GameSchema>[],
+): Promise<GameResponse[]> {
+  // Collect all player IDs across all games
+  const allPlayerIds: string[] = [];
+  for (const game of db_games) {
+    for (const p of game.players ?? []) {
+      if (p) allPlayerIds.push(p);
+    }
+  }
+
+  const usersMap = await getUsersByIds(allPlayerIds);
+
+  return db_games.map((db_game) => {
+    const config = sanitizeConfig(db_game.variant, db_game.config);
+    return {
+      id: db_game._id.toString(),
+      variant: db_game.variant,
+      moves: db_game.moves,
+      config,
+      players: db_game.players?.map((p) =>
+        p ? (usersMap.get(p) ?? { id: p }) : undefined,
+      ),
+      time_control: db_game.time_control,
+      creator: db_game.creator,
+      subscriptions: db_game.subscriptions,
+    };
+  });
 }
 
 export function tryComputeState(

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -134,7 +134,15 @@ export async function createGame(
     throw new Error("Failed to create game.");
   }
 
-  return getGame(result.insertedId.toString());
+  return {
+    id: result.insertedId.toString(),
+    variant: game.variant,
+    moves: game.moves,
+    config: sanitizeConfig(game.variant, game.config),
+    players: game.players?.map((): User | undefined => undefined),
+    time_control: game.time_control,
+    creator: game.creator,
+  };
 }
 
 export async function playMove(

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -137,7 +137,7 @@ export async function createGame(
   return {
     id: result.insertedId.toString(),
     ...game,
-    config: sanitizeConfig(game.variant, game.config),
+    // TODO: align null/undefined — GameSchema uses null, GameResponse uses undefined
     players: game.players?.map((): User | undefined => undefined),
   };
 }

--- a/packages/server/src/users.ts
+++ b/packages/server/src/users.ts
@@ -1,5 +1,6 @@
 import { getDb } from "./db";
 import {
+  User,
   UserResponse,
   UserRankings,
   UserRole,
@@ -179,6 +180,29 @@ export async function createUserWithSessionId(
     token: session_id,
     login_type: "guest",
   };
+}
+
+export async function getUsersByIds(
+  user_ids: string[],
+): Promise<Map<string, User>> {
+  const uniqueIds = [...new Set(user_ids)];
+  if (uniqueIds.length === 0) return new Map();
+
+  const db_users = await usersCollection()
+    .find({ _id: { $in: uniqueIds.map((id) => new ObjectId(id)) } })
+    .toArray();
+
+  const map = new Map<string, User>();
+  for (const db_user of db_users) {
+    const id = db_user._id.toString();
+    map.set(id, {
+      id,
+      username:
+        db_user.login_type === "persistent" ? db_user.username : undefined,
+      ranking: db_user.ranking,
+    });
+  }
+  return map;
 }
 
 export async function getUser(user_id: string): Promise<UserResponse> {

--- a/packages/server/src/users.ts
+++ b/packages/server/src/users.ts
@@ -188,14 +188,8 @@ export async function getUsersByIds(
   const uniqueIds = [...new Set(user_ids)];
   if (uniqueIds.length === 0) return new Map();
 
-  const validObjectIds = uniqueIds
-    .filter((id) => ObjectId.isValid(id))
-    .map((id) => new ObjectId(id));
-
-  if (validObjectIds.length === 0) return new Map();
-
   const db_users = await usersCollection()
-    .find({ _id: { $in: validObjectIds } })
+    .find({ _id: { $in: uniqueIds.map((id) => new ObjectId(id)) } })
     .toArray();
 
   const map = new Map<string, User>();

--- a/packages/server/src/users.ts
+++ b/packages/server/src/users.ts
@@ -188,8 +188,18 @@ export async function getUsersByIds(
   const uniqueIds = [...new Set(user_ids)];
   if (uniqueIds.length === 0) return new Map();
 
+  const validObjectIds = uniqueIds.flatMap((id) => {
+    try {
+      return [new ObjectId(id)];
+    } catch {
+      return [];
+    }
+  });
+
+  if (validObjectIds.length === 0) return new Map();
+
   const db_users = await usersCollection()
-    .find({ _id: { $in: uniqueIds.map((id) => new ObjectId(id)) } })
+    .find({ _id: { $in: validObjectIds } })
     .toArray();
 
   const map = new Map<string, User>();

--- a/packages/server/src/users.ts
+++ b/packages/server/src/users.ts
@@ -188,13 +188,9 @@ export async function getUsersByIds(
   const uniqueIds = [...new Set(user_ids)];
   if (uniqueIds.length === 0) return new Map();
 
-  const validObjectIds = uniqueIds.flatMap((id) => {
-    try {
-      return [new ObjectId(id)];
-    } catch {
-      return [];
-    }
-  });
+  const validObjectIds = uniqueIds
+    .filter((id) => ObjectId.isValid(id))
+    .map((id) => new ObjectId(id));
 
   if (validObjectIds.length === 0) return new Map();
 


### PR DESCRIPTION
## Summary

- **Game documents now store only user ID strings in the `players` array instead of embedding the full user object (username, ranking, role)**
- User data is hydrated via a batch lookup (`getUsersByIds`) at read time
- Includes a `migrate-mongo` migration to convert all existing game documents
- Added `getUsersByIds` to `users.ts` for efficient batch user fetching
- Added MongoDB index on `players` array (no equivalent existed before — the old `players.id` query was unindexed).  this is important for the "My Games" feature
- Note: rank behavior changes - instead of "rank at game start" it's now "current rank".  this was chosen because rank is not very visible right now and this is the simpler approach.  we can change it later if desired.

Fixes #370

## Why $lookup / hydration instead of keeping embedded data?

The embedded approach caused user data in game documents to go stale — e.g., ratings wouldn't update after a game finished. At our scale, the read-time cost of a batch user lookup is negligible, and it eliminates a whole class of sync bugs. It also moves the data model closer to relational, which reduces friction for a potential future Postgres migration.

## Test plan

- [x] `yarn build` — all packages build cleanly
- [x] `yarn test` — all 206 tests pass (shared: 176, server: 29, vue-client: 1)
- [x] Ran migration against local DB successfully
- [x] `yarn start` — server and vite start with 0 errors
- [x] Manual e2e: browsed games, verified player names display correctly after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)