### PR TITLE
Push notification counts over the socket

### DIFF
--- a/packages/server/src/__mocks__/socket_io.ts
+++ b/packages/server/src/__mocks__/socket_io.ts
@@ -3,9 +3,12 @@ import { vi } from "vitest";
 const mockEmit = vi.fn();
 const mockSocketsLeave = vi.fn();
 const mockIn = vi.fn(() => ({ socketsLeave: mockSocketsLeave }));
+const mockRoomEmit = vi.fn<(event: string, ...args: unknown[]) => void>();
+const mockTo = vi.fn((_room: string) => ({ emit: mockRoomEmit }));
 const mockIo = {
   emit: mockEmit,
   in: mockIn,
+  to: mockTo,
 };
 
 export function init() {
@@ -16,10 +19,12 @@ export function io() {
   return mockIo;
 }
 
-export { mockSocketsLeave };
+export { mockSocketsLeave, mockTo, mockRoomEmit };
 
 export function resetMocks() {
   mockEmit.mockClear();
   mockIn.mockClear();
   mockSocketsLeave.mockClear();
+  mockTo.mockClear();
+  mockRoomEmit.mockClear();
 }

--- a/packages/server/src/__tests__/notifications.test.ts
+++ b/packages/server/src/__tests__/notifications.test.ts
@@ -1,0 +1,118 @@
+import { NOTIFICATIONS_COUNT_EVENT, Notifications } from "@govariants/shared";
+import { setupTestDb, teardownTestDb, clearTestDb } from "./helpers/setup";
+import { userNotificationsTopic } from "../socket_validation";
+
+// Mock socket.io so that broadcasts can be inspected without a real server
+vi.mock("../socket_io");
+
+import {
+  resetMocks as resetSocketIoMocks,
+  mockTo,
+  mockRoomEmit,
+} from "../__mocks__/socket_io";
+
+const ALICE = "alice";
+const BOB = "bob";
+const GAME_ID = "507f1f77bcf86cd799439011";
+
+// Imported after the test database is set up — see helpers/setup.ts
+let notifications: typeof import("../notifications/notifications");
+
+beforeAll(async () => {
+  await setupTestDb();
+  notifications = await import("../notifications/notifications");
+});
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  await clearTestDb();
+  await notifications.initUserNotifications(ALICE);
+  await notifications.initUserNotifications(BOB);
+  resetSocketIoMocks();
+});
+
+/** The counts broadcast since the last reset, keyed by user id. */
+function pushedCounts(): Record<string, number> {
+  const counts: Record<string, number> = {};
+  mockTo.mock.calls.forEach(([room], index) => {
+    const [event, count] = mockRoomEmit.mock.calls[index];
+    expect(event).toBe(NOTIFICATIONS_COUNT_EVENT);
+    const userId = [ALICE, BOB].find(
+      (id) => userNotificationsTopic(id) === room,
+    );
+    counts[userId ?? room] = count as number;
+  });
+  return counts;
+}
+
+describe("unread count broadcasts", () => {
+  it("pushes the new count to every subscriber of a new round", async () => {
+    await notifications.notifyOfNewRound(
+      { [ALICE]: [Notifications.myMove], [BOB]: [Notifications.newRound] },
+      GAME_ID,
+      1,
+      [ALICE],
+    );
+
+    expect(pushedCounts()).toEqual({ [ALICE]: 1, [BOB]: 1 });
+  });
+
+  it("pushes zero to the player who just moved", async () => {
+    const subscriptions = {
+      [ALICE]: [Notifications.myMove],
+      [BOB]: [Notifications.myMove],
+    };
+
+    await notifications.notifyOfNewRound(subscriptions, GAME_ID, 1, [ALICE]);
+    expect(pushedCounts()).toEqual({ [ALICE]: 1, [BOB]: 0 });
+
+    // Alice plays, so it is Bob's move and Alice's notification is gone
+    resetSocketIoMocks();
+    await notifications.notifyOfNewRound(subscriptions, GAME_ID, 2, [BOB]);
+
+    expect(pushedCounts()).toEqual({ [ALICE]: 0, [BOB]: 1 });
+  });
+
+  it("pushes only to the recipients of a seat change", async () => {
+    await notifications.notifyOfSeatChange(
+      { [ALICE]: [Notifications.seatChange], [BOB]: [Notifications.myMove] },
+      GAME_ID,
+      0,
+      "charlie",
+      true,
+    );
+
+    expect(pushedCounts()).toEqual({ [ALICE]: 1 });
+  });
+
+  it("pushes zero once the notifications are marked as read", async () => {
+    await notifications.notifyOfNewRound(
+      { [ALICE]: [Notifications.myMove] },
+      GAME_ID,
+      1,
+      [ALICE],
+    );
+
+    resetSocketIoMocks();
+    await notifications.markAsRead(ALICE, GAME_ID);
+
+    expect(pushedCounts()).toEqual({ [ALICE]: 0 });
+  });
+
+  it("pushes zero once the notifications are cleared", async () => {
+    await notifications.notifyOfNewRound(
+      { [ALICE]: [Notifications.myMove] },
+      GAME_ID,
+      1,
+      [ALICE],
+    );
+
+    resetSocketIoMocks();
+    await notifications.clearNotifications(ALICE, GAME_ID);
+
+    expect(pushedCounts()).toEqual({ [ALICE]: 0 });
+  });
+});

