### PR TITLE
Keep the notification bell in the top bar on mobile

### DIFF
--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -2,15 +2,32 @@
 import { RouterLink, RouterView } from "vue-router";
 import UserNav from "./components/UserNav.vue";
 import NotificationsNav from "./components/NotificationsNav.vue";
-import { ref } from "vue";
+import { ref, watchEffect } from "vue";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faBars, faBook } from "@fortawesome/free-solid-svg-icons";
 import { faHouse } from "@fortawesome/free-solid-svg-icons";
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons";
+import * as requests from "@/requests";
+import { useCurrentUser, useStore } from "@/stores/user";
+import { setNotificationsCount } from "@/stores/notifications";
 
 library.add(faBars, faHouse, faCircleInfo, faBook);
 const is_menu_closed = ref(true);
+
+// The bell is rendered twice (see below), so the unread count is fetched here
+// rather than in NotificationsNav: one request no matter how many are mounted.
+const user_store = useStore();
+const user = useCurrentUser();
+
+watchEffect(async () => {
+  if (user.value && user_store.csrf_token) {
+    await requests
+      .get("/notifications/count")
+      .then((result) => setNotificationsCount(result.count))
+      .catch(alert);
+  }
+});
 
 const closeMenuFn = (event: MouseEvent) => {
   event.stopPropagation();
@@ -34,6 +51,14 @@ const toggleMenuFn = (event: MouseEvent) => {
     <RouterLink class="navLogo" to="/">
       <img class="navLogoImg" src="/favicon.ico" />
     </RouterLink>
+    <!--
+      The bell is rendered in two places and exactly one copy is ever visible
+      (see the .navBell* rules below). On mobile the nav links collapse behind
+      the hamburger, so a bell inside .navContent would hide the unread badge
+      until the menu is opened; it lives in the bar instead. On desktop nothing
+      is collapsed, so it stays with the other nav links.
+    -->
+    <NotificationsNav class="navBellBar" />
     <button class="navHamburgerContainer navElement" @click="toggleMenuFn">
       <font-awesome-icon icon="fa-solid fa-bars" class="navHamburgerMenu" />
     </button>
@@ -51,7 +76,7 @@ const toggleMenuFn = (event: MouseEvent) => {
           <font-awesome-icon icon="fa-solid fa-book" class="icon" />
           {{ $t("rules") }}
         </RouterLink>
-        <NotificationsNav />
+        <NotificationsNav class="navBellMenu" />
       </div>
       <div>
         <UserNav />
@@ -90,6 +115,11 @@ nav {
     }
   }
 
+  /* Hidden until the nav collapses; .navBellMenu is the visible copy here. */
+  a.navBellBar {
+    display: none;
+  }
+
   .navContent {
     display: flex;
     justify-content: space-between;
@@ -110,6 +140,16 @@ nav {
       .navHamburgerMenu {
         display: flex;
       }
+    }
+
+    /* Swap which bell is visible: the bar one, kept beside the hamburger. */
+    a.navBellBar {
+      display: flex;
+      margin-left: auto;
+    }
+
+    a.navBellMenu {
+      display: none;
     }
 
     .navContent {

--- a/packages/vue-client/src/components/NotificationsNav.vue
+++ b/packages/vue-client/src/components/NotificationsNav.vue
@@ -2,37 +2,24 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
-import { watchEffect } from "vue";
-import * as requests from "@/requests";
-import { useCurrentUser, useStore } from "@/stores/user";
-import {
-  setNotificationsCount,
-  useNotificationsCount,
-} from "@/stores/notifications";
+import { useNotificationsCount } from "@/stores/notifications";
 
 library.add(faBell);
 const notificationCount = useNotificationsCount();
-const store = useStore();
-const user = useCurrentUser();
-
-watchEffect(async () => {
-  if (user.value && store.csrf_token) {
-    await requests
-      .get("/notifications/count")
-      .then((result) => setNotificationsCount(result.count))
-      .catch(alert);
-  }
-});
 </script>
 
 <template>
   <RouterLink
     class="navElement"
     to="/notifications"
-    :aria-label="`Notifications${
-      notificationCount ? `, ${notificationCount} unread` : ''
-    }`"
-    title="Notifications"
+    :aria-label="
+      notificationCount
+        ? `${$t('notifications')} (${$t('notifications-unread', {
+            count: notificationCount,
+          })})`
+        : $t('notifications')
+    "
+    :title="$t('notifications')"
   >
     <div class="icon-wrapper">
       <font-awesome-icon icon="fa-solid fa-bell" />
@@ -40,7 +27,6 @@ watchEffect(async () => {
         Math.min(notificationCount, 99)
       }}</span>
     </div>
-    <span class="mobile-only">{{ $t("notifications") }}</span>
   </RouterLink>
 </template>
 
@@ -48,17 +34,6 @@ watchEffect(async () => {
 .icon-wrapper {
   position: relative;
   display: inline-block;
-}
-
-.mobile-only {
-  display: none;
-}
-
-/* Mobile breakpoint - keep in sync with App.vue nav hamburger */
-@media (max-width: 768px) {
-  .mobile-only {
-    display: inline;
-  }
 }
 
 .badge {

--- a/packages/vue-client/src/locales/de.json
+++ b/packages/vue-client/src/locales/de.json
@@ -7,6 +7,7 @@
   "logout": "Abmelden",
   "admin": "Administration",
   "notifications": "Nachrichten",
+  "notifications-unread": "{count} ungelesen",
   "pagination": {
     "size-label": "Anzahl:",
     "first": "Zum Anfang",

--- a/packages/vue-client/src/locales/en.json
+++ b/packages/vue-client/src/locales/en.json
@@ -7,6 +7,7 @@
   "logout": "Log out",
   "admin": "Admin",
   "notifications": "Notifications",
+  "notifications-unread": "{count} unread",
   "pagination": {
     "size-label": "show:",
     "first": "First",


### PR DESCRIPTION
## Problem

On narrow viewports the nav links collapse behind the hamburger, and `NotificationsNav` lived inside that collapsed menu. The unread count was fetched and stored, but the badge was invisible until the menu was opened — there was no way to tell you had notifications at a glance.

## Change

The bell now renders in the nav bar itself on mobile, beside the hamburger, and there is no Notifications entry in the menu. Desktop is unchanged: the bell stays with the other nav links, after Rules.

| | before | after |
|---|---|---|
| mobile bar | logo … hamburger | logo … 🔔 hamburger |
| mobile menu | Home / About / Rules / **Notifications** / user | Home / About / Rules / user |
| desktop | Home / About / Rules / 🔔 … user | unchanged |

### Why the component is rendered twice

The two placements are genuinely different DOM positions — on mobile the bell has to sit *outside* `.navContent` (the element the hamburger collapses), on desktop *inside* it — and CSS can't move a node between parents. So `<NotificationsNav>` appears in both positions and a single media query picks which copy is visible. It's the same `@media (max-width: 768px)` block that already toggles the hamburger, so the two can't drift apart.

Alternatives considered and rejected:

- **`display: contents` + `order`** on the nav children. Works with one instance, but requires an explicit `order` on every nav child — a trap for whoever adds the next nav item.
- **`<Teleport>`.** One instance and exact placement, but the target lives inside `App.vue` itself and Vue mounts an element's children before inserting it into the document, so the target isn't reachable at root mount. It also needs `useMediaQuery`, i.e. a third copy of the 768px breakpoint — in JS this time, where drifting from the CSS breaks the layout silently.

The duplication is only safe because the `/notifications/count` fetch moved up to `App.vue` first, so it runs once regardless of how many bells are mounted. `NotificationsNav` is now purely presentational.

### Incidental cleanups

The bell is icon-only in both layouts now (in the bar it's a bar icon, not a menu row), so the `.mobile-only` label is gone. That removes two things with it:

- the badge overlapping the label's first letter, which it did on mobile whenever the count was non-zero (`right: -15px` is tuned for desktop's `1.2rem` item padding);
- a second hardcoded `768px` media query carrying a "keep in sync with App.vue" comment.

Since that label was the component's only translated string, the accessible name moved to i18n (`notifications-unread`, added to `en.json` and `de.json`) rather than leaving hardcoded English as the only thing a screen reader gets.

## Testing

`lint:check`, `type-check` and `vitest` all pass.

Layout verified against the dev server at 390px and 1100px, logged out, with the unread count forced to 7 so the badge renders.

### Mobile, menu closed (390px)

This is the bug: seven unread, and before the change nothing in the bar says so.

Before:

<!-- drop before_bar.png here -->

After:

<!-- drop after_bar.png here -->

### Mobile, menu open (390px)

Note the badge landing on the "N" of Notifications in the before shot, and the absence of the row in the after shot.

Before:

<!-- drop before_menu.png here -->

After:

<!-- drop after_menu.png here -->

### Desktop (1100px)

Unchanged — one bell, still after Rules.

Before:

<!-- drop before_desktop.png here -->

After:

<!-- drop after_desktop.png here -->

## Deliberately not included

- **Bar icon sizing.** The bell renders at 14×16px in both layouts (measured — this PR doesn't scale it), but in the bar its only neighbour is the 40×40px hamburger, so it reads as undersized. The hamburger is sized with `calc(var(--navbar-height) * 0.8)`, the same multiplier as the logo. Worth sizing both bar icons together as a follow-up.
- `right: -15px` on the badge, left as-is: it's tuned for desktop's padding, and in the mobile bar it drifts slightly toward the hamburger. Changing it would move desktop pixels.
- Logged-out users still see a bell. That's pre-existing desktop behavior, now just more prominent.
- The nav's accessibility gaps (the hamburger has no `aria-label` / `aria-expanded`, Escape doesn't close the menu) and its manual `document` click listener. Both are real, both are out of scope here.