### PR TITLE
Rate-limit auth routes and SPA fallback

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,6 +26,7 @@
     "@types/passport-local": "^1.0.35",
     "connect-mongo": "^5.0.0",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.6.2",
     "express-session": "^1.17.3",
     "glicko2": "^1.2.1",
     "migrate-mongo": "^12.1.3",

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -43,6 +43,7 @@ import { io } from "./socket_io";
 import { checkCSRFToken, generateCSRFToken } from "./csrf_guard";
 import { sendEmail } from "./email";
 import { HttpError } from "./http-error";
+import { authLimiter } from "./rate_limit";
 import {
   clearNotifications,
   getUserNotifications,
@@ -169,7 +170,7 @@ router.post("/games/:gameId/leave/:seat", checkCSRFToken, async (req, res) => {
   res.send(players);
 });
 
-router.post("/register", async (req, res, next) => {
+router.post("/register", authLimiter, async (req, res, next) => {
   const { username, password, email } = req.body;
   const user = await getUserByName(username);
   if (user) {
@@ -311,11 +312,11 @@ function make_auth_cb(
   }) as AuthenticateCallback; // Cast needed: we narrow passport's `any` params to stricter types
 }
 
-router.post("/login", (req, res, next) => {
+router.post("/login", authLimiter, (req, res, next) => {
   passport.authenticate("local", make_auth_cb(req, res))(req, res, next);
 });
 
-router.get("/guestLogin", function (req, res, next) {
+router.get("/guestLogin", authLimiter, function (req, res, next) {
   passport.authenticate("guest", make_auth_cb(req, res))(req, res, next);
 });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -88,13 +88,30 @@ passport.deserializeUser<string>(function (id, callback) {
     });
 });
 
+function parseTrustProxy(value: string | undefined): number | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  const hops = Number(value);
+  if (!Number.isInteger(hops)) {
+    throw new Error(
+      `TRUST_PROXY must be a whole number of proxy hops; got "${value}"`,
+    );
+  }
+  return hops;
+}
+
 // initialize Express
 const app = express();
-// In production we sit behind a single reverse proxy, so trust exactly one hop:
-// req.ip must be the client address for rate limiting to key on the right party
-// (and for the session cookie's `secure: "auto"` to detect HTTPS).
-if (process.env.NODE_ENV === "production") {
-  app.set("trust proxy", 1);
+// Behind a reverse proxy, req.ip is the proxy's address unless Express is told
+// how far to trust X-Forwarded-For. That matters for rate limiting (every
+// client would otherwise share one bucket) and for the session cookie's
+// `secure: "auto"` HTTPS detection. Deployments that sit behind a proxy set
+// TRUST_PROXY to the number of hops ("1"); leave it unset when serving
+// directly, as in development.
+const trustProxy = parseTrustProxy(process.env.TRUST_PROXY);
+if (trustProxy !== undefined) {
+  app.set("trust proxy", trustProxy);
 }
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,6 +20,7 @@ import * as socket_io from "./socket_io";
 import { validateSeatSubscription } from "./socket_validation";
 import { ITimeoutService, TimeoutService } from "./time-control/timeout";
 import { HttpError } from "./http-error";
+import { staticLimiter } from "./rate_limit";
 
 const LOCAL_ORIGIN = [
   "http://127.0.0.1:5173",
@@ -89,6 +90,12 @@ passport.deserializeUser<string>(function (id, callback) {
 
 // initialize Express
 const app = express();
+// In production we sit behind a single reverse proxy, so trust exactly one hop:
+// req.ip must be the client address for rate limiting to key on the right party
+// (and for the session cookie's `secure: "auto"` to detect HTTPS).
+if (process.env.NODE_ENV === "production") {
+  app.set("trust proxy", 1);
+}
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 const sessionMiddleware = session({
@@ -163,7 +170,7 @@ if (isProd) {
   // Setup build path as a static assets path
   app.use(express.static(build_path));
   // Serve index.html on unmatched routes
-  app.get("/{*splat}", (_req, res) => res.sendFile(indexHtml));
+  app.get("/{*splat}", staticLimiter, (_req, res) => res.sendFile(indexHtml));
 }
 
 // Centralized error handler — Express 5 forwards rejected promises from async

--- a/packages/server/src/rate_limit.ts
+++ b/packages/server/src/rate_limit.ts
@@ -3,25 +3,39 @@ import rateLimit from "express-rate-limit";
 const FIFTEEN_MINUTES = 15 * 60 * 1000;
 
 /**
+ * Counts hits in memory, which assumes we run as a single process. Scaling out
+ * would need a shared store rather than different numbers.
+ */
+function rateLimitWithJsonError(limit: number, message: string) {
+  return rateLimit({
+    windowMs: FIFTEEN_MINUTES,
+    limit,
+    standardHeaders: "draft-7",
+    legacyHeaders: false,
+    // Match the rest of the API's error shape — a bare JSON string — instead
+    // of express-rate-limit's default plain-text body, so clients can parse
+    // every error response the same way.
+    handler: (_req, res, _next, options) => {
+      res.status(options.statusCode).json(message);
+    },
+  });
+}
+
+/**
  * Strict limiter for authentication endpoints (login, registration, guest
  * login). These are the endpoints worth brute-forcing, so the budget is small.
  */
-export const authLimiter = rateLimit({
-  windowMs: FIFTEEN_MINUTES,
-  limit: 30,
-  standardHeaders: "draft-7",
-  legacyHeaders: false,
-  message: "Too many authentication attempts, please try again later.",
-});
+export const authLimiter = rateLimitWithJsonError(
+  30,
+  "Too many authentication attempts, please try again later.",
+);
 
 /**
  * Generous limiter for the single-page-app fallback route, which reads
  * index.html off disk. Only unmatched routes reach it — static assets are
  * served by express.static — so normal browsing costs a handful of requests.
  */
-export const staticLimiter = rateLimit({
-  windowMs: FIFTEEN_MINUTES,
-  limit: 1000,
-  standardHeaders: "draft-7",
-  legacyHeaders: false,
-});
+export const staticLimiter = rateLimitWithJsonError(
+  1000,
+  "Too many requests, please try again later.",
+);

--- a/packages/server/src/rate_limit.ts
+++ b/packages/server/src/rate_limit.ts
@@ -1,0 +1,27 @@
+import rateLimit from "express-rate-limit";
+
+const FIFTEEN_MINUTES = 15 * 60 * 1000;
+
+/**
+ * Strict limiter for authentication endpoints (login, registration, guest
+ * login). These are the endpoints worth brute-forcing, so the budget is small.
+ */
+export const authLimiter = rateLimit({
+  windowMs: FIFTEEN_MINUTES,
+  limit: 30,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  message: "Too many authentication attempts, please try again later.",
+});
+
+/**
+ * Generous limiter for the single-page-app fallback route, which reads
+ * index.html off disk. Only unmatched routes reach it — static assets are
+ * served by express.static — so normal browsing costs a handful of requests.
+ */
+export const staticLimiter = rateLimit({
+  windowMs: FIFTEEN_MINUTES,
+  limit: 1000,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,7 @@ __metadata:
     connect-mongo: ^5.0.0
     eslint: ^10
     express: ^5.2.1
+    express-rate-limit: ^8.6.2
     express-session: ^1.17.3
     glicko2: ^1.2.1
     migrate-mongo: ^12.1.3
@@ -3241,6 +3242,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.6.2":
+  version: 8.6.2
+  resolution: "express-rate-limit@npm:8.6.2"
+  dependencies:
+    debug: ^4.4.3
+    ip-address: ^10.2.0
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 3fb4658eb38a4a9d2aaa36791ac0d080efdba238aa9d0339eb17379c0936c649463e484a273b5ce4a4a6029a2c91062aedb2394a09d464998cf32a486d9cd518
+  languageName: node
+  linkType: hard
+
 "express-session@npm:^1.17.3":
   version: 1.19.0
   resolution: "express-session@npm:1.19.0"
@@ -3948,7 +3961,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
+"ip-address@npm:^10.1.1, ip-address@npm:^10.2.0":
   version: 10.5.0
   resolution: "ip-address@npm:10.5.0"
   checksum: ffb64aea3ab0bf975b237954f89bf3c37cb5fc9d078cf5868408e54d29636d14618ed67dafcde664b3cdfc778ee78c811286cf67e59d1243a0c198d05aa47683


### PR DESCRIPTION
Clears all four open `js/missing-rate-limiting` code scanning alerts.

| Alert | Location | Route |
|---|---|---|
| #17 | `packages/server/src/api.ts:172` | `POST /register` |
| #4 | `packages/server/src/api.ts:314` | `POST /login` |
| #5 | `packages/server/src/api.ts:318` | `GET /guestLogin` |
| #23 | `packages/server/src/index.ts:166` | SPA catch-all `res.sendFile` |

## What changed

New `packages/server/src/rate_limit.ts` with two `express-rate-limit` limiters:

- **`authLimiter`** — 30 requests / 15 min, on the three authentication endpoints. These are the ones worth brute-forcing, so the budget is small.
- **`staticLimiter`** — 1000 requests / 15 min, on the production SPA fallback. Only requests that miss both the `/api` router and `express.static` reach it, so normal browsing costs a handful of requests.

Both send their 429 as a bare JSON string, matching every other error response in the API, rather than express-rate-limit's default plain-text body.

## Beyond the alerts

Also makes Express's `trust proxy` setting configurable. We run behind a reverse proxy, so without it `req.ip` is the proxy's address and every client shares a single rate-limit bucket — the limiter would be worse than useless. Side benefit: the session cookie's `secure: "auto"` correctly detects HTTPS.

## ⚠️ Deploy note: set `TRUST_PROXY` before merging

The hop count comes from a new **`TRUST_PROXY`** environment variable, and there is no `NODE_ENV` fallback. **Production needs `TRUST_PROXY=1` set in its environment**, otherwise this merges into the one-bucket-for-everyone behavior described above.

- Set it to the number of proxy hops in front of the server — `1` for our current setup.
- Leave it unset anywhere that serves directly, including local dev; the setting is then skipped entirely.
- Only a whole number is accepted. Anything else throws at startup, so a typo fails loudly instead of silently trusting nothing. (Env vars are strings, and Express reads a string as a list of trusted addresses — `"1"` parses as `0.0.0.1`, which would boot fine and match nothing.)

## Worth a look

- **The specific limits.** 30/15min for auth is fairly tight — a user fumbling their password is fine, but shared-NAT traffic could bunch up.
- **The hop count.** `TRUST_PROXY=1` assumes exactly one proxy in front of us.
- **Single-process assumption.** The limiters use the default in-memory store, so counters are per process; scaling out horizontally would need a shared store.

Build, lint, and all 39 server tests pass. No existing test hits the auth routes, so the limits don't interfere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
