### PR TITLE
Bump minimatch and brace-expansion to patched versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,7 +2337,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
+"brace-expansion@npm:^2.0.2":
   version: 2.1.4
   resolution: "brace-expansion@npm:2.1.4"
   dependencies:
@@ -2346,12 +2346,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
+"brace-expansion@npm:^5.0.8":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: ^4.0.2
-  checksum: ded86c0f0b138734110d67437fee52c1f97bc19175644788b1d71afec2d87d405cf05424ce428f88ae3abe8e09e13ee55f2675534b38076ef70e1e583ed75686
+  checksum: 81d14bf63c4683fa03163320a0686ee34e67c4fba8525c26949cae42aae6020369a3263f01345ec456a8bc572ab762f85216d6700997ae9ef3eeecb7f3d8b28a
   languageName: node
   linkType: hard
 
@@ -2990,16 +2990,16 @@ __metadata:
   linkType: hard
 
 "editorconfig@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "editorconfig@npm:1.0.4"
+  version: 1.0.7
+  resolution: "editorconfig@npm:1.0.7"
   dependencies:
     "@one-ini/wasm": 0.1.1
     commander: ^10.0.0
-    minimatch: 9.0.1
+    minimatch: ^9.0.1
     semver: ^7.5.3
   bin:
     editorconfig: bin/editorconfig
-  checksum: 09904f19381b3ddf132cea0762971aba887236f387be3540909e96b8eb9337e1793834e10f06890cd8e8e7bb1ba80cb13e7d50a863f227806c9ca74def4165fb
+  checksum: 01418f7117a38fd770478f22076b09009f564b3543ed6c2cb2698a21bda4413d1a2bde156b8a71956dc44ccf2fa4546df0aed1da5b4a87cb60651f31193f7464
   languageName: node
   linkType: hard
 
@@ -5079,30 +5079,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:9.0.1":
-  version: 9.0.1
-  resolution: "minimatch@npm:9.0.1"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 97f5f5284bb57dc65b9415dec7f17a0f6531a33572193991c60ff18450dcfad5c2dad24ffeaf60b5261dccd63aae58cc3306e2209d57e7f88c51295a532d8ec3
-  languageName: node
-  linkType: hard
-
 "minimatch@npm:^10.2.1, minimatch@npm:^10.2.4":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
+  version: 10.2.6
+  resolution: "minimatch@npm:10.2.6"
   dependencies:
-    brace-expansion: ^5.0.2
-  checksum: 56dce6b04c6b30b500d81d7a29822c108b7d58c46696ec7332d04a2bd104a5cb69e5c7ce93e1783dc66d61400d831e6e226ca101ac23665aff32ca303619dc3d
+    brace-expansion: ^5.0.8
+  checksum: 6f3d0ba7654a6d667dc1787a3684192d65e130cbcf02c1b0cf0d0b2f7f69ab41703d4d255dc171632dc25994527a35fb6ea7d44cc6132e4d93de5a2efb210bd1
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 2c035575eda1e50623c731ec6c14f65a85296268f749b9337005210bb2b34e2705f8ef1a358b188f69892286ab99dc42c8fb98a57bde55c8d81b3023c19cea28
+    brace-expansion: ^2.0.2
+  checksum: 5292681ba1e14544ca9214ba5e412bb346214fb783354b22752f2d1e5c176e4a2c0bfcafeb1046389b816009ab73ba5410b176ce605632e8aa695db25f87f6b9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Lockfile-only bump clearing the outstanding minimatch / brace-expansion advisories.

```
minimatch        9.0.5 -> 9.0.9,  10.2.4 -> 10.2.6
brace-expansion  5.0.4 -> 5.0.9
editorconfig     1.0.4 -> 1.0.7
```

Reproduced entirely by `yarn up -R minimatch editorconfig`. No `package.json` changes.

### What was actually vulnerable

`brace-expansion@5.0.4` — minimatch's only dependency — was hit by five advisories:

| Advisory | Summary |
|---|---|
| GHSA-rgw5-rvv9-x895 | DoS via unbounded intermediate arrays |
| GHSA-mh99-v99m-4gvg | DoS via unbounded expansion length (OOM crash) |
| GHSA-3jxr-9vmj-r5cp | Exponential-time expansion of consecutive `{}` groups |
| GHSA-jxxr-4gwj-5jf2 | Large numeric range defeats documented `max` protection |
| GHSA-f886-m6hf-6m8v | Zero-step sequence hangs the process |

minimatch 9.0.5 was also affected by the three Feb 2026 ReDoS advisories (CVE-2026-26996 / -27903 / -27904), all requiring ≥9.0.7.

### Note on the Dependabot alerts

The two alerts that prompted this were both false positives:

- **minimatch** — alert cited a 3.x tree, but 3.x has not been in this lockfile since f54b3d0 (2026-03-23). Stale by ~5 months.
- **brace-expansion** — alert reported "earliest fixed is 5.0.9" against a 2.1.4 resolution, but 2.1.4 *is* the patched head of the `maintenance-v2` branch (GHSA-rgw5 lists `>=2.0.0 <2.1.4` → fixed 2.1.4).

In both cases Dependabot anchored to the highest-numbered fix in a multi-branch advisory rather than the branch range that applies. The real fix — brace-expansion 5.0.4 — was not what either alert named.

### Why editorconfig is included

`editorconfig@1.0.4` pinned `minimatch` to exactly `9.0.1`, which no range upgrade could dislodge, leaving a third stranded copy. `1.0.7` relaxes it to `^9.0.1` and sits inside js-beautify's existing `^1.0.4` range, so the pin dissolves without needing a `resolutions` override.

### Verification

`yarn install`, `yarn build`, `yarn lint:check` pass; 249 tests across 44 files pass. All four remaining resolutions (minimatch 9.0.9 / 10.2.6, brace-expansion 2.1.4 / 5.0.9) confirmed clean against the OSV API.

Out of scope and left for Dependabot: sweetalert2, markdown-it, ws, socket.io, express-session, body-parser, yaml, ip-address, socks, diff, bn.js, sharp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
