### PR TITLE
Add a Dimensions class

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export * from "./abstract_game";
 export * from "./variant_map";
 export * from "./api_types";
 export * from "./lib/grid";
+export * from "./lib/dimensions";
 export * from "./lib/coordinate";
 export * from "./lib/grid_compat";
 export * from "./lib/board_types";

--- a/packages/shared/src/lib/__tests__/dimensions.test.ts
+++ b/packages/shared/src/lib/__tests__/dimensions.test.ts
@@ -1,0 +1,96 @@
+import { Coordinate } from "../coordinate";
+import { Dimensions } from "../dimensions";
+
+test("constructor", () => {
+  const dims = new Dimensions(2, 3);
+  expect(dims.width).toBe(2);
+  expect(dims.height).toBe(3);
+  expect(dims.area).toBe(6);
+});
+
+test("constructor rejects negative dimensions", () => {
+  expect(() => new Dimensions(-1, 3)).toThrow();
+  expect(() => new Dimensions(2, -1)).toThrow();
+});
+
+test("from", () => {
+  expect(Dimensions.from({ width: 2, height: 3 })).toEqual(
+    new Dimensions(2, 3),
+  );
+});
+
+test("isInBounds", () => {
+  const dims = new Dimensions(3, 4);
+
+  expect(dims.isInBounds({ x: 1, y: 2 })).toBe(true);
+  expect(dims.isInBounds({ x: 0, y: 0 })).toBe(true);
+  expect(dims.isInBounds({ x: 2, y: 3 })).toBe(true);
+
+  expect(dims.isInBounds({ x: 3, y: 2 })).toBe(false);
+  expect(dims.isInBounds({ x: 1, y: 4 })).toBe(false);
+  expect(dims.isInBounds({ x: -1, y: 2 })).toBe(false);
+  expect(dims.isInBounds({ x: 1, y: -1 })).toBe(false);
+});
+
+test("neighbors", () => {
+  const dims = new Dimensions(3, 4);
+
+  expect(dims.neighbors({ x: 1, y: 2 })).toEqual([
+    new Coordinate(1, 1),
+    new Coordinate(1, 3),
+    new Coordinate(0, 2),
+    new Coordinate(2, 2),
+  ]);
+
+  // corner
+  expect(dims.neighbors({ x: 0, y: 0 })).toEqual([
+    new Coordinate(0, 1),
+    new Coordinate(1, 0),
+  ]);
+
+  // out of bounds
+  expect(dims.neighbors({ x: 3, y: 0 })).toEqual([]);
+});
+
+test("flat index round trip", () => {
+  const dims = new Dimensions(3, 4);
+
+  expect(dims.toFlatIndex({ x: 2, y: 1 })).toBe(5);
+  expect(dims.fromFlatIndex(5)).toEqual(new Coordinate(2, 1));
+
+  dims.forEach((index) => {
+    expect(dims.fromFlatIndex(dims.toFlatIndex(index))).toEqual(index);
+  });
+});
+
+test("resolveNegativeIndices", () => {
+  const dims = new Dimensions(3, 4);
+
+  expect(dims.resolveNegativeIndices({ x: -1, y: -2 })).toEqual(
+    new Coordinate(2, 2),
+  );
+  expect(dims.resolveNegativeIndices({ x: 1, y: 2 })).toEqual(
+    new Coordinate(1, 2),
+  );
+});
+
+test("forEach visits every coordinate in row-major order", () => {
+  const visited: Coordinate[] = [];
+  new Dimensions(2, 3).forEach((index) => visited.push(index));
+
+  expect(visited).toEqual([
+    new Coordinate(0, 0),
+    new Coordinate(1, 0),
+    new Coordinate(0, 1),
+    new Coordinate(1, 1),
+    new Coordinate(0, 2),
+    new Coordinate(1, 2),
+  ]);
+});
+
+test("equals", () => {
+  const dims = new Dimensions(2, 3);
+
+  expect(dims.equals({ width: 2, height: 3 })).toBe(true);
+  expect(dims.equals({ width: 3, height: 2 })).toBe(false);
+});