--- a/packages/server/src/__tests__/subscription-validation.test.ts
+++ b/packages/server/src/__tests__/subscription-validation.test.ts
@@ -1,8 +1,9 @@
 import { GameResponse, UserResponse } from "@govariants/shared";
 import {
-  validateSeatSubscription,
+  validateSubscription,
   gameTopic,
   seatTopic,
+  userNotificationsTopic,
 } from "../socket_validation";
 
 function makeUser(id: string): UserResponse {
@@ -21,7 +22,7 @@ function makeGame(players: ({ id: string } | null)[]): GameResponse {
 
 const GAME_ID = "507f1f77bcf86cd799439011";
 
-describe("validateSeatSubscription", () => {
+describe("validateSubscription", () => {
   const mockGetGame = vi.fn<(id: string) => Promise<GameResponse>>();
 
   beforeEach(() => {
@@ -29,7 +30,7 @@ describe("validateSeatSubscription", () => {
   });
 
   it("allows non-seat topics without validation", async () => {
-    const result = await validateSeatSubscription(
+    const result = await validateSubscription(
       gameTopic(GAME_ID),
       undefined,
       mockGetGame,
@@ -38,8 +39,19 @@ describe("validateSeatSubscription", () => {
     expect(mockGetGame).not.toHaveBeenCalled();
   });
 
+  it("rejects a user topic even when it is the subscriber's own", async () => {
+    const user = makeUser("someuser");
+
+    const result = await validateSubscription(
+      userNotificationsTopic(user.id),
+      user,
+      mockGetGame,
+    );
+    expect(result).toBe("user topics are not client-subscribable");
+  });
+
   it("rejects seat topic when no user is authenticated", async () => {
-    const result = await validateSeatSubscription(
+    const result = await validateSubscription(
       seatTopic(GAME_ID, 0),
       undefined,
       mockGetGame,
@@ -51,7 +63,7 @@ describe("validateSeatSubscription", () => {
   it("rejects seat topic when game does not exist", async () => {
     mockGetGame.mockRejectedValue(new Error("Game not found"));
 
-    const result = await validateSeatSubscription(
+    const result = await validateSubscription(
       seatTopic(GAME_ID, 0),
       makeUser("someuser"),
       mockGetGame,
@@ -62,7 +74,7 @@ describe("validateSeatSubscription", () => {
   it("rejects seat topic when user does not occupy the seat", async () => {
     mockGetGame.mockResolvedValue(makeGame([{ id: "otheruser" }, null]));
 
-    const result = await validateSeatSubscription(
+    const result = await validateSubscription(
       seatTopic(GAME_ID, 0),
       makeUser("attacker"),
       mockGetGame,
@@ -73,7 +85,7 @@ describe("validateSeatSubscription", () => {
   it("rejects seat topic when seat is empty", async () => {
     mockGetGame.mockResolvedValue(makeGame([null, null]));
 
-    const result = await validateSeatSubscription(
+    const result = await validateSubscription(
       seatTopic(GAME_ID, 0),
       makeUser("someuser"),
       mockGetGame,
@@ -84,7 +96,7 @@ describe("validateSeatSubscription", () => {
   it("allows seat topic when user occupies the seat", async () => {
     mockGetGame.mockResolvedValue(makeGame([{ id: "rightuser" }, null]));
 
-    const result = await validateSeatSubscription(
+    const result = await validateSubscription(
       seatTopic(GAME_ID, 0),
       makeUser("rightuser"),
       mockGetGame,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -151,10 +151,10 @@ io.engine.use(passport.session());
 io.on("connection", (socket) => {
   console.log("a user connected");
 
-  // Passport populates .user on the request via the shared session middleware.
-  // It is read once, during the handshake, so a socket that outlives a login or
-  // logout keeps the identity it connected with — the client re-handshakes on
-  // those transitions.
+  // Passport populates .user on the request via the shared session middleware,
+  // which runs on the handshake request only. This is therefore the identity the
+  // socket connected with, and it does not change for the socket's lifetime: a
+  // socket that outlives a login or logout keeps the old one (see #557).
   const user = (
     socket.request as http.IncomingMessage & { user?: UserResponse }
   ).user;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -17,7 +17,10 @@ import { SITE_NAME, UserResponse } from "@govariants/shared";
 import { router as apiRouter } from "./api";
 import { getGame } from "./games";
 import * as socket_io from "./socket_io";
-import { validateSeatSubscription } from "./socket_validation";
+import {
+  userNotificationsTopic,
+  validateSubscription,
+} from "./socket_validation";
 import { ITimeoutService, TimeoutService } from "./time-control/timeout";
 import { HttpError } from "./http-error";
 import { staticLimiter } from "./rate_limit";
@@ -148,19 +151,28 @@ io.engine.use(passport.session());
 io.on("connection", (socket) => {
   console.log("a user connected");
 
+  // Passport populates .user on the request via the shared session middleware.
+  // It is read once, during the handshake, so a socket that outlives a login or
+  // logout keeps the identity it connected with — the client re-handshakes on
+  // those transitions.
+  const user = (
+    socket.request as http.IncomingMessage & { user?: UserResponse }
+  ).user;
+
+  if (user) {
+    // Joined here rather than on request, so that a client cannot listen in on
+    // another user's notifications.
+    void socket.join(userNotificationsTopic(user.id));
+  }
+
   socket.on("ping", function (data) {
     io.emit("pong", data);
     console.log("ping");
   });
 
   socket.on("subscribe", async (topics) => {
-    // Passport populates .user on the request via the shared session middleware
-    const user = (
-      socket.request as http.IncomingMessage & { user?: UserResponse }
-    ).user;
-
     for (const topic of topics) {
-      const rejection = await validateSeatSubscription(topic, user, getGame);
+      const rejection = await validateSubscription(topic, user, getGame);
       if (rejection) {
         console.warn(`Rejected subscription to ${topic}: ${rejection}`);
         continue;

--- a/packages/server/src/notifications/notifications.ts
+++ b/packages/server/src/notifications/notifications.ts
@@ -4,9 +4,12 @@ import { UserNotifications } from "./notifications.types";
 import {
   GameNotification,
   GameSubscriptions,
+  NOTIFICATIONS_COUNT_EVENT,
   Notifications,
   NotificationType,
 } from "@govariants/shared";
+import { io } from "../socket_io";
+import { userNotificationsTopic } from "../socket_validation";
 
 function outwardMap(userNotifications: UserNotifications): GameNotification[] {
   return userNotifications.notifications as GameNotification[];
@@ -35,11 +38,25 @@ export async function getUserNotifications(
 export async function getUserNotificationsCount(
   userId: string,
 ): Promise<number> {
+  return (await getUserNotificationsCounts([userId])).get(userId) ?? 0;
+}
+
+/**
+ * Unread count per user, keyed by id. Users without a notifications document
+ * are reported as zero rather than omitted.
+ */
+async function getUserNotificationsCounts(
+  userIds: string[],
+): Promise<Map<string, number>> {
+  const counts = new Map(userIds.map((userId) => [userId, 0]));
+  if (!counts.size) return counts;
+
   const queryResult = await notifications()
     .aggregate([
-      { $match: { userId: userId } },
+      { $match: { userId: { $in: [...counts.keys()] } } },
       {
         $project: {
+          userId: 1,
           num: {
             $size: {
               $filter: {
@@ -54,7 +71,24 @@ export async function getUserNotificationsCount(
     ])
     .toArray();
 
-  return queryResult.at(0)?.num ?? 0;
+  for (const { userId, num } of queryResult) {
+    counts.set(userId, num);
+  }
+
+  return counts;
+}
+
+/**
+ * Pushes each user's unread count to their own room, so that clients already on
+ * the site update their badge instead of showing the count they loaded with.
+ */
+async function emitNotificationsCounts(userIds: string[]): Promise<void> {
+  const counts = await getUserNotificationsCounts(userIds);
+  for (const [userId, count] of counts) {
+    io()
+      .to(userNotificationsTopic(userId))
+      .emit(NOTIFICATIONS_COUNT_EVENT, count);
+  }
 }
 
 async function addGameNotification(
@@ -96,7 +130,8 @@ export async function notifyOfGameEnd(
   gameId: string,
   gameResult: string,
 ): Promise<void> {
-  await deleteGameNotifications(getSubscriberIds(subscriptions), gameId, [
+  const subscriberIds = getSubscriberIds(subscriptions);
+  await deleteGameNotifications(subscriberIds, gameId, [
     Notifications.myMove,
     Notifications.newRound,
   ]);
@@ -111,6 +146,8 @@ export async function notifyOfGameEnd(
     getRecipientIDs(subscriptions, Notifications.gameEnd),
     newNotification,
   );
+
+  await emitNotificationsCounts(subscriberIds);
 }
 
 export async function notifyOfNewRound(
@@ -119,7 +156,8 @@ export async function notifyOfNewRound(
   round: number,
   nextToPlayIds: string[],
 ): Promise<void> {
-  await deleteGameNotifications(getSubscriberIds(subscriptions), gameId, [
+  const subscriberIds = getSubscriberIds(subscriptions);
+  await deleteGameNotifications(subscriberIds, gameId, [
     Notifications.myMove,
     Notifications.newRound,
   ]);
@@ -146,6 +184,8 @@ export async function notifyOfNewRound(
     getRecipientIDs(subscriptions, Notifications.newRound),
     newRoundNotification,
   );
+
+  await emitNotificationsCounts(subscriberIds);
 }
 
 export async function notifyOfSeatChange(
@@ -161,10 +201,10 @@ export async function notifyOfSeatChange(
     params: { seat: seat, user: user, didTakeSeat: didTakeSeat },
     read: false,
   };
-  await addGameNotification(
-    getRecipientIDs(subscriptions, Notifications.seatChange),
-    newNotification,
-  );
+  const recipientIds = getRecipientIDs(subscriptions, Notifications.seatChange);
+  await addGameNotification(recipientIds, newNotification);
+
+  await emitNotificationsCounts(recipientIds);
 }
 
 export async function markAsRead(
@@ -176,6 +216,8 @@ export async function markAsRead(
     { $set: { "notifications.$[notification].read": true } },
     { arrayFilters: [{ "notification.gameId": gameId }] },
   );
+
+  await emitNotificationsCounts([userId]);
 }
 
 export async function clearNotifications(
@@ -186,6 +228,8 @@ export async function clearNotifications(
     { userId: userId },
     { $pull: { notifications: { gameId: gameId } } },
   );
+
+  await emitNotificationsCounts([userId]);
 }
 
 export async function deleteAllNotificationsOfUser(

--- a/packages/server/src/socket_validation.ts
+++ b/packages/server/src/socket_validation.ts
@@ -1,6 +1,7 @@
 import { GameResponse, UserResponse } from "@govariants/shared";
 
 export const SEAT_TOPIC_RE = /^game\/([a-f0-9]{24})\/(\d+)$/;
+export const USER_TOPIC_RE = /^user\//;
 
 export function gameTopic(gameId: string): string {
   return `game/${gameId}`;
@@ -14,17 +15,28 @@ export function seatsTopic(gameId: string): string {
   return `game/${gameId}/seats`;
 }
 
+export function userNotificationsTopic(userId: string): string {
+  return `user/${userId}/notifications`;
+}
+
 type GameLookup = (gameId: string) => Promise<GameResponse>;
 
 /**
- * Validates whether a user is allowed to subscribe to a seat-specific topic.
+ * Validates whether a user is allowed to subscribe to a topic.
  * Returns null if allowed, or a rejection reason string if not.
  */
-export async function validateSeatSubscription(
+export async function validateSubscription(
   topic: string,
   user: UserResponse | undefined,
   getGame: GameLookup,
 ): Promise<string | null> {
+  // User-scoped topics are joined server-side from the handshake session, which
+  // is the only identity a socket cannot lie about. A client asking for one is
+  // asking to read somebody else's notifications.
+  if (USER_TOPIC_RE.test(topic)) {
+    return "user topics are not client-subscribable";
+  }
+
   const match = topic.match(SEAT_TOPIC_RE);
   if (!match) return null; // Not a seat topic, always allowed
 

--- a/packages/shared/src/notifications.types.ts
+++ b/packages/shared/src/notifications.types.ts
@@ -1,3 +1,10 @@
+/**
+ * Socket.IO event carrying the recipient's unread notification count. Emitted
+ * to a user's own room whenever their notifications change, so open clients can
+ * update their badge without polling.
+ */
+export const NOTIFICATIONS_COUNT_EVENT = "notifications_count";
+
 export const Notifications = {
   gameEnd: 1,
   newRound: 2,

--- a/packages/vue-client/src/components/NotificationsNav.vue
+++ b/packages/vue-client/src/components/NotificationsNav.vue
@@ -2,19 +2,22 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
-import { watchEffect } from "vue";
+import { onUnmounted, watchEffect } from "vue";
 import * as requests from "@/requests";
 import { useCurrentUser, useStore } from "@/stores/user";
 import {
   setNotificationsCount,
   useNotificationsCount,
 } from "@/stores/notifications";
+import { NOTIFICATIONS_COUNT_EVENT } from "@govariants/shared";
 
 library.add(faBell);
 const notificationCount = useNotificationsCount();
 const store = useStore();
 const user = useCurrentUser();
 
+// The fetch only covers the count at page load; the server pushes every later
+// change to this user's own room.
 watchEffect(async () => {
   if (user.value && store.csrf_token) {
     await requests
@@ -22,6 +25,11 @@ watchEffect(async () => {
       .then((result) => setNotificationsCount(result.count))
       .catch(alert);
   }
+});
+
+requests.socket.on(NOTIFICATIONS_COUNT_EVENT, setNotificationsCount);
+onUnmounted(() => {
+  requests.socket.off(NOTIFICATIONS_COUNT_EVENT, setNotificationsCount);
 });
 </script>
 


### PR DESCRIPTION
## Problem

The bell badge showed the unread count as of page load, but did not update as the count changed.

`NotificationsNav` fetches `/notifications/count` inside a `watchEffect` whose only reactive dependencies are `user.value` and `store.csrf_token`, so it fires once after login and never again. There is no socket event for the count, and the component is permanently mounted in `App.vue` (the hamburger toggles a CSS class, not `v-if`), so no navigation remounts it.

## Change

Broadcast each affected user's unread count whenever their notifications change.

- Sockets join a per-user room, `user/<id>/notifications`, in the `connection` handler.
- Counts are broadcast at the end of each operation that mutates notifications.
- `NotificationsNav` listens for the event; the existing fetch stays as the page-load value.

## Verification

`yarn build`, `yarn test` and `yarn lint` are clean. Beyond that, run against the real stack with two registered users and a live socket:

```
A plays (A is black, nothing pending)  << push: 0
B plays -> A is on the move            << push: 1
A plays -> A has addressed it          << push: 0
```

Added 5 integration tests for the broadcasts (`notifications.test.ts`), a rejection test for user topics, and `to()` on the socket.io mock.

## Follow-ups, deliberately not in this PR

- **Socket identity is fixed at the handshake.** see #557

- **A race on the final move.** see #558 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UDbeZZ4okUf2BrXLVyFuV
