### PR TITLE
Persist immediate submit preference in localStorage

### DIFF
--- a/packages/vue-client/src/local_storage_keys.ts
+++ b/packages/vue-client/src/local_storage_keys.ts
@@ -1,0 +1,6 @@
+// Keys for preferences we keep in the browser rather than on the user account.
+// These are per-device by design: someone's answer on their phone may differ
+// from their answer on desktop.
+export const LOCAL_STORAGE_KEYS = {
+  immediateSubmit: "govariants:immediate-submit",
+} as const;

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -20,6 +20,7 @@ import {
   getMovePreview,
 } from "@govariants/shared";
 import { computed, ref, watch, watchEffect, type Ref } from "vue";
+import { useLocalStorage } from "@vueuse/core";
 import { socket } from "../requests";
 import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
@@ -71,7 +72,13 @@ const adminMode = ref<boolean>(false);
 const creator = ref<User | undefined>();
 const subscription = ref<NotificationType[]>([]);
 
-const userEnabledImmediateSubmit = ref(false);
+// This is a client-specific preference: someone may want immediate submit
+// on desktop but not on their phone, so it lives in localStorage rather
+// than on the user account.
+const userEnabledImmediateSubmit = useLocalStorage(
+  "govariants:immediate-submit",
+  false,
+);
 const doesVariantSupportsMovePreview = computed(() => {
   if (variant.value && game_state.value) {
     return variantSupportsMovePreview(variant.value);
@@ -82,6 +89,14 @@ const movePreview = ref<{ move: string; player: number } | null>(null);
 function clearMovePreview() {
   movePreview.value = null;
 }
+
+// A pending preview can't be submitted or cancelled once immediate submit is
+// on (both buttons are disabled), so drop it when the setting is switched on.
+watch(userEnabledImmediateSubmit, (enabled) => {
+  if (enabled) {
+    clearMovePreview();
+  }
+});
 
 function setNewState(stateResponse: GameStateResponse): void {
   const { timeControl: timeControl, ...state } = stateResponse;

--- a/packages/vue-client/src/views/GameView.vue
+++ b/packages/vue-client/src/views/GameView.vue
@@ -21,6 +21,7 @@ import {
 } from "@govariants/shared";
 import { computed, ref, watch, watchEffect, type Ref } from "vue";
 import { useLocalStorage } from "@vueuse/core";
+import { LOCAL_STORAGE_KEYS } from "@/local_storage_keys";
 import { socket } from "../requests";
 import NavButtons from "@/components/GameView/NavButtons.vue";
 import PlayersToMove from "@/components/GameView/PlayersToMove.vue";
@@ -72,11 +73,8 @@ const adminMode = ref<boolean>(false);
 const creator = ref<User | undefined>();
 const subscription = ref<NotificationType[]>([]);
 
-// This is a client-specific preference: someone may want immediate submit
-// on desktop but not on their phone, so it lives in localStorage rather
-// than on the user account.
 const userEnabledImmediateSubmit = useLocalStorage(
-  "govariants:immediate-submit",
+  LOCAL_STORAGE_KEYS.immediateSubmit,
   false,
 );
 const doesVariantSupportsMovePreview = computed(() => {


### PR DESCRIPTION
## Summary

The "immediate submit" checkbox in `GameView` reset on every page load. This stores it in `localStorage` so it sticks.

`localStorage` rather than the user account is deliberate: this is a client-specific preference, and someone's answer on their phone may differ from their answer on desktop.

## Also included: a small pre-existing bug fix

Added a `watch` that drops the preview when "immediately submit" is switched on.

## Testing

Ensure it's sticky

1) go to a game
2) enable **immediate submit**
3) leave page, come back
4) ensure it's still set to **immediate submit**
5) do the same for **immediate submit OFF**

Ensure immediate submit clears any pending move

1) go to game
2) stage a move
3) enable **immediate submit**, observe move is no longer staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)