### PR TITLE
Bump ws to 8.21.3 via engine.io-client and socket.io-adapter

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2852,7 +2852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:~4.3.1, debug@npm:~4.3.2, debug@npm:~4.3.4":
+"debug@npm:~4.3.2":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
   dependencies:
@@ -3048,15 +3048,15 @@ __metadata:
   linkType: hard
 
 "engine.io-client@npm:~6.6.1":
-  version: 6.6.3
-  resolution: "engine.io-client@npm:6.6.3"
+  version: 6.6.6
+  resolution: "engine.io-client@npm:6.6.6"
   dependencies:
     "@socket.io/component-emitter": ~3.1.0
-    debug: ~4.3.1
+    debug: ~4.4.1
     engine.io-parser: ~5.2.1
-    ws: ~8.17.1
+    ws: ~8.21.0
     xmlhttprequest-ssl: ~2.1.1
-  checksum: 90aee334e8c699ab471d4eebc360afa0d59f763f47fee7ba6eaaf0610819ae46025a5f2205908ef031e82915a0590c481655cc84e429e43afaf8b12617c21221
+  checksum: 45c24e975866f3561fc3839e66648459314f7012cb5e1634af193d7680d1e5eda1ea954cef0b1b3bba19db50ec59e82f039e9647a03e04bafa97a9915dbefdcb
   languageName: node
   linkType: hard
 
@@ -6601,12 +6601,12 @@ __metadata:
   linkType: hard
 
 "socket.io-adapter@npm:~2.5.2":
-  version: 2.5.5
-  resolution: "socket.io-adapter@npm:2.5.5"
+  version: 2.5.8
+  resolution: "socket.io-adapter@npm:2.5.8"
   dependencies:
-    debug: ~4.3.4
-    ws: ~8.17.1
-  checksum: fc52253c31d5fec24abc9bcd8d6557545fd1604387c64328def142e9a3d31c92ee8635839d668454fcdc0e7bb0442e8655623879e07b127df12756c28ef7632e
+    debug: ~4.4.1
+    ws: ~8.21.0
+  checksum: 1d03c73dc160a196115efe85b9e673a413b4a80fa9363d4c46069f036d49855d7047cd558d72b06ae63dac55e4f3ade149a0c927c37faa2a7edf3b508f2ed1f9
   languageName: node
   linkType: hard
 
@@ -7719,37 +7719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.3":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: d64ef1631227bd0c5fe21b3eb3646c9c91229402fb963d12d87b49af0a1ef757277083af23a5f85742bae1e520feddfb434cb882ea59249b15673c16dc3f36e0
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.17.1":
-  version: 8.17.1
-  resolution: "ws@npm:8.17.1"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 442badcce1f1178ec87a0b5372ae2e9771e07c4929a3180321901f226127f252441e8689d765aa5cfba5f50ac60dd830954afc5aeae81609aefa11d3ddf5cecf
-  languageName: node
-  linkType: hard
-
-"ws@npm:~8.21.0":
+"ws@npm:^8.18.3, ws@npm:~8.21.0":
   version: 8.21.3
   resolution: "ws@npm:8.21.3"
   peerDependencies:


### PR DESCRIPTION
Resolves the Dependabot alert reporting that `ws` could not be updated to a non-vulnerable version ("the latest possible version that can be installed is 8.17.1; the earliest fixed version is 8.21.0").

## What was actually blocking it

The lockfile carried three copies of `ws`, two below the 8.21.0 fix line:

| `ws` | Pulled in by | Path |
|---|---|---|
| 8.17.1 ❌ | `engine.io-client@6.6.3` (`ws: ~8.17.1`) | `socket.io-client` → vue-client |
| 8.17.1 ❌ | `socket.io-adapter@2.5.5` (`ws: ~8.17.1`) | `socket.io` → server |
| 8.18.3 ❌ | `jsdom@27.4.0` (`ws: ^8.18.3`) | vue-client devDep |
| 8.21.3 ✅ | `engine.io@6.6.9` (`ws: ~8.21.0`) | already fixed by #534 |

The `~8.17.1` tilde ranges are what produced the 8.17.1 ceiling — a tilde pins the minor, so within those two parent versions there is genuinely no path to 8.21.0. That is what Dependabot was reporting.

However, both parents have since published patched releases that **already satisfy the ranges our tree declares** (`socket.io`'s `socket.io-adapter: ~2.5.2` and `socket.io-client`'s `engine.io-client: ~6.6.1`), so no manifest change is needed — only a lockfile re-resolution:

```
yarn up -R engine.io-client socket.io-adapter ws
```

## Changes

- `engine.io-client` 6.6.3 → **6.6.6** (`ws: ~8.21.0`)
- `socket.io-adapter` 2.5.5 → **2.5.8** (`ws: ~8.21.0`)
- All three `ws` entries collapse onto a single **8.21.3**
- `debug` entry consolidates (`~4.3.1`/`~4.3.4` → `~4.3.2`) as a side effect of those parents' own dep bumps

`yarn.lock` only — **no `package.json` changes**, 12 insertions / 42 deletions.

## Verification

- `yarn build` — clean across all three workspaces
- `yarn test` — 249 passing (206 shared / 39 server / 4 vue-client)
- Single `ws@npm:8.21.3` entry remains in the lockfile; all four `ws:` requesters now resolve to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
