### PR TITLE
Remove "repair game" workaround (#414)

### DIFF
--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -14,7 +14,6 @@ import {
   takeSeat,
   leaveSeat,
   getGameState,
-  repairGame,
   subscribeToGameNotifications,
   getGamesById,
   tryComputeState,
@@ -377,11 +376,6 @@ router.get("/games/:gameId/state", async (req, res) => {
 
   const stateResponse = getGameState(game, seat, round);
   res.send(stateResponse);
-});
-
-router.post("/game/:gameId/repair", checkCSRFToken, async (req, res) => {
-  await repairGame(req.params.gameId);
-  res.send({});
 });
 
 router.post("/admin/test-email", checkCSRFToken, async (req, res) => {

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -389,31 +389,6 @@ export function getGameState(
   };
 }
 
-export async function repairGame(gameId: string): Promise<void> {
-  const game = await getGame(gameId);
-  const gameInstance = makeGameObject(game.variant, game.config);
-  const errorlessMoves: MovesType[] = [];
-  let errorOccured = false;
-
-  // play moves until an error occurred, if any
-  try {
-    game.moves.forEach((encoded_move) => {
-      const { player, move } = getOnlyMove(encoded_move);
-      gameInstance.playMove(player, move);
-      errorlessMoves.push(encoded_move);
-    });
-  } catch (_error) {
-    errorOccured = true;
-  }
-
-  if (errorOccured) {
-    await gamesCollection().updateOne(
-      { _id: new ObjectId(gameId) },
-      { $set: { moves: errorlessMoves } },
-    );
-  }
-}
-
 export async function subscribeToGameNotifications(
   gameId: string,
   userId: string,

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -25,7 +25,6 @@ import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 import DownloadSGF from "@/components/GameView/DownloadSGF.vue";
 import { getPlayingTable } from "@/playing_table_map";
-import Swal from "sweetalert2";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
@@ -69,7 +68,6 @@ const time_control = ref<ITimeControlBase | null>(null);
 // Admins probably don't want to do admin stuff most of the time.  Let's hide
 // admin interface behind a toggle.
 const adminMode = ref<boolean>(false);
-const errorOccured = ref<boolean>(false);
 const creator = ref<User | undefined>();
 const subscription = ref<NotificationType[]>([]);
 
@@ -157,7 +155,6 @@ watchEffect(async () => {
       }
     })
     .catch((err) => {
-      errorOccured.value = true;
       alert(err);
     });
 });
@@ -286,20 +283,6 @@ const createTimeControlPreview = (
   }
   return null;
 };
-async function repairGame(): Promise<void> {
-  await Swal.fire({
-    title: "Repair game",
-    text: "This action may delete moves in order to restore a game state without errors. If the game has time control, this may have unknown consequences.",
-    showCancelButton: true,
-  }).then((result) => {
-    if (result.isConfirmed) {
-      return requests
-        .post(`/game/${props.gameId}/repair`)
-        .catch(alert)
-        .then(() => location.reload());
-    }
-  });
-}
 </script>
 
 <template>
@@ -427,9 +410,6 @@ async function repairGame(): Promise<void> {
           <label for="admin">Admin Mode</label>
         </div>
       </div>
-      <button v-if="errorOccured" class="repair-game-btn" @click="repairGame">
-        repair game
-      </button>
     </div>
   </main>
 </template>
@@ -456,11 +436,6 @@ async function repairGame(): Promise<void> {
   }
 }
 
-.repair-game-btn {
-  background-color: var(--color-warn);
-  height: 64px;
-  font-size: large;
-}
 .subscribe-button-container {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Summary
- Removes the "repair game" button, client handler, server route, and `repairGame()` function.
- The feature was a temporary workaround for the move race condition in #226, which has since been fixed properly by #413. Likely there are no active games that still require this fix.
- Closes #414.

## Test plan
- [x] `yarn build`
- [x] `yarn lint`
- [x] `yarn test`
- [x] Manual: load a normal game — no visual regression in GameView
- [x] Manual: simulate a game fetch failure (e.g. bad game id) — still get the alert, no orphaned "repair game" button

<img width="643" height="700" alt="Screenshot 2026-04-13 at 9 39 31 PM" src="https://github.com/user-attachments/assets/3f9816f9-6ca0-45ec-aedf-4b8ebbe09f26" />
<img width="446" height="237" alt="Screenshot 2026-04-13 at 9 38 53 PM" src="https://github.com/user-attachments/assets/e2e88ed8-27c8-4495-bd6f-896ea0b212e7" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)