### PR TITLE
Bump ip-address to 10.5.0 via socks

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,13 +4157,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "ip-address@npm:9.0.5"
-  dependencies:
-    jsbn: 1.1.0
-    sprintf-js: ^1.1.3
-  checksum: aa15f12cfd0ef5e38349744e3654bae649a34c3b10c77a674a167e99925d1549486c5b14730eebce9fea26f6db9d5e42097b00aa4f9f612e68c79121c71652dc
+"ip-address@npm:^10.1.1":
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: ffb64aea3ab0bf975b237954f89bf3c37cb5fc9d078cf5868408e54d29636d14618ed67dafcde664b3cdfc778ee78c811286cf67e59d1243a0c198d05aa47683
   languageName: node
   linkType: hard
 
@@ -4459,13 +4456,6 @@ __metadata:
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 8a95213a5a77deb6cbe94d86340e8d9ace2b93bc367790b260101d2f36a2eaf4e4e22d9fa9cf459b38af3a32fb4190e638024cf82ec95ef708680e405ea7cc78
-  languageName: node
-  linkType: hard
-
-"jsbn@npm:1.1.0":
-  version: 1.1.0
-  resolution: "jsbn@npm:1.1.0"
-  checksum: 944f924f2bd67ad533b3850eee47603eed0f6ae425fd1ee8c760f477e8c34a05f144c1bd4f5a5dd1963141dc79a2c55f89ccc5ab77d039e7077f3ad196b64965
   languageName: node
   linkType: hard
 
@@ -6659,12 +6649,12 @@ __metadata:
   linkType: hard
 
 "socks@npm:^2.7.1, socks@npm:^2.8.3":
-  version: 2.8.4
-  resolution: "socks@npm:2.8.4"
+  version: 2.8.9
+  resolution: "socks@npm:2.8.9"
   dependencies:
-    ip-address: ^9.0.5
+    ip-address: ^10.1.1
     smart-buffer: ^4.2.0
-  checksum: cd1edc924475d5dfde534adf66038df7e62c7343e6b8c0113e52dc9bb6a0a10e25b2f136197f379d695f18e8f0f2b7f6e42977bf720ddbee912a851201c396ad
+  checksum: b573ed4cfb935624d3688e7065cd03fd72ca258156923c9ebb9d462e545cd78f296b64a0e36f911b16326c94aabe2bf94ff405f8afef27ac7bf80fa3c971c6f6
   languageName: node
   linkType: hard
 
@@ -6681,13 +6671,6 @@ __metadata:
   dependencies:
     memory-pager: ^1.0.2
   checksum: 174da88dbbcc783d5dbd26921931cc83830280b8055fb05333786ebe6fc015b9601b24972b3d55920dd2d9f5fb120576fbfa2469b08e5222c9cadf3f05210aab
-  languageName: node
-  linkType: hard
-
-"sprintf-js@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "sprintf-js@npm:1.1.3"
-  checksum: a3fdac7b49643875b70864a9d9b469d87a40dfeaf5d34d9d0c5b1cda5fd7d065531fcb43c76357d62254c57184a7b151954156563a4d6a747015cfb41021cad0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves the Dependabot alert that reports "cannot update ip-address to a non-vulnerable version."

## Why Dependabot was stuck

`ip-address` is not a direct dependency. The only thing pulling it in is `socks`, pinned in the lockfile at 2.8.4, which declares `ip-address: ^9.0.5`. That caret range caps resolution at 9.0.5, so Dependabot — which only tries to bump `ip-address` itself — finds nothing in range that clears the advisory and gives up.

```
socks@2.8.4  ->  ip-address ^9.0.5     <- the cap
├── mongodb@5.9.2 (packages/server "mongodb": "^5.6.0")  -> socks ^2.7.1
└── socks-proxy-agent@8.0.5 -> @npmcli/agent -> make-fetch-happen -> node-gyp  -> socks ^2.8.3
```

`socks` loosened the range upstream in a patch release, not a major:

| socks | ip-address range |
|---|---|
| 2.8.4 – 2.8.6 | `^9.0.5` |
| **2.8.7** | `^10.0.1` |
| 2.8.8 – 2.8.9 | `^10.1.1` |

Both consumer ranges already permit 2.8.9, so this was a stale lockfile entry rather than a real constraint. No `package.json` change and no mongodb upgrade needed — just `yarn up -R socks`.

## Change

Lockfile-only, +8/-25:

- `socks` 2.8.4 -> 2.8.9
- `ip-address` 9.0.5 -> **10.5.0** (clears the 10.3.1 fix threshold)
- `jsbn@1.1.0` and `sprintf-js@1.1.3` drop out of the tree — ip-address 10 has no dependencies

## Verification

- `yarn build` — clean across shared, server, and vue-client
- `yarn test` — 249 tests / 44 files passing (shared 206, server 4, vue-client 39)

🤖 Generated with [Claude Code](https://claude.com/claude-code)