--- a/packages/shared/src/lib/__tests__/hoshi.test.ts
+++ b/packages/shared/src/lib/__tests__/hoshi.test.ts
@@ -1,7 +1,7 @@
 import { getHoshi } from "../hoshi";
 
 test("19x19 has the standard star points", () => {
-  const hoshi = getHoshi(19, 19);
+  const hoshi = getHoshi({ width: 19, height: 19 });
   hoshi.sort((a, b) => {
     if (a.x === b.x) {
       return a.y - b.y;

--- a/packages/shared/src/lib/dimensions.ts
+++ b/packages/shared/src/lib/dimensions.ts
@@ -1,0 +1,90 @@
+import { Coordinate, type CoordinateLike } from "./coordinate";
+
+export interface DimensionsLike {
+  width: number;
+  height: number;
+}
+
+/**
+ * The width and height of a rectangular board, along with the calculations
+ * that depend on nothing else.
+ *
+ * Use this instead of a Grid when the values stored at each intersection are
+ * irrelevant - creating a Dimensions does not allocate an array.
+ */
+export class Dimensions implements DimensionsLike {
+  constructor(
+    public readonly width: number,
+    public readonly height: number,
+  ) {
+    if (width < 0) {
+      throw new Error(`Invalid width: ${width}`);
+    }
+    if (height < 0) {
+      throw new Error(`Invalid height: ${height}`);
+    }
+  }
+
+  static from({ width, height }: DimensionsLike): Dimensions {
+    return new Dimensions(width, height);
+  }
+
+  /** The number of intersections on the board. */
+  get area(): number {
+    return this.width * this.height;
+  }
+
+  isInBounds({ x, y }: CoordinateLike): boolean {
+    return x >= 0 && y >= 0 && x < this.width && y < this.height;
+  }
+
+  /** @returns the in-bounds orthogonal neighbors of index, or [] if index itself
+   * is out of bounds.
+   */
+  neighbors({ x, y }: CoordinateLike): Coordinate[] {
+    if (!this.isInBounds({ x, y })) {
+      // An alternative is to return edge points for some out-of-bounds inputs,
+      // but our floodfill algorithms depend on an empty array here.
+      return [];
+    }
+    return [
+      new Coordinate(x, y - 1),
+      new Coordinate(x, y + 1),
+      new Coordinate(x - 1, y),
+      new Coordinate(x + 1, y),
+    ].filter((index) => this.isInBounds(index));
+  }
+
+  /** @returns the index of a coordinate in a row-major flat array. */
+  toFlatIndex({ x, y }: CoordinateLike): number {
+    return y * this.width + x;
+  }
+
+  /** @returns the coordinate at an index of a row-major flat array. */
+  fromFlatIndex(index: number): Coordinate {
+    return new Coordinate(index % this.width, Math.floor(index / this.width));
+  }
+
+  /** If a component of index is negative, count from the end of that row or
+   * column, as Array.prototype.at does.
+   */
+  resolveNegativeIndices({ x, y }: CoordinateLike): Coordinate {
+    return new Coordinate(
+      x < 0 ? this.width + x : x,
+      y < 0 ? this.height + y : y,
+    );
+  }
+
+  /** Calls f on every coordinate of the board, in row-major order. */
+  forEach(f: (index: Coordinate) => void): void {
+    for (let y = 0; y < this.height; ++y) {
+      for (let x = 0; x < this.width; ++x) {
+        f(new Coordinate(x, y));
+      }
+    }
+  }
+
+  equals(other: DimensionsLike): boolean {
+    return this.width === other.width && this.height === other.height;
+  }
+}

--- a/packages/shared/src/lib/grid.ts
+++ b/packages/shared/src/lib/grid.ts
@@ -1,4 +1,5 @@
 import { Coordinate, type CoordinateLike } from "./coordinate";
+import { Dimensions } from "./dimensions";
 import { Fillable } from "./group_utils";
 
 /**
@@ -7,40 +8,38 @@ import { Fillable } from "./group_utils";
  */
 export class Grid<T> implements Fillable<CoordinateLike, T> {
   private arr: Array<T>;
-  constructor(
-    public readonly width: number,
-    public readonly height: number,
-  ) {
-    if (width < 0) {
-      throw new Error("Invalid array width");
-    }
+  public readonly dims: Dimensions;
 
-    this.arr = new Array(width * height);
+  constructor(width: number, height: number) {
+    this.dims = new Dimensions(width, height);
+    this.arr = new Array(this.dims.area);
+  }
+
+  get width(): number {
+    return this.dims.width;
+  }
+
+  get height(): number {
+    return this.dims.height;
   }
 
   at(index: CoordinateLike): T | undefined {
-    const w = this.width;
-    const h = this.height;
-
-    index = handleNegativeIndices(index, w, h);
+    index = this.dims.resolveNegativeIndices(index);
 
     if (!this.isInBounds(index)) {
       return undefined;
     }
-    return this.arr[coordinate_to_flat_index(index, w)];
+    return this.arr[this.dims.toFlatIndex(index)];
   }
 
   set(index: CoordinateLike, value: T): void {
-    const w = this.width;
-    const h = this.height;
-
-    index = handleNegativeIndices(index, w, h);
+    index = this.dims.resolveNegativeIndices(index);
 
     if (!this.isInBounds(index)) {
       return;
     }
 
-    this.arr[coordinate_to_flat_index(index, w)] = value;
+    this.arr[this.dims.toFlatIndex(index)] = value;
   }
 
   map<S>(
@@ -50,11 +49,7 @@ export class Grid<T> implements Fillable<CoordinateLike, T> {
     const ret = new Grid<S>(this.width, this.height);
     ret.arr = this.arr.map(
       (value: T, flat_index: number) =>
-        callbackfn(
-          value,
-          flat_index_to_coordinate(flat_index, this.width),
-          this,
-        ),
+        callbackfn(value, this.dims.fromFlatIndex(flat_index), this),
       thisArg,
     );
     return ret;
@@ -65,7 +60,7 @@ export class Grid<T> implements Fillable<CoordinateLike, T> {
     thisArg?: this,
   ): void {
     this.arr.forEach((value: T, flat_index: number) => {
-      callbackfn(value, flat_index_to_coordinate(flat_index, this.width), this);
+      callbackfn(value, this.dims.fromFlatIndex(flat_index), this);
     }, thisArg);
   }
 
@@ -103,25 +98,12 @@ export class Grid<T> implements Fillable<CoordinateLike, T> {
     return this;
   }
 
-  neighbors(index: CoordinateLike) {
-    if (!this.isInBounds(index)) {
-      // An alternative is to return edge points for some out-of-bounds inputs,
-      // but our floodfill algorithms depend on an empty array here.
-      return [];
-    }
-    const { x, y } = index;
-    return [
-      { x, y: y - 1 },
-      { x, y: y + 1 },
-      { x: x - 1, y },
-      { x: x + 1, y },
-    ].filter((index) => this.isInBounds(index));
+  neighbors(index: CoordinateLike): Coordinate[] {
+    return this.dims.neighbors(index);
   }
 
-  isInBounds({ x, y }: CoordinateLike) {
-    const w = this.width;
-    const h = this.height;
-    return x < w && y < h && x >= 0 && y >= 0;
+  isInBounds(index: CoordinateLike): boolean {
+    return this.dims.isInBounds(index);
   }
 
   reduce<OutT>(
@@ -138,7 +120,7 @@ export class Grid<T> implements Fillable<CoordinateLike, T> {
         callbackfn(
           previousValue,
           currentValue,
-          flat_index_to_coordinate(flat_index, this.width),
+          this.dims.fromFlatIndex(flat_index),
           this,
         ),
       initialValue,
@@ -148,31 +130,4 @@ export class Grid<T> implements Fillable<CoordinateLike, T> {
   serialize() {
     return this.to2DArray();
   }
-}
-
-function flat_index_to_coordinate(index: number, width: number): Coordinate {
-  return new Coordinate(index % width, Math.floor(index / width));
-}
-
-function coordinate_to_flat_index(
-  { x, y }: CoordinateLike,
-  width: number,
-): number {
-  return y * width + x;
-}
-
-/** If index is negative, count from the end of the row or column. */
-function handleNegativeIndices(
-  { x, y }: CoordinateLike,
-  w: number,
-  h: number,
-): Coordinate {
-  // Backwards indexing
-  if (x < 0) {
-    x = w + x;
-  }
-  if (y < 0) {
-    y = h + y;
-  }
-  return new Coordinate(x, y);
 }

--- a/packages/shared/src/lib/hoshi.ts
+++ b/packages/shared/src/lib/hoshi.ts
@@ -23,9 +23,10 @@ SOFTWARE.
 */
 
 import { Coordinate } from "./coordinate";
+import { type DimensionsLike } from "./dimensions";
 
 /** @returns the coordinates of the hoshi for a given board size */
-export function getHoshi(width: number, height: number): Coordinate[] {
+export function getHoshi({ width, height }: DimensionsLike): Coordinate[] {
   const ret: Coordinate[] = [];
   const addStar = (i: number, j: number) =>
     // We subtract one here because the BesoGo implementation is 1-indexed

--- a/packages/shared/src/variants/__tests__/baduk_utils.test.ts
+++ b/packages/shared/src/variants/__tests__/baduk_utils.test.ts
@@ -1,0 +1,58 @@
+import { isInBounds } from "../baduk_utils";
+
+const at = (x: number, y = 0) => ({ x, y });
+
+test("isInBounds on a grid board", () => {
+  const config = {
+    komi: 6.5,
+    board: { type: "grid" as const, width: 3, height: 4 },
+  };
+
+  expect(isInBounds(config, at(1, 2))).toBe(true);
+  expect(isInBounds(config, at(2, 3))).toBe(true);
+
+  expect(isInBounds(config, at(3, 2))).toBe(false);
+  expect(isInBounds(config, at(1, 4))).toBe(false);
+  expect(isInBounds(config, at(-1, 2))).toBe(false);
+});
+
+test("isInBounds on a legacy grid config", () => {
+  const config = { komi: 6.5, width: 3, height: 4 };
+
+  expect(isInBounds(config, at(1, 2))).toBe(true);
+  expect(isInBounds(config, at(3, 2))).toBe(false);
+});
+
+test("isInBounds on a graph board", () => {
+  // sierpinsky size 3 has 123 intersections, which estimateNodeCount reports
+  // exactly.
+  const config = {
+    komi: 6.5,
+    board: { type: "sierpinsky" as const, size: 3 },
+  };
+
+  expect(isInBounds(config, at(0))).toBe(true);
+  expect(isInBounds(config, at(122))).toBe(true);
+
+  expect(isInBounds(config, at(123))).toBe(false);
+  expect(isInBounds(config, at(-1))).toBe(false);
+  // graph boards pack their index into x, so a nonzero y is never on the board
+  expect(isInBounds(config, at(0, 1))).toBe(false);
+});
+
+test("isInBounds on a graph board whose intersections are shared", () => {
+  // trihexagonal size 5 has 12 intersections, but estimateNodeCount only
+  // bounds it at 25 - both sides of that gap must be out of bounds.
+  const config = {
+    komi: 6.5,
+    board: { type: "trihexagonal" as const, size: 5 },
+  };
+
+  expect(isInBounds(config, at(11))).toBe(true);
+
+  // below the estimate, so this needs the exact count
+  expect(isInBounds(config, at(12))).toBe(false);
+  // at and above the estimate, rejected without laying the board out
+  expect(isInBounds(config, at(25))).toBe(false);
+  expect(isInBounds(config, at(1000))).toBe(false);
+});

--- a/packages/shared/src/variants/baduk_utils.ts
+++ b/packages/shared/src/variants/baduk_utils.ts
@@ -2,8 +2,11 @@ import {
   BoardConfig,
   BoardPattern,
   GridBoardConfig,
+  createBoard,
 } from "../lib/abstractBoard/boardFactory";
+import { Intersection } from "../lib/abstractBoard/intersection";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";
+import { Dimensions } from "../lib/dimensions";
 import { Grid } from "../lib/grid";
 import { BadukConfig } from "./baduk";
 
@@ -38,6 +41,26 @@ export function getWidthAndHeight(config: GridBadukConfig): {
   const width = "board" in config ? config.board.width : config.width;
   const height = "board" in config ? config.board.height : config.height;
   return { width: width, height: height };
+}
+
+/** @returns whether index refers to an intersection of the board described by
+ * config.
+ */
+export function isInBounds(
+  config: BadukConfig,
+  index: CoordinateLike,
+): boolean {
+  if (isGridBadukConfig(config)) {
+    return Dimensions.from(getWidthAndHeight(config)).isInBounds(index);
+  }
+  // Graph boards are indexed by a single number, packed into the x coordinate.
+  // Their intersections aren't described by a width and height, so the only
+  // way to count them is to lay the board out.
+  return (
+    index.y === 0 &&
+    index.x >= 0 &&
+    index.x < createBoard(config.board, Intersection).length
+  );
 }
 
 export function isLegacyBadukConfig(

--- a/packages/shared/src/variants/baduk_utils.ts
+++ b/packages/shared/src/variants/baduk_utils.ts
@@ -3,6 +3,7 @@ import {
   BoardPattern,
   GridBoardConfig,
   createBoard,
+  estimateNodeCount,
 } from "../lib/abstractBoard/boardFactory";
 import { Intersection } from "../lib/abstractBoard/intersection";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";
@@ -54,13 +55,17 @@ export function isInBounds(
     return Dimensions.from(getWidthAndHeight(config)).isInBounds(index);
   }
   // Graph boards are indexed by a single number, packed into the x coordinate.
-  // Their intersections aren't described by a width and height, so the only
-  // way to count them is to lay the board out.
-  return (
-    index.y === 0 &&
-    index.x >= 0 &&
-    index.x < createBoard(config.board, Intersection).length
-  );
+  if (index.y !== 0 || index.x < 0) {
+    return false;
+  }
+  // estimateNodeCount never undercounts, so anything at or past it is out of
+  // bounds without having to look at the board.
+  if (index.x >= estimateNodeCount(config.board)) {
+    return false;
+  }
+  // Some shapes share or filter out intersections, so below the estimate the
+  // only exact count is the one we get by laying the board out.
+  return index.x < createBoard(config.board, Intersection).length;
 }
 
 export function isLegacyBadukConfig(

--- a/packages/shared/src/variants/parallel.ts
+++ b/packages/shared/src/variants/parallel.ts
@@ -205,12 +205,7 @@ export class ParallelGo extends AbstractGame<
   }
 
   private isOutOfBounds(pos: Coordinate) {
-    return (
-      pos.x < 0 ||
-      pos.y < 0 ||
-      pos.x >= this.board.width ||
-      pos.y >= this.board.height
-    );
+    return !this.board.dims.isInBounds(pos);
   }
 
   private removeGroupsIf(predicate: (group: Group) => boolean) {

--- a/packages/shared/src/variants/quantum.ts
+++ b/packages/shared/src/variants/quantum.ts
@@ -1,7 +1,6 @@
 import { AbstractGame } from "../abstract_game";
 import { BoardPattern } from "../lib/abstractBoard/boardFactory";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";
-import { Dimensions } from "../lib/dimensions";
 import { quantumRulesDescription } from "../templates/quantum_rules";
 import { Variant } from "../variant";
 import { Baduk, BadukBoard, BadukConfig, badukVariant, Color } from "./baduk";
@@ -10,6 +9,7 @@ import {
   NewGridBadukConfig,
   getWidthAndHeight,
   isGridBadukConfig,
+  isInBounds,
   isLegacyBadukConfig,
   mapToNewConfig,
 } from "./baduk_utils";
@@ -78,18 +78,6 @@ export class QuantumGo extends AbstractGame<NewBadukConfig, QuantumGoState> {
     return new Coordinate(Number(move), 0);
   }
 
-  private isInBounds(pos: CoordinateLike): boolean {
-    if (isGridBadukConfig(this.config)) {
-      return Dimensions.from(getWidthAndHeight(this.config)).isInBounds(pos);
-    }
-    // Graph boards have no width and height - only the board itself knows
-    // which nodes exist.
-    return new BadukHelper({
-      ...this.config,
-      komi: 0,
-    }).badukGame.board.isInBounds(pos);
-  }
-
   private encodeMove(pos: Coordinate): string {
     if (isGridBadukConfig(this.config)) {
       return pos.toSgfRepr();
@@ -134,7 +122,7 @@ export class QuantumGo extends AbstractGame<NewBadukConfig, QuantumGoState> {
     }
 
     const pos = this.decodeMove(move);
-    if (!this.isInBounds(pos)) {
+    if (!isInBounds(this.config, pos)) {
       throw new Error("Out of bounds!");
     }
 

--- a/packages/shared/src/variants/quantum.ts
+++ b/packages/shared/src/variants/quantum.ts
@@ -1,6 +1,7 @@
 import { AbstractGame } from "../abstract_game";
 import { BoardPattern } from "../lib/abstractBoard/boardFactory";
 import { Coordinate, CoordinateLike } from "../lib/coordinate";
+import { Dimensions } from "../lib/dimensions";
 import { quantumRulesDescription } from "../templates/quantum_rules";
 import { Variant } from "../variant";
 import { Baduk, BadukBoard, BadukConfig, badukVariant, Color } from "./baduk";
@@ -77,6 +78,18 @@ export class QuantumGo extends AbstractGame<NewBadukConfig, QuantumGoState> {
     return new Coordinate(Number(move), 0);
   }
 
+  private isInBounds(pos: CoordinateLike): boolean {
+    if (isGridBadukConfig(this.config)) {
+      return Dimensions.from(getWidthAndHeight(this.config)).isInBounds(pos);
+    }
+    // Graph boards have no width and height - only the board itself knows
+    // which nodes exist.
+    return new BadukHelper({
+      ...this.config,
+      komi: 0,
+    }).badukGame.board.isInBounds(pos);
+  }
+
   private encodeMove(pos: Coordinate): string {
     if (isGridBadukConfig(this.config)) {
       return pos.toSgfRepr();
@@ -121,13 +134,7 @@ export class QuantumGo extends AbstractGame<NewBadukConfig, QuantumGoState> {
     }
 
     const pos = this.decodeMove(move);
-    // TODO: add a Dimensions class (#216) and look at that instead of
-    // building a grid for no reason
-    if (
-      !new BadukHelper({ ...this.config, komi: 0 }).badukGame.board.isInBounds(
-        pos,
-      )
-    ) {
+    if (!this.isInBounds(pos)) {
       throw new Error("Out of bounds!");
     }
 

--- a/packages/vue-client/src/components/boards/CubeBoard.vue
+++ b/packages/vue-client/src/components/boards/CubeBoard.vue
@@ -519,7 +519,7 @@ function createCubeBoard() {
  * Add star points to each face of the cube
  */
 function addStarPoints(size: number, faceOffset: number) {
-  const hoshiCoords = getHoshi(size, size);
+  const hoshiCoords = getHoshi({ width: size, height: size });
 
   // For each of the 6 faces, add star points
   for (let face = 0; face < 6; face++) {

--- a/packages/vue-client/src/components/boards/FractionalBoard.vue
+++ b/packages/vue-client/src/components/boards/FractionalBoard.vue
@@ -55,7 +55,7 @@ const board = computed(() => createGraph(intersections.value, null));
 const hoshi = computed(() => {
   const b = props.config.board;
   if (b.type === "grid") {
-    return getHoshi(b.width, b.height);
+    return getHoshi(b);
   }
   return [];
 });

--- a/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
+++ b/packages/vue-client/src/components/boards/MulticolorGridBoard.vue
@@ -90,7 +90,7 @@ function positionHovered(pos: Coordinate) {
       />
 
       <circle
-        v-for="{ x, y } in getHoshi(width, height)"
+        v-for="{ x, y } in getHoshi(props.boardDimensions)"
         :key="`${x},${y}`"
         :cx="x"
         :cy="y"


### PR DESCRIPTION
Closes #216

- first commit adds the Dimensions class which can perform operations that don't require the grid array to be allocated
- Later commits use it where applicable

Testing: new tests added, `yarn build` (including `vue-tsc` type-check), `yarn lint`, and all 262 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PN3WJdWZ4MTpZ1Sfm6TEN