### PR TITLE
Rename shared package to @govariants and enable subpath imports (#479)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}/packages/server",
             "runtimeExecutable": "yarn",
-            "runtimeArgs": ["workspace", "@ogfcommunity/variants-server", "run", "start"],
+            "runtimeArgs": ["workspace", "@govariants/server", "run", "start"],
             "outputCapture": "std",
         },
         {
@@ -19,7 +19,7 @@
             "request": "launch",
             "cwd": "${workspaceFolder}/packages/vue-client",
             "runtimeExecutable": "yarn",
-            "runtimeArgs": ["workspace", "@ogfcommunity/variants-vue-client", "run", "dev"],
+            "runtimeArgs": ["workspace", "@govariants/vue-client", "run", "dev"],
         },
     ],
     "compounds": [

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: yarn workspace @ogfcommunity/variants-server migrate
-web: yarn workspace @ogfcommunity/variants-server launch
+release: yarn workspace @govariants/server migrate
+web: yarn workspace @govariants/server launch

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ogfcommunity/variants-monorepo",
+  "name": "@govariants/monorepo",
   "version": "1.0.0",
   "description": "A place to play Go variants, brought to you by the OGF community.",
   "main": "index.js",
@@ -11,9 +11,9 @@
     "test": "yarn workspaces foreach -pti run test",
     "lint:check": "yarn workspaces foreach -pti run lint:check",
     "lint": "yarn workspaces foreach -pti run lint",
-    "start:server": "yarn workspace @ogfcommunity/variants-server run start",
-    "start:client": "yarn workspace @ogfcommunity/variants-vue-client run start",
-    "start:shared": "yarn workspace @ogfcommunity/variants-shared run start",
+    "start:server": "yarn workspace @govariants/server run start",
+    "start:client": "yarn workspace @govariants/vue-client run start",
+    "start:shared": "yarn workspace @govariants/shared run start",
     "new-variant": "node  ./scripts/create-new-app.js",
     "postinstall": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@govariants/monorepo",
+  "name": "govariants",
   "version": "1.0.0",
+  "private": true,
   "description": "A place to play Go variants, brought to you by the OGF community.",
   "main": "index.js",
   "license": "AGPL-3.0",

--- a/packages/server/eslint.config.mjs
+++ b/packages/server/eslint.config.mjs
@@ -32,12 +32,12 @@ export default tseslint.config(
           patterns: [
             {
               group: [
-                "@ogfcommunity/variants-shared/src/*",
+                "@govariants/shared/src/*",
                 "**/shared/**",
                 "shared/**",
               ],
               message:
-                "Import the shared package using the package alias: import {X} from '@ogfcommunity/variants-shared' (not via a relative path).",
+                "Import the shared package using the package alias: import {X} from '@govariants/shared' (not via a relative path).",
             },
           ],
         },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ogfcommunity/variants-server",
+  "name": "@govariants/server",
   "main": "dist/index.js",
   "scripts": {
     "start": "nodemon ./src/index.ts",
@@ -17,7 +17,7 @@
     ]
   },
   "dependencies": {
-    "@ogfcommunity/variants-shared": "1.0.0",
+    "@govariants/shared": "1.0.0",
     "@types/express": "^5.0.6",
     "@types/express-session": "^1.18.2",
     "@types/migrate-mongo": "10.0.5",

--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -7,7 +7,7 @@ import {
   clearTestDb,
   getTestClient,
 } from "./helpers/setup";
-import { UserResponse } from "@ogfcommunity/variants-shared";
+import { UserResponse } from "@govariants/shared";
 import { HttpError } from "../http-error";
 
 // Mock modules BEFORE importing api - this prevents the real index.ts from loading

--- a/packages/server/src/__tests__/subscription-validation.test.ts
+++ b/packages/server/src/__tests__/subscription-validation.test.ts
@@ -1,4 +1,4 @@
-import { GameResponse, UserResponse } from "@ogfcommunity/variants-shared";
+import { GameResponse, UserResponse } from "@govariants/shared";
 import {
   validateSeatSubscription,
   gameTopic,

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -4,7 +4,7 @@ import {
   makeGameObject,
   NotificationsResponse,
   groupBy,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import passport, { AuthenticateCallback } from "passport";
 import {
   getGame,
@@ -38,7 +38,7 @@ import {
   UserResponse,
   GameInitialResponse,
   validateNotificationTypeArray,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { io } from "./socket_io";
 import { checkCSRFToken, generateCSRFToken } from "./csrf_guard";
 import { sendEmail } from "./email";

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -15,7 +15,7 @@ import {
   GameSubscriptions,
   GameInitialResponse,
   GameErrorResponse,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ObjectId, WithId, Document, Filter, Collection } from "mongodb";
 import { getDb } from "./db";
 import { io } from "./socket_io";

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -13,7 +13,7 @@ import { connectToDb, getDb } from "./db";
 import passport from "passport";
 import { Strategy as CustomStrategy } from "passport-custom";
 import { Strategy as LocalStrategy } from "passport-local";
-import { SITE_NAME, UserResponse } from "@ogfcommunity/variants-shared";
+import { SITE_NAME, UserResponse } from "@govariants/shared";
 import { router as apiRouter } from "./api";
 import { getGame } from "./games";
 import * as socket_io from "./socket_io";

--- a/packages/server/src/notifications/notifications.ts
+++ b/packages/server/src/notifications/notifications.ts
@@ -6,7 +6,7 @@ import {
   GameSubscriptions,
   Notifications,
   NotificationType,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 
 function outwardMap(userNotifications: UserNotifications): GameNotification[] {
   return userNotifications.notifications as GameNotification[];

--- a/packages/server/src/notifications/notifications.types.ts
+++ b/packages/server/src/notifications/notifications.types.ts
@@ -1,4 +1,4 @@
-import { NotificationType } from "@ogfcommunity/variants-shared";
+import { NotificationType } from "@govariants/shared";
 
 export type DBGameNotification = {
   gameId: string;

--- a/packages/server/src/rating/__tests__/rating.test.ts
+++ b/packages/server/src/rating/__tests__/rating.test.ts
@@ -5,11 +5,7 @@ import {
   getGlickoResult,
 } from "../rating";
 import { Glicko2 } from "glicko2";
-import {
-  UserRanking,
-  UserRankings,
-  UserResponse,
-} from "@ogfcommunity/variants-shared";
+import { UserRanking, UserRankings, UserResponse } from "@govariants/shared";
 
 test("supportsRatings", () => {
   const supportsRating = supportsRatings("chess");

--- a/packages/server/src/rating/rating.ts
+++ b/packages/server/src/rating/rating.ts
@@ -4,7 +4,7 @@ import {
   UserRanking,
   UserRankings,
   UserResponse,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { Glicko2, Player } from "glicko2";
 import { updateUserRanking, getUser } from "../users";
 

--- a/packages/server/src/socket_validation.ts
+++ b/packages/server/src/socket_validation.ts
@@ -1,4 +1,4 @@
-import { GameResponse, UserResponse } from "@ogfcommunity/variants-shared";
+import { GameResponse, UserResponse } from "@govariants/shared";
 
 export const SEAT_TOPIC_RE = /^game\/([a-f0-9]{24})\/(\d+)$/;
 

--- a/packages/server/src/time-control/__tests__/parallel.test.ts
+++ b/packages/server/src/time-control/__tests__/parallel.test.ts
@@ -5,7 +5,7 @@ import {
   PerPlayerTimeControlParallel,
   TimeControlType,
   parallelVariant,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { TestClock } from "../clock";
 import { TimeHandlerParallelMoves } from "../time-handler-parallel";
 import { TestTimeoutService } from "../mocks/timeout-service.mock";

--- a/packages/server/src/time-control/__tests__/sequential.test.ts
+++ b/packages/server/src/time-control/__tests__/sequential.test.ts
@@ -7,7 +7,7 @@ import {
   ITimeControlBase,
   TimeControlType,
   makeGameObject,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { TestClock } from "../clock";
 import { TimeHandlerSequentialMoves } from "../time-handler-sequential";
 import { TestTimeoutService } from "../mocks/timeout-service.mock";

--- a/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
+++ b/packages/server/src/time-control/__tests__/time-handler-utils.test.ts
@@ -3,7 +3,7 @@ import {
   IPerPlayerTimeControlBase,
   TimeControlType,
   badukVariant,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import {
   getMsUntilTimeout,
   initialState,

--- a/packages/server/src/time-control/time-control.ts
+++ b/packages/server/src/time-control/time-control.ts
@@ -6,8 +6,8 @@ import {
   TimeControlType,
   IFischerConfig,
   getTimeHandling,
-} from "@ogfcommunity/variants-shared";
-import { AbstractGame, GameResponse } from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
+import { AbstractGame, GameResponse } from "@govariants/shared";
 import { Clock } from "./clock";
 import { getTimeoutService } from "..";
 import { TimeHandlerSequentialMoves } from "./time-handler-sequential";

--- a/packages/server/src/time-control/time-handler-parallel.ts
+++ b/packages/server/src/time-control/time-handler-parallel.ts
@@ -6,7 +6,7 @@ import {
   PerPlayerTimeControlParallel,
   TimeControlParallel,
   timeControlMap,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ITimeoutService } from "./timeout";
 import { ITimeHandler } from "./time-control";
 import { IClock } from "./clock";

--- a/packages/server/src/time-control/time-handler-sequential.ts
+++ b/packages/server/src/time-control/time-handler-sequential.ts
@@ -4,7 +4,7 @@ import {
   IConfigWithTimeControl,
   IPerPlayerTimeControlBase,
   ITimeControlBase,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ITimeoutService } from "./timeout";
 import { ITimeHandler } from "./time-control";
 import { IClock } from "./clock";

--- a/packages/server/src/time-control/time-handler-utils.ts
+++ b/packages/server/src/time-control/time-handler-utils.ts
@@ -7,7 +7,7 @@ import {
   TimeControl,
   makeGameObject,
   timeControlMap,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 
 export function initialState(
   variant: string,

--- a/packages/server/src/time-control/timeout.ts
+++ b/packages/server/src/time-control/timeout.ts
@@ -4,7 +4,7 @@ import {
   getOnlyMove,
   makeGameObject,
   timeControlMap,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { nullTimeState } from "./time-handler-utils";
 import { getTimeHandler } from "./time-control";
 

--- a/packages/server/src/users.ts
+++ b/packages/server/src/users.ts
@@ -1,10 +1,5 @@
 import { getDb } from "./db";
-import {
-  User,
-  UserResponse,
-  UserRankings,
-  UserRole,
-} from "@ogfcommunity/variants-shared";
+import { User, UserResponse, UserRankings, UserRole } from "@govariants/shared";
 import { Collection, WithId, ObjectId } from "mongodb";
 import { randomBytes, scrypt } from "node:crypto";
 import { deleteAllNotificationsOfUser } from "./notifications/notifications";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,17 @@
 {
-  "name": "@ogfcommunity/variants-shared",
+  "name": "@govariants/shared",
   "version": "1.0.0",
   "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.js"
+    }
+  },
   "devDependencies": {
     "@eslint/js": "^10",
     "@types/markdown-it": "^14.1.2",

--- a/packages/vue-client/eslint.config.mjs
+++ b/packages/vue-client/eslint.config.mjs
@@ -45,12 +45,12 @@ export default defineConfigWithVueTs(
           patterns: [
             {
               group: [
-                "@ogfcommunity/variants-shared/src/*",
+                "@govariants/shared/src/*",
                 "**/shared/**",
                 "shared/**",
               ],
               message:
-                "Import the shared package using the package alias: import {X} from '@ogfcommunity/variants-shared' (not via a relative path).",
+                "Import the shared package using the package alias: import {X} from '@govariants/shared' (not via a relative path).",
             },
           ],
         },

--- a/packages/vue-client/package.json
+++ b/packages/vue-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ogfcommunity/variants-vue-client",
+  "name": "@govariants/vue-client",
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
@@ -26,7 +26,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/vue-fontawesome": "latest-3",
-    "@ogfcommunity/variants-shared": "1.0.0",
+    "@govariants/shared": "1.0.0",
     "@types/jsdom": "^21.1.7",
     "@types/three": "^0.182.0",
     "@vueuse/core": "^10.2.1",

--- a/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BadukConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BoardConfig, NewBadukConfig } from "@ogfcommunity/variants-shared";
+import { BoardConfig, NewBadukConfig } from "@govariants/shared";
 import BoardConfigForm from "./BoardConfigForms/BoardConfigForm.vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/BoardConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BoardConfig, BoardPattern } from "@ogfcommunity/variants-shared";
+import { BoardConfig, BoardPattern } from "@govariants/shared";
 import { type Ref, ref } from "vue";
 import GridBoardConfigForm from "./GridBoardConfigForm.vue";
 import GridWithHolesBoardConfigForm from "./GridWithHolesBoardConfigForm.vue";

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/CircularBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/CircularBoardConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CircularBoardConfig } from "@ogfcommunity/variants-shared";
+import { CircularBoardConfig } from "@govariants/shared";
 import { ref } from "vue";
 
 const defaultConfig: CircularBoardConfig = {

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/CustomBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/CustomBoardConfigForm.vue
@@ -4,7 +4,7 @@ import {
   CustomBoardConfig,
   validateCustomBoardConfig,
   getCustomBoardConfigWarning,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ref } from "vue";
 
 const defaultConfigStr = `{

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridBoardConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { GridBoardConfig } from "@ogfcommunity/variants-shared";
+import { GridBoardConfig } from "@govariants/shared";
 import { ref } from "vue";
 
 const defaultConfig: GridBoardConfig = {

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridWithHolesBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/GridWithHolesBoardConfigForm.vue
@@ -2,7 +2,7 @@
 import {
   GridWithHolesBoardConfig,
   assertRectangular2DArrayOf,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ref, watch } from "vue";
 
 const defaultConfig: GridWithHolesBoardConfig = {

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/RhombitrihexagonalBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/RhombitrihexagonalBoardConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { RhombitrihexagonalBoardConfig } from "@ogfcommunity/variants-shared";
+import { RhombitrihexagonalBoardConfig } from "@govariants/shared";
 import { ref } from "vue";
 
 const defaultConfig: RhombitrihexagonalBoardConfig = {

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/SierpinskyBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/SierpinskyBoardConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { SierpinskyBoardConfig } from "@ogfcommunity/variants-shared";
+import { SierpinskyBoardConfig } from "@govariants/shared";
 import { ref } from "vue";
 
 const defaultConfig: SierpinskyBoardConfig = {

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/SunflowerBoardConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/SunflowerBoardConfigForm.vue
@@ -2,7 +2,7 @@
 import {
   BoardPattern,
   SunflowerBoardConfig,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ref } from "vue";
 
 const defaultConfig: SunflowerBoardConfig = {

--- a/packages/vue-client/src/components/GameCreation/BoardConfigForms/TrihexagonalConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/BoardConfigForms/TrihexagonalConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TrihexagonalBoardConfig } from "@ogfcommunity/variants-shared";
+import { TrihexagonalBoardConfig } from "@govariants/shared";
 import { ref } from "vue";
 
 const defaultConfig: TrihexagonalBoardConfig = {

--- a/packages/vue-client/src/components/GameCreation/CubeBadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/CubeBadukConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CubeBadukConfig, BoardPattern } from "@ogfcommunity/variants-shared";
+import { CubeBadukConfig, BoardPattern } from "@govariants/shared";
 import { ref, watch } from "vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/DriftGoConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type DriftGoConfig } from "@ogfcommunity/variants-shared";
+import { type DriftGoConfig } from "@govariants/shared";
 
 const props = defineProps<{ initialConfig: DriftGoConfig }>();
 const config: DriftGoConfig = {

--- a/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
+++ b/packages/vue-client/src/components/GameCreation/GameCreationForm.vue
@@ -7,7 +7,7 @@ import {
   BoardPattern,
   getTimeHandling,
   getDescription,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import * as requests from "@/requests";
 import router from "@/router";
 import { config_form_map } from "@/config_form_map";

--- a/packages/vue-client/src/components/GameCreation/GridBadukConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/GridBadukConfigForm.vue
@@ -2,7 +2,7 @@
 import {
   NewBadukConfig,
   NewGridBadukConfig,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import BadukConfigForm from "./BadukConfigForm.vue";
 
 const _props = defineProps<{

--- a/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/ParallelGoConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ParallelGoConfig } from "@ogfcommunity/variants-shared";
+import type { ParallelGoConfig } from "@govariants/shared";
 
 const props = defineProps<{ initialConfig: ParallelGoConfig }>();
 const config = { ...props.initialConfig } as ParallelGoConfig;

--- a/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/PyramidConfigForm.vue
@@ -6,7 +6,7 @@ import {
   NewBadukConfig,
   generalizedPyramid,
   PyramidConfig,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import BadukConfigForm from "./BadukConfigForm.vue";
 
 defineProps<{

--- a/packages/vue-client/src/components/GameCreation/RengoConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/RengoConfigForm.vue
@@ -5,7 +5,7 @@ import {
   getVariantList,
   makeGameObject,
   RengoConfig,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ref, watch, type Component } from "vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/GameCreation/RizomaConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/RizomaConfigForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { reactive, watch } from "vue";
-import type { RizomaConfig } from "@ogfcommunity/variants-shared";
+import type { RizomaConfig } from "@govariants/shared";
 
 const props = defineProps<{
   initialConfig: RizomaConfig;

--- a/packages/vue-client/src/components/GameCreation/SFractionalConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/SFractionalConfigForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BoardConfig, SFractionalConfig } from "@ogfcommunity/variants-shared";
+import { BoardConfig, SFractionalConfig } from "@govariants/shared";
 import BoardConfigForm from "./BoardConfigForms/BoardConfigForm.vue";
 import { reactive } from "vue";
 

--- a/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
+++ b/packages/vue-client/src/components/GameCreation/TimeControlConfigForm.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { TimeControlType } from "@ogfcommunity/variants-shared";
+import { TimeControlType } from "@govariants/shared";
 function shouldShowPeriodTime(type: TimeControlType) {
   return type === TimeControlType.ByoYomi || type === TimeControlType.Canadian;
 }
@@ -11,7 +11,7 @@ import type {
   ICanadianTimeConfig,
   ITimeControlConfig,
   IFischerConfig,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ref } from "vue";
 
 const typeRef = ref(null);

--- a/packages/vue-client/src/components/GameCreation/__tests__/GameCreationForm.test.ts
+++ b/packages/vue-client/src/components/GameCreation/__tests__/GameCreationForm.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent } from "@testing-library/vue";
 import { flushPromises } from "@vue/test-utils";
-import { BoardPattern } from "@ogfcommunity/variants-shared";
+import { BoardPattern } from "@govariants/shared";
 import GameCreationForm from "../GameCreationForm.vue";
 import * as requests from "@/requests";
 

--- a/packages/vue-client/src/components/GameList.vue
+++ b/packages/vue-client/src/components/GameList.vue
@@ -7,7 +7,7 @@ import {
   type GamesFilter,
   gamesFilterToUrlParams,
   isErrorResult,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import GameListItem from "@/components/GameListItem.vue";
 import GameListItemFallback from "@/components/GameListItemFallback.vue";
 import GamesFilterForm from "@/components/GamesFilterForm.vue";

--- a/packages/vue-client/src/components/GameListItem.vue
+++ b/packages/vue-client/src/components/GameListItem.vue
@@ -2,7 +2,7 @@
 import {
   uiTransform,
   type GameInitialResponse,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { computed } from "vue";
 import { getBoard } from "@/board_map";
 

--- a/packages/vue-client/src/components/GameTimer.vue
+++ b/packages/vue-client/src/components/GameTimer.vue
@@ -4,7 +4,7 @@ import {
   type IPerPlayerTimeControlBase,
   timeControlMap,
   type ITimeControlConfig,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { isDefined } from "@vueuse/core";
 import { stop_and_speak } from "@/utils/voice-synthesizer";
 import { useInterval } from "@/utils/restartable_interval";

--- a/packages/vue-client/src/components/GameView/PlayerSymbol.vue
+++ b/packages/vue-client/src/components/GameView/PlayerSymbol.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getPlayerColors } from "@ogfcommunity/variants-shared";
+import { getPlayerColors } from "@govariants/shared";
 import TaegeukStone from "../TaegeukStone.vue";
 import { computed } from "vue";
 

--- a/packages/vue-client/src/components/GameView/SeatComponent.vue
+++ b/packages/vue-client/src/components/GameView/SeatComponent.vue
@@ -3,7 +3,7 @@ import type {
   User,
   IPerPlayerTimeControlBase,
   IConfigWithTimeControl,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { computed, getCurrentInstance } from "vue";
 import GameTimer from "../GameTimer.vue";
 import PlayerSymbol from "./PlayerSymbol.vue";

--- a/packages/vue-client/src/components/GameView/SubscriptionDialog.ts
+++ b/packages/vue-client/src/components/GameView/SubscriptionDialog.ts
@@ -1,4 +1,4 @@
-import { type NotificationType } from "@ogfcommunity/variants-shared";
+import { type NotificationType } from "@govariants/shared";
 import { createApp, ref } from "vue";
 import Swal from "sweetalert2";
 import * as requests from "@/requests";

--- a/packages/vue-client/src/components/GamesFilterForm.vue
+++ b/packages/vue-client/src/components/GamesFilterForm.vue
@@ -3,7 +3,7 @@ import { useCurrentUser } from "@/stores/user";
 import {
   getVariantList,
   type GamesFilter,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { ref } from "vue";
 
 const filter = defineModel<GamesFilter>();

--- a/packages/vue-client/src/components/PlayingTable/CubeTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/CubeTable.vue
@@ -4,7 +4,7 @@ import CubeBoard from "../boards/CubeBoard.vue";
 import type {
   CubeBadukConfig,
   DefaultBoardState,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 
 defineProps<{
   gamestate: DefaultBoardState;

--- a/packages/vue-client/src/components/PlayingTable/PolymorphicPlayingTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/PolymorphicPlayingTable.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getPlayingTable } from "@/playing_table_map";
-import { IHigherOrderConfig, uiTransform } from "@ogfcommunity/variants-shared";
+import { IHigherOrderConfig, uiTransform } from "@govariants/shared";
 import { computed } from "vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/SFractionalTable.vue
@@ -3,7 +3,7 @@ import {
   DefaultBoardState,
   SFractional,
   sFractionalMoveColors,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import MoveSequenceDisplay from "../MoveSequenceDisplay.vue";
 import DefaultBoard from "../boards/DefaultBoard.vue";
 

--- a/packages/vue-client/src/components/PlayingTable/ThueMorseTable.vue
+++ b/packages/vue-client/src/components/PlayingTable/ThueMorseTable.vue
@@ -2,9 +2,9 @@
 import {
   DefaultBoardConfig,
   DefaultBoardState,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import MoveSequenceDisplay from "../MoveSequenceDisplay.vue";
-import { count_binary_ones } from "@ogfcommunity/variants-shared";
+import { count_binary_ones } from "@govariants/shared";
 import DefaultBoard from "../boards/DefaultBoard.vue";
 
 defineProps<{

--- a/packages/vue-client/src/components/boards/CubeBoard.vue
+++ b/packages/vue-client/src/components/boards/CubeBoard.vue
@@ -22,7 +22,7 @@ import {
   projectToSquircle,
   calculateSquircleNormal,
   getHoshi,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 
 const props = withDefaults(
   defineProps<{

--- a/packages/vue-client/src/components/boards/DefaultBoard.vue
+++ b/packages/vue-client/src/components/boards/DefaultBoard.vue
@@ -6,13 +6,13 @@ board color etc.
 
 <script setup lang="ts">
 import MulticolorGridBoard from "./MulticolorGridBoard.vue";
-import { Coordinate, indexToMove } from "@ogfcommunity/variants-shared";
+import { Coordinate, indexToMove } from "@govariants/shared";
 import MulticolorGraphBoard from "./MulticolorGraphBoard.vue";
 import {
   DefaultBoardConfig,
   DefaultBoardState,
   MulticolorStone,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 
 const props = defineProps<{
   config: DefaultBoardConfig;

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -5,8 +5,8 @@ import {
   type FractionalState,
   Intersection,
   getHoshi,
-} from "@ogfcommunity/variants-shared";
-import { createGraph } from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
+import { createGraph } from "@govariants/shared";
 import { computed } from "vue";
 import TaegeukStone from "../TaegeukStone.vue";
 import IntersectionAnnotation from "../IntersectionAnnotation.vue";

--- a/packages/vue-client/src/components/boards/KeimaBoard.vue
+++ b/packages/vue-client/src/components/boards/KeimaBoard.vue
@@ -7,8 +7,8 @@ import {
   Color,
   getWidthAndHeight,
   getKeimaMoves,
-} from "@ogfcommunity/variants-shared";
-import { GridBadukConfig } from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
+import { GridBadukConfig } from "@govariants/shared";
 import { computed } from "vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGraphBoard.vue
@@ -8,7 +8,7 @@ import {
   Intersection,
   createGraph,
   MulticolorStone,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import ScoreMark from "./ScoreMark.vue";
 import { Voronoi, Site, Cell } from "voronoijs";
 import { STONE_RADIUS, LINE_WIDTH, BOARD_COLOR } from "./board_constants";

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -6,7 +6,7 @@ import {
   Coordinate,
   getHoshi,
   MulticolorStone,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { positionsGetter } from "./board_utils";
 import {
   STONE_RADIUS,

--- a/packages/vue-client/src/components/boards/ParallelGoBoard.vue
+++ b/packages/vue-client/src/components/boards/ParallelGoBoard.vue
@@ -2,7 +2,7 @@
 import {
   type MovesType,
   colors_for_parallel,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 
 type Stone = { colors: string[]; annotation?: "CR" };
 
@@ -34,8 +34,8 @@ import {
   Coordinate,
   type ParallelGoConfig,
   type ParallelGoState,
-} from "@ogfcommunity/variants-shared";
-import { Grid } from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
+import { Grid } from "@govariants/shared";
 import { computed } from "vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/boards/PolymorphicBoard.vue
+++ b/packages/vue-client/src/components/boards/PolymorphicBoard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { getBoard } from "@/board_map";
-import { IHigherOrderConfig, uiTransform } from "@ogfcommunity/variants-shared";
+import { IHigherOrderConfig, uiTransform } from "@govariants/shared";
 import { computed } from "vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/boards/QuantumBoard.vue
+++ b/packages/vue-client/src/components/boards/QuantumBoard.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Color, type CoordinateLike } from "@ogfcommunity/variants-shared";
+import { Color, type CoordinateLike } from "@govariants/shared";
 </script>
 
 <script setup lang="ts">
@@ -11,7 +11,7 @@ import {
   MulticolorStone,
   NewBadukConfig,
   moveToIndex,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { computed } from "vue";
 
 const props = defineProps<{

--- a/packages/vue-client/src/components/boards/RizomaBoard.vue
+++ b/packages/vue-client/src/components/boards/RizomaBoard.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import MulticolorGridBoard from "./MulticolorGridBoard.vue";
-import { Coordinate } from "@ogfcommunity/variants-shared";
+import { Coordinate } from "@govariants/shared";
 import type {
   RizomaConfig,
   RizomaState,
   BoardScore,
-} from "@ogfcommunity/variants-shared";
-import type { MulticolorStone } from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
+import type { MulticolorStone } from "@govariants/shared";
 
 const props = defineProps<{
   config: RizomaConfig;

--- a/packages/vue-client/src/components/boards/board_utils.ts
+++ b/packages/vue-client/src/components/boards/board_utils.ts
@@ -1,4 +1,4 @@
-import { Coordinate } from "@ogfcommunity/variants-shared";
+import { Coordinate } from "@govariants/shared";
 import type { Ref } from "vue";
 
 /** Given Refs for width and height, return a flat array of coordinates containing

--- a/packages/vue-client/src/stores/user.ts
+++ b/packages/vue-client/src/stores/user.ts
@@ -1,6 +1,6 @@
 import { defineStore, storeToRefs } from "pinia";
 import * as requests from "../requests";
-import type { UserResponse } from "@ogfcommunity/variants-shared";
+import type { UserResponse } from "@govariants/shared";
 import type { Ref } from "vue";
 
 interface UserStoreStateTree {

--- a/packages/vue-client/src/views/ComponentView.vue
+++ b/packages/vue-client/src/views/ComponentView.vue
@@ -2,7 +2,7 @@
 import { reactive, ref } from "vue";
 import TaegeukStone from "../components/TaegeukStone.vue";
 import MulticolorGridBoard from "../components/boards/MulticolorGridBoard.vue";
-import type { Coordinate } from "@ogfcommunity/variants-shared";
+import type { Coordinate } from "@govariants/shared";
 import SocketTest from "../components/SocketTest.vue";
 
 // https://sashamaps.net/docs/resources/20-colors/

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -7,7 +7,7 @@ import {
   NotificationType,
   MovesType,
   variantSupportsMovePreview,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import * as requests from "../requests";
 import SeatComponent from "@/components/GameView/SeatComponent.vue";
 import { useCurrentUser } from "../stores/user";
@@ -18,7 +18,7 @@ import {
   GameStateResponse,
   ITimeControlBase,
   getMovePreview,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { computed, ref, watch, watchEffect, type Ref } from "vue";
 import { socket } from "../requests";
 import NavButtons from "@/components/GameView/NavButtons.vue";

--- a/packages/vue-client/src/views/HomeView.vue
+++ b/packages/vue-client/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import GameCreationForm from "@/components/GameCreation/GameCreationForm.vue";
 import GameList from "@/components/GameList.vue";
-import { SITE_NAME } from "@ogfcommunity/variants-shared";
+import { SITE_NAME } from "@govariants/shared";
 </script>
 
 <template>

--- a/packages/vue-client/src/views/NotificationsView.vue
+++ b/packages/vue-client/src/views/NotificationsView.vue
@@ -7,7 +7,7 @@ import {
   isErrorResult,
   Notifications,
   NotificationsResponse,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { setNotificationsCount } from "@/stores/notifications";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {

--- a/packages/vue-client/src/views/RulesListView.vue
+++ b/packages/vue-client/src/views/RulesListView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { toUpperCaseFirstLetter } from "@/utils/format-utils";
-import { getVariantList } from "@ogfcommunity/variants-shared";
+import { getVariantList } from "@govariants/shared";
 import { RouterLink } from "vue-router";
 </script>
 

--- a/packages/vue-client/src/views/RulesView.vue
+++ b/packages/vue-client/src/views/RulesView.vue
@@ -3,7 +3,7 @@ import {
   getDescription,
   getRulesDescription,
   getVariantList,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import { computed } from "vue";
 import VariantDemoView from "./VariantDemoView.vue";
 import { toUpperCaseFirstLetter } from "@/utils/format-utils";

--- a/packages/vue-client/src/views/UserView.vue
+++ b/packages/vue-client/src/views/UserView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { UserResponse, UserRole } from "@ogfcommunity/variants-shared";
+import { UserResponse, UserRole } from "@govariants/shared";
 import { ref, watchEffect, computed } from "vue";
 import * as requests from "../requests";
 import { useCurrentUser } from "@/stores/user";

--- a/packages/vue-client/src/views/VariantDemoView.vue
+++ b/packages/vue-client/src/views/VariantDemoView.vue
@@ -5,11 +5,11 @@ import {
   getDefaultConfig,
   getDescription,
   uiTransform,
-} from "@ogfcommunity/variants-shared";
+} from "@govariants/shared";
 import SeatComponent from "@/components/GameView/SeatComponent.vue";
 import { useCurrentUser } from "../stores/user";
 import { computed, reactive, ref, watch, type Ref } from "vue";
-import type { MovesType } from "@ogfcommunity/variants-shared";
+import type { MovesType } from "@govariants/shared";
 import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
 import { config_form_map } from "@/config_form_map";

--- a/packages/vue-client/src/views/__tests__/GameView.test.ts
+++ b/packages/vue-client/src/views/__tests__/GameView.test.ts
@@ -3,7 +3,7 @@ import { mount, flushPromises } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import GameView from "../GameView.vue";
 import * as requests from "../../requests";
-import type { User } from "@ogfcommunity/variants-shared";
+import type { User } from "@govariants/shared";
 
 // Mock the requests module
 vi.mock("../../requests", () => ({

--- a/packages/vue-client/tsconfig.app.json
+++ b/packages/vue-client/tsconfig.app.json
@@ -8,7 +8,8 @@
     "rootDir": "..",
     "paths": {
       "@/*": ["vue-client/src/*"],
-      "@ogfcommunity/variants-shared": ["./shared/src/index"]
+      "@govariants/shared": ["./shared/src/index"],
+      "@govariants/shared/*": ["./shared/src/*"]
     }
     ,
     "verbatimModuleSyntax": false,

--- a/packages/vue-client/tsconfig.config.json
+++ b/packages/vue-client/tsconfig.config.json
@@ -8,7 +8,8 @@
     "rootDir": "..",
     "paths": {
       "@/*": ["vue-client/src/*"],
-      "@ogfcommunity/variants-shared": ["./shared/src/index"]
+      "@govariants/shared": ["./shared/src/index"],
+      "@govariants/shared/*": ["./shared/src/*"]
     },
     "verbatimModuleSyntax": false,
     "moduleResolution": "node",

--- a/packages/vue-client/tsconfig.json
+++ b/packages/vue-client/tsconfig.json
@@ -15,8 +15,9 @@
     "baseUrl": "..",
     "rootDir": "..",
     "paths": {
-      "@/*": ["vue-client/src/*"], 
-      "@ogfcommunity/variants-shared": ["./shared/src/index"],
+      "@/*": ["vue-client/src/*"],
+      "@govariants/shared": ["./shared/src/index"],
+      "@govariants/shared/*": ["./shared/src/*"],
     }
     ,
     "verbatimModuleSyntax": false,

--- a/packages/vue-client/vite.config.ts
+++ b/packages/vue-client/vite.config.ts
@@ -9,10 +9,10 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
-      "@ogfcommunity/variants-shared/src": fileURLToPath(
+      "@govariants/shared/src": fileURLToPath(
         new URL("../shared/src", import.meta.url),
       ),
-      "@ogfcommunity/variants-shared": fileURLToPath(
+      "@govariants/shared": fileURLToPath(
         new URL("../shared/src", import.meta.url),
       ),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,16 +752,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@govariants/monorepo@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@govariants/monorepo@workspace:."
-  dependencies:
-    "@types/jsdom": ^21.1.7
-    husky: ^9.1.7
-    lint-staged: ^15.2.11
-  languageName: unknown
-  linkType: soft
-
 "@govariants/server@workspace:packages/server":
   version: 0.0.0-use.local
   resolution: "@govariants/server@workspace:packages/server"
@@ -4534,6 +4524,16 @@ __metadata:
   checksum: cc6d8e655e360955bdccaca51a12a474268f95bb793fc3e1f2bdadb075f28bfd1fd988dab872daf77a61d78cbaf13744bc8727a17cfb1d150d76047d805375f3
   languageName: node
   linkType: hard
+
+"govariants@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "govariants@workspace:."
+  dependencies:
+    "@types/jsdom": ^21.1.7
+    husky: ^9.1.7
+    lint-staged: ^15.2.11
+  languageName: unknown
+  linkType: soft
 
 "graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
   version: 4.2.11

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,6 +752,122 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@govariants/monorepo@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@govariants/monorepo@workspace:."
+  dependencies:
+    "@types/jsdom": ^21.1.7
+    husky: ^9.1.7
+    lint-staged: ^15.2.11
+  languageName: unknown
+  linkType: soft
+
+"@govariants/server@workspace:packages/server":
+  version: 0.0.0-use.local
+  resolution: "@govariants/server@workspace:packages/server"
+  dependencies:
+    "@eslint/js": ^10
+    "@govariants/shared": 1.0.0
+    "@types/express": ^5.0.6
+    "@types/express-session": ^1.18.2
+    "@types/migrate-mongo": 10.0.5
+    "@types/nodemailer": ^7.0.11
+    "@types/passport": ^1.0.17
+    "@types/passport-local": ^1.0.35
+    "@types/supertest": ^6.0.3
+    connect-mongo: ^5.0.0
+    eslint: ^10
+    express: ^5.2.1
+    express-session: ^1.17.3
+    glicko2: ^1.2.1
+    migrate-mongo: ^12.1.3
+    mongodb: ^5.6.0
+    mongodb-memory-server: ^11.0.1
+    nodemailer: ^7.0.11
+    nodemon: ^3.1.14
+    passport: ^0.6.0
+    passport-custom: ^1.1.1
+    passport-local: ^1.0.0
+    prettier: ^3.0.0
+    socket.io: ^4.8.1
+    supertest: ^7.2.2
+    ts-node: ^10.9.1
+    typescript: ^5.1.6
+    typescript-eslint: ^8
+    vitest: ^3.0.0
+  languageName: unknown
+  linkType: soft
+
+"@govariants/shared@1.0.0, @govariants/shared@workspace:packages/shared":
+  version: 0.0.0-use.local
+  resolution: "@govariants/shared@workspace:packages/shared"
+  dependencies:
+    "@eslint/js": ^10
+    "@types/markdown-it": ^14.1.2
+    chess.js: ^1.0.0-beta.6
+    eslint: ^10
+    markdown-it: ^14.1.0
+    nunjucks: ^3.2.4
+    prettier: ^3.0.0
+    ts-node: ^10.9.1
+    typescript: ^5.1.6
+    typescript-eslint: ^8
+    vitest: ^3.0.0
+  languageName: unknown
+  linkType: soft
+
+"@govariants/vue-client@workspace:packages/vue-client":
+  version: 0.0.0-use.local
+  resolution: "@govariants/vue-client@workspace:packages/vue-client"
+  dependencies:
+    "@fortawesome/fontawesome-svg-core": ^6.5.1
+    "@fortawesome/free-brands-svg-icons": ^6.5.1
+    "@fortawesome/free-regular-svg-icons": ^6.5.1
+    "@fortawesome/free-solid-svg-icons": ^6.5.1
+    "@fortawesome/vue-fontawesome": latest-3
+    "@govariants/shared": 1.0.0
+    "@testing-library/vue": ^8.1.0
+    "@tsconfig/node18": ^18.2.0
+    "@types/jsdom": ^21.1.7
+    "@types/node": ^20.3.3
+    "@types/three": ^0.182.0
+    "@types/validator": ^13.15.10
+    "@vitejs/plugin-vue": ^5.0.0
+    "@vue/eslint-config-prettier": ^10
+    "@vue/eslint-config-typescript": ^14
+    "@vue/test-utils": ^2.4.0
+    "@vue/tsconfig": ^0.4.0
+    "@vueuse/core": ^10.2.1
+    chessground: ^8.3.12
+    eslint: ^10
+    eslint-config-prettier: ^10
+    eslint-plugin-prettier: ^5
+    eslint-plugin-vue: ^10
+    icon-gen: ^5.0.0
+    jsdom: ^27.4.0
+    npm-run-all2: ^6.1.2
+    pinia: ^2.1.4
+    postcss: ^8.4.35
+    postcss-nesting: ^12.0.4
+    prettier: ^3
+    socket.io-client: ^4.8.1
+    sweetalert2: ^11.15.3
+    three: ^0.182.0
+    typescript: ^5.1.6
+    typescript-eslint: ^8
+    validator: ^13.15.23
+    vite: ^6.0.0
+    vitest: ^3.0.0
+    voronoijs: ^1.0.0
+    vue: ^3.4.25
+    vue-error-boundary: ^2.0.3
+    vue-i18n: ^11.3.2
+    vue-router: ^4.2.2
+    vue-tsc: ^2.2.0
+    vue3-chessboard: ^1.2.0
+  languageName: unknown
+  linkType: soft
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -1116,122 +1232,6 @@ __metadata:
   checksum: 68951c589e9a4328698a35fd82fe71909a257d6f2ede0434d236fa55634f0fbcad9bb8755553ce5849bd25ee6f019f4d435921ac715c853582c4a7f5983c8d4a
   languageName: node
   linkType: hard
-
-"@ogfcommunity/variants-monorepo@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "@ogfcommunity/variants-monorepo@workspace:."
-  dependencies:
-    "@types/jsdom": ^21.1.7
-    husky: ^9.1.7
-    lint-staged: ^15.2.11
-  languageName: unknown
-  linkType: soft
-
-"@ogfcommunity/variants-server@workspace:packages/server":
-  version: 0.0.0-use.local
-  resolution: "@ogfcommunity/variants-server@workspace:packages/server"
-  dependencies:
-    "@eslint/js": ^10
-    "@ogfcommunity/variants-shared": 1.0.0
-    "@types/express": ^5.0.6
-    "@types/express-session": ^1.18.2
-    "@types/migrate-mongo": 10.0.5
-    "@types/nodemailer": ^7.0.11
-    "@types/passport": ^1.0.17
-    "@types/passport-local": ^1.0.35
-    "@types/supertest": ^6.0.3
-    connect-mongo: ^5.0.0
-    eslint: ^10
-    express: ^5.2.1
-    express-session: ^1.17.3
-    glicko2: ^1.2.1
-    migrate-mongo: ^12.1.3
-    mongodb: ^5.6.0
-    mongodb-memory-server: ^11.0.1
-    nodemailer: ^7.0.11
-    nodemon: ^3.1.14
-    passport: ^0.6.0
-    passport-custom: ^1.1.1
-    passport-local: ^1.0.0
-    prettier: ^3.0.0
-    socket.io: ^4.8.1
-    supertest: ^7.2.2
-    ts-node: ^10.9.1
-    typescript: ^5.1.6
-    typescript-eslint: ^8
-    vitest: ^3.0.0
-  languageName: unknown
-  linkType: soft
-
-"@ogfcommunity/variants-shared@1.0.0, @ogfcommunity/variants-shared@workspace:packages/shared":
-  version: 0.0.0-use.local
-  resolution: "@ogfcommunity/variants-shared@workspace:packages/shared"
-  dependencies:
-    "@eslint/js": ^10
-    "@types/markdown-it": ^14.1.2
-    chess.js: ^1.0.0-beta.6
-    eslint: ^10
-    markdown-it: ^14.1.0
-    nunjucks: ^3.2.4
-    prettier: ^3.0.0
-    ts-node: ^10.9.1
-    typescript: ^5.1.6
-    typescript-eslint: ^8
-    vitest: ^3.0.0
-  languageName: unknown
-  linkType: soft
-
-"@ogfcommunity/variants-vue-client@workspace:packages/vue-client":
-  version: 0.0.0-use.local
-  resolution: "@ogfcommunity/variants-vue-client@workspace:packages/vue-client"
-  dependencies:
-    "@fortawesome/fontawesome-svg-core": ^6.5.1
-    "@fortawesome/free-brands-svg-icons": ^6.5.1
-    "@fortawesome/free-regular-svg-icons": ^6.5.1
-    "@fortawesome/free-solid-svg-icons": ^6.5.1
-    "@fortawesome/vue-fontawesome": latest-3
-    "@ogfcommunity/variants-shared": 1.0.0
-    "@testing-library/vue": ^8.1.0
-    "@tsconfig/node18": ^18.2.0
-    "@types/jsdom": ^21.1.7
-    "@types/node": ^20.3.3
-    "@types/three": ^0.182.0
-    "@types/validator": ^13.15.10
-    "@vitejs/plugin-vue": ^5.0.0
-    "@vue/eslint-config-prettier": ^10
-    "@vue/eslint-config-typescript": ^14
-    "@vue/test-utils": ^2.4.0
-    "@vue/tsconfig": ^0.4.0
-    "@vueuse/core": ^10.2.1
-    chessground: ^8.3.12
-    eslint: ^10
-    eslint-config-prettier: ^10
-    eslint-plugin-prettier: ^5
-    eslint-plugin-vue: ^10
-    icon-gen: ^5.0.0
-    jsdom: ^27.4.0
-    npm-run-all2: ^6.1.2
-    pinia: ^2.1.4
-    postcss: ^8.4.35
-    postcss-nesting: ^12.0.4
-    prettier: ^3
-    socket.io-client: ^4.8.1
-    sweetalert2: ^11.15.3
-    three: ^0.182.0
-    typescript: ^5.1.6
-    typescript-eslint: ^8
-    validator: ^13.15.23
-    vite: ^6.0.0
-    vitest: ^3.0.0
-    voronoijs: ^1.0.0
-    vue: ^3.4.25
-    vue-error-boundary: ^2.0.3
-    vue-i18n: ^11.3.2
-    vue-router: ^4.2.2
-    vue-tsc: ^2.2.0
-    vue3-chessboard: ^1.2.0
-  languageName: unknown
-  linkType: soft
 
 "@one-ini/wasm@npm:0.1.1":
   version: 0.1.1


### PR DESCRIPTION
Closes #479.

## What

Renames every workspace package from the `@ogfcommunity/variants-*` scope to `@govariants/*`, and enables (but does not adopt) subpath imports from the shared package.

| Old | New |
|-----|-----|
| `@ogfcommunity/variants-shared` | `@govariants/shared` |
| `@ogfcommunity/variants-server` | `@govariants/server` |
| `@ogfcommunity/variants-vue-client` | `@govariants/vue-client` |
| `@ogfcommunity/variants-monorepo` | `govariants` (unscoped, see below) |

The root manifest is never published and nothing imports or targets it by name, so the `@scope/` prefix bought nothing there. It's named plainly `govariants` and marked `"private": true` (which is what actually guards against an accidental publish). The three real packages keep the `@govariants/` scope.

## Method

Every tracked occurrence was `@ogfcommunity/variants-<X>`, so the whole rename collapsed to **one substitution** — package names, workspace scripts, deps, all 73 import sites, eslint rules, tsconfig paths, the vite alias, and launch.json:

```sh
git grep -lE "@ogfcommunity/variants-" -- ':!yarn.lock' \
  | xargs perl -pi -e 's{@ogfcommunity/variants-}{@govariants/}g'
yarn install   # regenerate the lockfile
```

Verification is equally mechanical: `git grep @ogfcommunity` → clean everywhere. (The root `govariants` / `private` tweak was a small follow-up edit on top.)

## Subpath imports

Enabled as a capability per the issue — existing barrel imports are intentionally left as-is.

- **`packages/shared/package.json`** — added an `exports` map (`.` → `dist/index`, `./*` → `dist/*`, each with `types` + `default`). The server (`moduleResolution: node16`) honors this and resolves subpaths to `dist`.
- **`packages/vue-client/{tsconfig.json,tsconfig.app.json,tsconfig.config.json}`** — added `"@govariants/shared/*": ["./shared/src/*"]`. Vue-client uses `moduleResolution: node` (ignores `exports`) and resolves to source; vite's existing bare alias already prefix-matches subpaths, so no vite change was needed.
- The eslint `no-restricted-imports` ban now reads `@govariants/shared/src/*` — still blocks reaching past the package boundary.

This means both forms now work:

```ts
import { X } from "@govariants/shared";
import { Grid } from "@govariants/shared/lib/grid";
```

## Verification

- `yarn build` — shared → server → vue-client all build.
- Tests: shared **206**, server **39**, vue-client **4** — all pass. `yarn lint` clean.
- Subpath proof: `require('@govariants/shared/lib/grid')` resolves at runtime via the exports map; swapping a real vue-client import to the subpath form passed the full `vue-tsc` solution build.
- App smoke-tested: full stack runs (`yarn start`), client serves and `/api/games` returns data through the Vite proxy on the renamed packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
