### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/govariantsteam/govariants/security/code-scanning/13](https://github.com/govariantsteam/govariants/security/code-scanning/13)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is scoped to least privilege.  
Best fix here: define workflow-level permissions directly under `on:` (or before `jobs:`), with:

- `contents: read`

This applies to all jobs unless overridden, preserves existing behavior, and satisfies CodeQL’s recommendation without granting unnecessary write scopes.

Modify only `.github/workflows/node.js.yml` by inserting the new `permissions` section between the trigger (`on:`) and `jobs:` blocks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
