### PR TITLE
ci: bump checkout and setup-node to v7

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,9 +23,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         cache: "yarn"


### PR DESCRIPTION
Closes #553

## Problem

The Node.js CI workflow still uses `actions/checkout@v3` and `actions/setup-node@v3`. Those releases run on the retired Node 16 action runtime and leave CI on unsupported action versions.

## User impact

CI setup now runs on the current GitHub Actions runtime, avoiding deprecated-runtime warnings and keeping checkout and Yarn caching on supported releases.

## Root cause

Both action references were pinned to v3 and had not been updated as new runtime generations were released.

## Fix

- Update `actions/checkout` from v3 to v7.
- Update `actions/setup-node` from v3 to v7.
- Keep the existing Node 20 matrix and Yarn cache inputs unchanged.

The issue requested checking the current majors before opening the PR. The latest official releases are now checkout v7.0.1 and setup-node v7.0.0, so this uses `@v7` rather than the v5 examples in the original description.

## Verification

- Immutable Yarn 3 install on Node 20
- `yarn build`
- Parsed `.github/workflows/node.js.yml` as YAML and asserted both updated action references
- Confirmed the current majors against the official `actions/checkout` and `actions/setup-node` releases

`yarn lint:check` reports existing CRLF formatting differences across unchanged TypeScript files on Windows; the PR's Ubuntu CI run remains the authoritative lint/test verification and directly exercises both upgraded actions.
