### PR TITLE
Restrict phantom exportState so spectators see an empty board

### DIFF
--- a/packages/shared/src/variants/__tests__/phantom.test.ts
+++ b/packages/shared/src/variants/__tests__/phantom.test.ts
@@ -56,3 +56,24 @@ test("Play a game with captures", () => {
   expect(game.exportState(0).captures).toEqual({ "0": 0, "1": 2 });
   expect(game.exportState(1).captures).toEqual({ "0": 0, "1": 2 });
 });
+
+test("Reveals full board to everyone after the game ends", () => {
+  const game = new Phantom({ width: 4, height: 2, komi: 0.5 });
+  // - W B -
+  // - W B -
+  game.playMove(0, "ca");
+  game.playMove(1, "ba");
+  game.playMove(0, "cb");
+  game.playMove(1, "bb");
+  game.playMove(0, "pass");
+  game.playMove(1, "pass");
+
+  const fullBoard = [
+    [Color.EMPTY, Color.WHITE, Color.BLACK, Color.EMPTY],
+    [Color.EMPTY, Color.WHITE, Color.BLACK, Color.EMPTY],
+  ];
+
+  expect(game.exportState().board).toEqual(fullBoard);
+  expect(game.exportState(0).board).toEqual(fullBoard);
+  expect(game.exportState(1).board).toEqual(fullBoard);
+});

--- a/packages/shared/src/variants/__tests__/phantom.test.ts
+++ b/packages/shared/src/variants/__tests__/phantom.test.ts
@@ -11,10 +11,10 @@ test("Play a game", () => {
   game.playMove(0, "cb");
   game.playMove(1, "bb");
 
-  // check that gobal state is as expected
+  // spectators should see an empty board (no second-tab cheating)
   expect(game.exportState().board).toEqual([
-    [Color.EMPTY, Color.WHITE, Color.BLACK, Color.EMPTY],
-    [Color.EMPTY, Color.WHITE, Color.BLACK, Color.EMPTY],
+    [Color.EMPTY, Color.EMPTY, Color.EMPTY, Color.EMPTY],
+    [Color.EMPTY, Color.EMPTY, Color.EMPTY, Color.EMPTY],
   ]);
 
   // BLACK should not see WHITE
@@ -41,8 +41,8 @@ test("Play a game with captures", () => {
   game.playMove(1, "bb");
 
   expect(game.exportState().board).toEqual([
-    [Color.EMPTY, Color.WHITE],
-    [Color.EMPTY, Color.WHITE],
+    [Color.EMPTY, Color.EMPTY],
+    [Color.EMPTY, Color.EMPTY],
   ]);
   expect(game.exportState(0).board).toEqual([
     [Color.EMPTY, Color.EMPTY],

--- a/packages/shared/src/variants/phantom.ts
+++ b/packages/shared/src/variants/phantom.ts
@@ -5,10 +5,6 @@ export class Phantom extends Baduk {
   exportState(player?: number): BadukState {
     const state = super.exportState();
 
-    if (player === undefined) {
-      return state;
-    }
-
     let board = Grid.from2DArray(state.board);
     board = board.map((color) =>
       color_to_player(color) === player ? color : Color.EMPTY,

--- a/packages/shared/src/variants/phantom.ts
+++ b/packages/shared/src/variants/phantom.ts
@@ -5,6 +5,10 @@ export class Phantom extends Baduk {
   exportState(player?: number): BadukState {
     const state = super.exportState();
 
+    if (this.phase === "gameover") {
+      return state;
+    }
+
     let board = Grid.from2DArray(state.board);
     board = board.map((color) =>
       color_to_player(color) === player ? color : Color.EMPTY,


### PR DESCRIPTION
## Summary

- Fix spectator leak: `Phantom.exportState(undefined)` previously returned the full unfiltered board, letting a seated player open a second tab as a spectator to reveal opponent stones. Removing the early return makes the existing filter apply to spectators too — `color_to_player` returns `undefined` only for `Color.EMPTY`, so matching against an `undefined` player keeps empty cells and blanks out every stone.
- Add post-game reveal: once `phase === "gameover"`, return the unfiltered board to everyone (seated players and spectators). Phantom is meant to be a reveal at the end — previously seated players continued to see only their own stones forever, making post-game review impossible.
- Tests updated and extended: the old assertions on `exportState()` (no arg) were checking the buggy full-board path; added a new test that plays stones, passes twice, and verifies every caller sees the full board after gameover.

Fixes #500. Tackles the phantom half of #502; the broader "extend `exportState` with a viewer context" design question remains open there.

## Test plan

- [x] `yarn workspace @ogfcommunity/variants-shared test phantom` (3 tests pass)
- [x] Full shared suite passes (192+ tests)
- [x] `yarn lint` clean
- [x] Manual: open a phantom game, confirm spectators see an empty board during play, and full board after both players pass

<img width="918" height="661" alt="Screenshot 2026-04-11 at 11 59 13 AM" src="https://github.com/user-attachments/assets/39a31507-4dbd-405c-bb5c-89fe435e8f55" />
<img width="876" height="704" alt="Screenshot 2026-04-11 at 11 59 22 AM" src="https://github.com/user-attachments/assets/25004c49-e22d-46d1-9cb9-8f55c2b6ecea" />
<img width="898" height="685" alt="Screenshot 2026-04-11 at 11 59 32 AM" src="https://github.com/user-attachments/assets/8a1e17a4-af4c-4451-ab9f-7923e0350da5" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)