### PR TITLE
Move notifications count tracking into the store

### DIFF
--- a/packages/vue-client/src/components/NotificationsNav.vue
+++ b/packages/vue-client/src/components/NotificationsNav.vue
@@ -2,35 +2,10 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { faBell } from "@fortawesome/free-solid-svg-icons";
-import { onUnmounted, watchEffect } from "vue";
-import * as requests from "@/requests";
-import { useCurrentUser, useStore } from "@/stores/user";
-import {
-  setNotificationsCount,
-  useNotificationsCount,
-} from "@/stores/notifications";
-import { NOTIFICATIONS_COUNT_EVENT } from "@govariants/shared";
+import { useNotificationsCount } from "@/stores/notifications";
 
 library.add(faBell);
 const notificationCount = useNotificationsCount();
-const store = useStore();
-const user = useCurrentUser();
-
-// The fetch only covers the count at page load; the server pushes every later
-// change to this user's own room.
-watchEffect(async () => {
-  if (user.value && store.csrf_token) {
-    await requests
-      .get("/notifications/count")
-      .then((result) => setNotificationsCount(result.count))
-      .catch(alert);
-  }
-});
-
-requests.socket.on(NOTIFICATIONS_COUNT_EVENT, setNotificationsCount);
-onUnmounted(() => {
-  requests.socket.off(NOTIFICATIONS_COUNT_EVENT, setNotificationsCount);
-});
 </script>
 
 <template>

--- a/packages/vue-client/src/stores/__tests__/notifications.test.ts
+++ b/packages/vue-client/src/stores/__tests__/notifications.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { NOTIFICATIONS_COUNT_EVENT } from "@govariants/shared";
+import * as requests from "../../requests";
+import { useStore } from "../user";
+import { useNotificationsCount } from "../notifications";
+
+vi.mock("../../requests", () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  socket: {
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+  },
+}));
+
+function logIn() {
+  const userStore = useStore();
+  userStore.user = { id: "user123", login_type: "persistent" };
+  userStore.csrf_token = "csrf-token";
+  return userStore;
+}
+
+describe("notifications store", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("fetches the unread count for a logged-in user", async () => {
+    vi.mocked(requests.get).mockResolvedValue({ count: 3 });
+    logIn();
+
+    const count = useNotificationsCount();
+    await flushPromises();
+
+    expect(requests.get).toHaveBeenCalledWith("/notifications/count");
+    expect(count.value).toBe(3);
+  });
+
+  it("does not fetch when nobody is logged in", async () => {
+    const count = useNotificationsCount();
+    await flushPromises();
+
+    expect(requests.get).not.toHaveBeenCalled();
+    expect(count.value).toBeNull();
+  });
+
+  it("clears the count on logout", async () => {
+    vi.mocked(requests.get).mockResolvedValue({ count: 3 });
+    const userStore = logIn();
+
+    const count = useNotificationsCount();
+    await flushPromises();
+    expect(count.value).toBe(3);
+
+    userStore.user = null;
+    userStore.csrf_token = null;
+    await flushPromises();
+
+    expect(count.value).toBeNull();
+  });
+
+  it("applies counts pushed by the server", async () => {
+    vi.mocked(requests.get).mockResolvedValue({ count: 3 });
+    logIn();
+
+    const count = useNotificationsCount();
+    await flushPromises();
+
+    const subscription = vi
+      .mocked(requests.socket.on)
+      .mock.calls.find(([event]) => event === NOTIFICATIONS_COUNT_EVENT);
+    expect(subscription).toBeDefined();
+
+    subscription![1](7);
+    expect(count.value).toBe(7);
+  });
+});

--- a/packages/vue-client/src/stores/notifications.ts
+++ b/packages/vue-client/src/stores/notifications.ts
@@ -1,17 +1,35 @@
 import { defineStore, storeToRefs } from "pinia";
-import { Ref } from "vue";
+import { onScopeDispose, ref, watchEffect } from "vue";
+import type { Ref } from "vue";
+import { NOTIFICATIONS_COUNT_EVENT } from "@govariants/shared";
+import * as requests from "../requests";
+import { useStore as useUserStore } from "./user";
 
-type NotificationsStoreState = {
-  unreadCount: number | null;
-};
+const notificationStore = defineStore("notifications", () => {
+  const unreadCount: Ref<number | null> = ref(null);
+  const userStore = useUserStore();
 
-const notificationStore = defineStore("notifications", {
-  state: (): NotificationsStoreState => ({ unreadCount: null }),
-  actions: {
-    set(count: number): void {
-      this.unreadCount = count;
-    },
-  },
+  function set(count: number): void {
+    unreadCount.value = count;
+  }
+
+  // The fetch only covers the count at page load; the server pushes every later
+  // change to this user's own room.
+  watchEffect(async () => {
+    if (userStore.user && userStore.csrf_token) {
+      await requests
+        .get("/notifications/count")
+        .then((result) => set(result.count))
+        .catch(alert);
+    }
+  });
+
+  requests.socket.on(NOTIFICATIONS_COUNT_EVENT, set);
+  onScopeDispose(() => {
+    requests.socket.off(NOTIFICATIONS_COUNT_EVENT, set);
+  });
+
+  return { unreadCount, set };
 });
 
 export function useNotificationsCount(): Ref<number | null> {

--- a/packages/vue-client/src/stores/notifications.ts
+++ b/packages/vue-client/src/stores/notifications.ts
@@ -21,6 +21,8 @@ const notificationStore = defineStore("notifications", () => {
         .get("/notifications/count")
         .then((result) => set(result.count))
         .catch(alert);
+    } else {
+      unreadCount.value = null;
     }
   });
 


### PR DESCRIPTION
`NotificationsNav` tracked the unread count itself: it fetched `/notifications/count` on load and subscribed to the server's `NOTIFICATIONS_COUNT_EVENT` push. I'd like to centralize this in the store.

**Why?** I felt #559 touched too much data fetching, when it was supposed to be a simple layout change. I'll re-attempt once this is in.

**Related Bug-fix:** cf3db04 clears the count on logout. Previously it was only ever written while logged in, so the badge kept the previous session's number until a reload.

**Tested:** this PR introduces 4 tests on the store. Also manually ran the serve and check notifications still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1iyNVQ1NGayfrb2DQ5VJa