### PR TITLE
feat: add admin site-stats dashboard

### DIFF
--- a/packages/server/src/__tests__/api.test.ts
+++ b/packages/server/src/__tests__/api.test.ts
@@ -404,4 +404,38 @@ describe("API Endpoints", () => {
       expect(response.body.username).toBe("testuser");
     });
   });
+
+  describe("GET /api/admin/stats", () => {
+    it("rejects anonymous requests", async () => {
+      const response = await request(app).get("/api/admin/stats").expect(401);
+
+      expect(response.body).toContain("Only admins");
+    });
+
+    it("rejects logged-in non-admins", async () => {
+      const userApp = createTestApp({
+        mockUser: { id: "user-id", login_type: "persistent" },
+      });
+
+      await request(userApp).get("/api/admin/stats").expect(401);
+    });
+
+    it("returns stats for admins", async () => {
+      const adminApp = createTestApp({
+        mockUser: { id: "admin-id", login_type: "persistent", role: "admin" },
+      });
+      const db = await getTestDb();
+      await db.collection("games").insertOne(makeTestGame());
+
+      const response = await request(adminApp)
+        .get("/api/admin/stats")
+        .expect(200);
+
+      expect(response.body.games.total).toBe(1);
+      expect(response.body.variants).toEqual([
+        expect.objectContaining({ variant: "baduk", games: 1 }),
+      ]);
+      expect(response.body.weeklyGames).toHaveLength(12);
+    });
+  });
 });

--- a/packages/server/src/__tests__/stats.test.ts
+++ b/packages/server/src/__tests__/stats.test.ts
@@ -1,0 +1,247 @@
+import { ObjectId } from "mongodb";
+import { randomBytes } from "node:crypto";
+import {
+  setupTestDb,
+  teardownTestDb,
+  clearTestDb,
+  getTestClient,
+} from "./helpers/setup";
+import { TimeControlType } from "@govariants/shared";
+
+vi.mock("../socket_io");
+vi.mock("../index");
+
+let getSiteStats: typeof import("../stats").getSiteStats;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+beforeAll(async () => {
+  await setupTestDb();
+  ({ getSiteStats } = await import("../stats"));
+}, 30000);
+
+afterAll(async () => {
+  await teardownTestDb();
+});
+
+beforeEach(async () => {
+  await clearTestDb();
+});
+
+async function getTestDb() {
+  return (await getTestClient()).db("govariants");
+}
+
+/**
+ * Games and users carry no created-at field, so getSiteStats reads creation time
+ * out of the ObjectId. Tests therefore have to backdate the _id, not a field.
+ */
+function idCreatedAt(date: Date): ObjectId {
+  // ObjectId.createFromTime zero-fills the remaining bytes, so two games created
+  // in the same second would collide. Randomise the tail to keep ids unique.
+  const timestampHex = Math.floor(date.getTime() / 1000)
+    .toString(16)
+    .padStart(8, "0");
+  return new ObjectId(timestampHex + randomBytes(8).toString("hex"));
+}
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * DAY_MS);
+}
+
+function makeGame(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: idCreatedAt(daysAgo(1)),
+    variant: "baduk",
+    config: { width: 9, height: 9, komi: 5.5 },
+    moves: [] as unknown[],
+    players: [null, null] as (string | null)[],
+    ...overrides,
+  };
+}
+
+function makeUser(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: idCreatedAt(daysAgo(1)),
+    login_type: "persistent",
+    username: "someone",
+    password_hash: "fake-hash",
+    ...overrides,
+  };
+}
+
+async function insertGames(...games: Record<string, unknown>[]) {
+  await (await getTestDb()).collection("games").insertMany(games);
+}
+
+describe("getSiteStats", () => {
+  it("returns zeroed stats for an empty database", async () => {
+    const stats = await getSiteStats();
+
+    expect(stats.games.total).toBe(0);
+    expect(stats.users.total).toBe(0);
+    expect(stats.users.activeSessions).toBe(0);
+    expect(stats.variants).toEqual([]);
+    expect(stats.timeControls).toEqual([]);
+  });
+
+  it("always returns twelve zero-filled weekly buckets, oldest first", async () => {
+    const stats = await getSiteStats();
+
+    expect(stats.weeklyGames).toHaveLength(12);
+    expect(stats.weeklyGames.every((week) => week.games === 0)).toBe(true);
+
+    const weekStarts = stats.weeklyGames.map((w) =>
+      new Date(w.weekStart).getTime(),
+    );
+    const ascending = [...weekStarts].sort((a, b) => a - b);
+    expect(weekStarts).toEqual(ascending);
+    // Every bucket starts on a Monday, exactly one week after the previous one.
+    expect(
+      stats.weeklyGames.every((w) => new Date(w.weekStart).getUTCDay() === 1),
+    ).toBe(true);
+  });
+
+  it("counts games created in the last week into the most recent bucket", async () => {
+    await insertGames(
+      makeGame({ _id: idCreatedAt(daysAgo(0)) }),
+      makeGame({ _id: idCreatedAt(daysAgo(200)) }),
+    );
+
+    const stats = await getSiteStats();
+
+    expect(stats.games.total).toBe(2);
+    // The 200-day-old game falls outside the twelve-week window.
+    const windowed = stats.weeklyGames.reduce((sum, w) => sum + w.games, 0);
+    expect(windowed).toBe(1);
+    expect(stats.weeklyGames[stats.weeklyGames.length - 1].games).toBe(1);
+  });
+
+  it("bucketizes games by recency window", async () => {
+    await insertGames(
+      makeGame({ _id: idCreatedAt(daysAgo(1)) }),
+      makeGame({ _id: idCreatedAt(daysAgo(10)) }),
+      makeGame({ _id: idCreatedAt(daysAgo(45)) }),
+    );
+
+    const stats = await getSiteStats();
+
+    expect(stats.games.total).toBe(3);
+    expect(stats.games.createdLast7Days).toBe(1);
+    expect(stats.games.createdLast30Days).toBe(2);
+  });
+
+  it("treats a game as seats-filled only when no seat is null", async () => {
+    await insertGames(
+      makeGame({ players: [null, null] }),
+      makeGame({ players: ["abc", null] }),
+      makeGame({ players: ["abc", "def"] }),
+    );
+
+    const stats = await getSiteStats();
+
+    expect(stats.games.seatsFilled).toBe(1);
+  });
+
+  it("counts played games and total moves", async () => {
+    await insertGames(
+      makeGame({ moves: [] }),
+      makeGame({ moves: [{ 0: "aa" }, { 1: "bb" }] }),
+      makeGame({ moves: [{ 0: "cc" }] }),
+    );
+
+    const stats = await getSiteStats();
+
+    expect(stats.games.withMoves).toBe(2);
+    expect(stats.games.totalMoves).toBe(3);
+  });
+
+  it("groups by variant, sorted by game count descending", async () => {
+    await insertGames(
+      makeGame({ variant: "baduk", players: ["a", "b"], moves: [{ 0: "aa" }] }),
+      makeGame({ variant: "baduk" }),
+      makeGame({ variant: "chess" }),
+      makeGame({ variant: "phantom", _id: idCreatedAt(daysAgo(90)) }),
+    );
+
+    const stats = await getSiteStats();
+
+    expect(stats.variants.map((v) => v.variant)).toEqual([
+      "baduk",
+      "chess",
+      "phantom",
+    ]);
+    expect(stats.variants[0]).toEqual({
+      variant: "baduk",
+      games: 2,
+      gamesLast30Days: 2,
+      seatsFilled: 1,
+      withMoves: 1,
+      totalMoves: 1,
+    });
+    // The phantom game is older than 30 days.
+    expect(stats.variants[2].gamesLast30Days).toBe(0);
+  });
+
+  it("labels time controls and folds unclocked games into Unlimited", async () => {
+    await insertGames(
+      makeGame({ config: { time_control: { type: TimeControlType.Fischer } } }),
+      makeGame({ config: { time_control: { type: TimeControlType.Fischer } } }),
+      makeGame({ config: { time_control: { type: TimeControlType.ByoYomi } } }),
+      makeGame({ config: { width: 9 } }),
+    );
+
+    const stats = await getSiteStats();
+
+    // Sorted by game count descending; ties break on the raw enum value, where
+    // the null of an unclocked game sorts ahead of any number.
+    expect(stats.timeControls).toEqual([
+      { label: "Fischer", games: 2 },
+      { label: "Unlimited", games: 1 },
+      { label: "Byo-Yomi", games: 1 },
+    ]);
+  });
+
+  it("splits users by login type and counts recent registrations", async () => {
+    const db = await getTestDb();
+    await db
+      .collection("users")
+      .insertMany([
+        makeUser({ _id: idCreatedAt(daysAgo(1)) }),
+        makeUser({ _id: idCreatedAt(daysAgo(100)) }),
+        { _id: idCreatedAt(daysAgo(2)), login_type: "guest", token: "t1" },
+        { _id: idCreatedAt(daysAgo(3)), login_type: "guest", token: "t2" },
+      ]);
+
+    const stats = await getSiteStats();
+
+    expect(stats.users.total).toBe(4);
+    expect(stats.users.registered).toBe(2);
+    expect(stats.users.guest).toBe(2);
+    expect(stats.users.registeredLast30Days).toBe(1);
+  });
+
+  it("counts only unexpired sessions as active", async () => {
+    const db = await getTestDb();
+    await db.collection("sessions").insertMany([
+      { _id: "a", expires: new Date(Date.now() + DAY_MS) },
+      { _id: "b", expires: new Date(Date.now() + 10 * DAY_MS) },
+      { _id: "c", expires: new Date(Date.now() - DAY_MS) },
+    ]);
+
+    const stats = await getSiteStats();
+
+    expect(stats.users.activeSessions).toBe(2);
+  });
+
+  it("reports no user-identifying data", async () => {
+    const db = await getTestDb();
+    await db.collection("users").insertOne(makeUser({ username: "alice" }));
+    await insertGames(makeGame({ players: ["alice-id", "bob-id"] }));
+
+    const serialized = JSON.stringify(await getSiteStats());
+
+    expect(serialized).not.toContain("alice");
+    expect(serialized).not.toContain("bob-id");
+  });
+});

--- a/packages/server/src/api.ts
+++ b/packages/server/src/api.ts
@@ -42,6 +42,7 @@ import {
 import { io } from "./socket_io";
 import { checkCSRFToken, generateCSRFToken } from "./csrf_guard";
 import { sendEmail } from "./email";
+import { getSiteStats } from "./stats";
 import { HttpError } from "./http-error";
 import { authLimiter } from "./rate_limit";
 import {
@@ -399,6 +400,15 @@ router.post("/admin/test-email", checkCSRFToken, async (req, res) => {
   );
 
   res.json({ success: true, message: "Test email sent successfully." });
+});
+
+router.get("/admin/stats", checkCSRFToken, async (req, res) => {
+  if (!req.user || (req.user as UserResponse).role !== "admin") {
+    res.status(401).json("Only admins may view site stats.");
+    return;
+  }
+
+  res.json(await getSiteStats());
 });
 
 router.get("/notifications/count", checkCSRFToken, async (req, res) => {

--- a/packages/server/src/stats.ts
+++ b/packages/server/src/stats.ts
@@ -1,0 +1,275 @@
+import { Collection, Document } from "mongodb";
+import {
+  SiteStatsResponse,
+  TimeControlType,
+  TimeControlUsage,
+  VariantStats,
+  WeeklyGameCount,
+} from "@govariants/shared";
+import { getDb } from "./db";
+import type { GameSchema } from "./games";
+
+/** Number of weeks in the game-creation series. */
+const WEEKS = 12;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * DAY_MS;
+
+function gamesCollection(): Collection<GameSchema> {
+  return getDb().db().collection<GameSchema>("games");
+}
+
+function usersCollection(): Collection<Document> {
+  return getDb().db().collection("users");
+}
+
+/** The session store configured in index.ts; connect-mongo's default collection. */
+function sessionsCollection(): Collection<Document> {
+  return getDb().db().collection("sessions");
+}
+
+const TIME_CONTROL_LABELS: Record<number, string> = {
+  [TimeControlType.Invalid]: "Invalid",
+  [TimeControlType.Absolute]: "Absolute",
+  [TimeControlType.Fischer]: "Fischer",
+  [TimeControlType.Simple]: "Simple",
+  [TimeControlType.ByoYomi]: "Byo-Yomi",
+  [TimeControlType.Canadian]: "Canadian",
+};
+
+function timeControlLabel(type: unknown): string {
+  if (type === null || type === undefined) {
+    // config.time_control is omitted for games played without a clock.
+    return "Unlimited";
+  }
+  return TIME_CONTROL_LABELS[type as number] ?? `Unknown (${String(type)})`;
+}
+
+/** Midnight UTC on the Monday of the week containing `date`. */
+function startOfIsoWeekUtc(date: Date): Date {
+  const utcMidnight = Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+  );
+  // getUTCDay() is 0 for Sunday, which is 6 days after the week's Monday.
+  const daysSinceMonday = (date.getUTCDay() + 6) % 7;
+  return new Date(utcMidnight - daysSinceMonday * DAY_MS);
+}
+
+/**
+ * Zero-fills the weekly series so the chart always shows `WEEKS` buckets, even
+ * for weeks in which no game was created.
+ */
+function buildWeeklySeries(
+  counts: Map<number, number>,
+  firstWeekStart: Date,
+): WeeklyGameCount[] {
+  return Array.from({ length: WEEKS }, (_, i) => {
+    const weekStart = new Date(firstWeekStart.getTime() + i * WEEK_MS);
+    return {
+      weekStart: weekStart.toISOString(),
+      games: counts.get(weekStart.getTime()) ?? 0,
+    };
+  });
+}
+
+type GamesFacet = {
+  totals: Array<{
+    total: number;
+    createdLast7Days: number;
+    createdLast30Days: number;
+    seatsFilled: number;
+    withMoves: number;
+    totalMoves: number;
+  }>;
+  byVariant: Array<Omit<VariantStats, "variant"> & { _id: string }>;
+  weekly: Array<{ _id: Date; games: number }>;
+  byTimeControl: Array<{ _id: number | null; games: number }>;
+};
+
+type UsersFacet = {
+  total: number;
+  registered: number;
+  guest: number;
+  registeredLast30Days: number;
+};
+
+/**
+ * Aggregate usage numbers for the admin dashboard.
+ *
+ * Everything here is derived from documents we already store, so no additional
+ * tracking is involved and nothing user-identifying is returned. Games and users
+ * have no created-at field; `_id` is an ObjectId, whose leading four bytes are a
+ * second-resolution creation timestamp, so `$toDate: "$_id"` recovers it.
+ *
+ * Note that "finished" is not among the metrics: whether a game has ended is not
+ * stored, and deriving it means replaying every game's moves through its variant.
+ * `withMoves` is the cheap proxy for "this game actually got played".
+ *
+ * These pipelines scan the games and users collections in full. That is fine at
+ * this site's scale, but it is the reason this is admin-only and computed on
+ * request rather than on every page load.
+ */
+export async function getSiteStats(): Promise<SiteStatsResponse> {
+  const now = new Date();
+  const last7Days = new Date(now.getTime() - 7 * DAY_MS);
+  const last30Days = new Date(now.getTime() - 30 * DAY_MS);
+  const firstWeekStart = new Date(
+    startOfIsoWeekUtc(now).getTime() - (WEEKS - 1) * WEEK_MS,
+  );
+
+  // A string condition is a field path (e.g. "$seatsFilled"); an object is an expression.
+  const countIf = (condition: Document | string) => ({
+    $sum: { $cond: [condition, 1, 0] },
+  });
+  const createdSince = (cutoff: Date) => ({ $gte: ["$createdAt", cutoff] });
+
+  const [gamesFacet, usersFacet, activeSessions] = await Promise.all([
+    gamesCollection()
+      .aggregate<GamesFacet>([
+        {
+          $addFields: {
+            createdAt: { $toDate: "$_id" },
+            moveCount: { $size: { $ifNull: ["$moves", []] } },
+            seatCount: { $size: { $ifNull: ["$players", []] } },
+            emptySeatCount: {
+              $size: {
+                $filter: {
+                  input: { $ifNull: ["$players", []] },
+                  cond: { $eq: ["$$this", null] },
+                },
+              },
+            },
+          },
+        },
+        {
+          $addFields: {
+            seatsFilled: {
+              $and: [
+                { $gt: ["$seatCount", 0] },
+                { $eq: ["$emptySeatCount", 0] },
+              ],
+            },
+          },
+        },
+        {
+          $facet: {
+            totals: [
+              {
+                $group: {
+                  _id: null,
+                  total: { $sum: 1 },
+                  createdLast7Days: countIf(createdSince(last7Days)),
+                  createdLast30Days: countIf(createdSince(last30Days)),
+                  seatsFilled: countIf("$seatsFilled"),
+                  withMoves: countIf({ $gt: ["$moveCount", 0] }),
+                  totalMoves: { $sum: "$moveCount" },
+                },
+              },
+            ],
+            byVariant: [
+              {
+                $group: {
+                  _id: "$variant",
+                  games: { $sum: 1 },
+                  gamesLast30Days: countIf(createdSince(last30Days)),
+                  seatsFilled: countIf("$seatsFilled"),
+                  withMoves: countIf({ $gt: ["$moveCount", 0] }),
+                  totalMoves: { $sum: "$moveCount" },
+                },
+              },
+              { $sort: { games: -1, _id: 1 } },
+            ],
+            weekly: [
+              { $match: { createdAt: { $gte: firstWeekStart } } },
+              {
+                $group: {
+                  _id: {
+                    $dateTrunc: {
+                      date: "$createdAt",
+                      unit: "week",
+                      startOfWeek: "monday",
+                      timezone: "UTC",
+                    },
+                  },
+                  games: { $sum: 1 },
+                },
+              },
+            ],
+            byTimeControl: [
+              {
+                $group: {
+                  _id: { $ifNull: ["$config.time_control.type", null] },
+                  games: { $sum: 1 },
+                },
+              },
+              { $sort: { games: -1, _id: 1 } },
+            ],
+          },
+        },
+      ])
+      .next(),
+    usersCollection()
+      .aggregate<UsersFacet>([
+        { $addFields: { createdAt: { $toDate: "$_id" } } },
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            registered: countIf({ $eq: ["$login_type", "persistent"] }),
+            guest: countIf({ $eq: ["$login_type", "guest"] }),
+            registeredLast30Days: countIf({
+              $and: [
+                { $eq: ["$login_type", "persistent"] },
+                createdSince(last30Days),
+              ],
+            }),
+          },
+        },
+      ])
+      .next(),
+    sessionsCollection().countDocuments({ expires: { $gt: now } }),
+  ]);
+
+  const totals = gamesFacet?.totals[0];
+  const weeklyCounts = new Map(
+    (gamesFacet?.weekly ?? []).map((bucket) => [
+      bucket._id.getTime(),
+      bucket.games,
+    ]),
+  );
+
+  const timeControls: TimeControlUsage[] = (
+    gamesFacet?.byTimeControl ?? []
+  ).map((entry) => ({
+    label: timeControlLabel(entry._id),
+    games: entry.games,
+  }));
+
+  const variants: VariantStats[] = (gamesFacet?.byVariant ?? []).map(
+    ({ _id, ...rest }) => ({ variant: _id, ...rest }),
+  );
+
+  return {
+    generatedAt: now.toISOString(),
+    games: {
+      total: totals?.total ?? 0,
+      createdLast7Days: totals?.createdLast7Days ?? 0,
+      createdLast30Days: totals?.createdLast30Days ?? 0,
+      seatsFilled: totals?.seatsFilled ?? 0,
+      withMoves: totals?.withMoves ?? 0,
+      totalMoves: totals?.totalMoves ?? 0,
+    },
+    users: {
+      total: usersFacet?.total ?? 0,
+      registered: usersFacet?.registered ?? 0,
+      guest: usersFacet?.guest ?? 0,
+      registeredLast30Days: usersFacet?.registeredLast30Days ?? 0,
+      activeSessions,
+    },
+    variants,
+    weeklyGames: buildWeeklySeries(weeklyCounts, firstWeekStart),
+    timeControls,
+  };
+}

--- a/packages/shared/src/api_types.ts
+++ b/packages/shared/src/api_types.ts
@@ -79,3 +79,54 @@ export type GameErrorResponse = {
   variant: string;
   errorMessage: string;
 };
+
+/** One bucket of the site-stats weekly game-creation series. */
+export type WeeklyGameCount = {
+  /** ISO date of the Monday that starts the (UTC) week. */
+  weekStart: string;
+  games: number;
+};
+
+export type VariantStats = {
+  variant: string;
+  games: number;
+  gamesLast30Days: number;
+  /** Games where every seat is occupied. */
+  seatsFilled: number;
+  /** Games with at least one move played. */
+  withMoves: number;
+  totalMoves: number;
+};
+
+export type TimeControlUsage = {
+  /** Human-readable time control name, or "Unlimited" when none is configured. */
+  label: string;
+  games: number;
+};
+
+/**
+ * Aggregate site usage, computed on demand from the games, users and sessions
+ * collections. Deliberately contains no per-user or per-game identifiers.
+ */
+export type SiteStatsResponse = {
+  generatedAt: string;
+  games: {
+    total: number;
+    createdLast7Days: number;
+    createdLast30Days: number;
+    seatsFilled: number;
+    withMoves: number;
+    totalMoves: number;
+  };
+  users: {
+    total: number;
+    registered: number;
+    guest: number;
+    registeredLast30Days: number;
+    /** Sessions whose cookie has not yet expired — a rough "recently active" count. */
+    activeSessions: number;
+  };
+  variants: VariantStats[];
+  weeklyGames: WeeklyGameCount[];
+  timeControls: TimeControlUsage[];
+};

--- a/packages/shared/src/api_types.ts
+++ b/packages/shared/src/api_types.ts
@@ -82,7 +82,7 @@ export type GameErrorResponse = {
 
 /** One bucket of the site-stats weekly game-creation series. */
 export type WeeklyGameCount = {
-  /** ISO date of the Monday that starts the (UTC) week. */
+  /** ISO timestamp of midnight UTC on the Monday that starts the week. */
   weekStart: string;
   games: number;
 };

--- a/packages/vue-client/src/components/AdminStats.vue
+++ b/packages/vue-client/src/components/AdminStats.vue
@@ -1,0 +1,611 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import type { SiteStatsResponse } from "@govariants/shared";
+import * as requests from "../requests";
+
+const stats = ref<SiteStatsResponse | null>(null);
+const errorMessage = ref<string | null>(null);
+const isLoading = ref(false);
+const showWeeklyTable = ref(false);
+const hoveredWeek = ref<number | null>(null);
+
+const compactFormatter = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const plainFormatter = new Intl.NumberFormat();
+
+/** Stat-tile values are compacted; table columns stay exact so they can be summed. */
+function compact(value: number): string {
+  return value < 10_000 ? plainFormatter.format(value) : compactFormatter.format(value);
+}
+
+function percentOf(value: number, total: number): string {
+  if (!total) return "—";
+  return `${Math.round((value / total) * 100)}%`;
+}
+
+function average(total: number, count: number): string {
+  if (!count) return "—";
+  return (total / count).toFixed(1);
+}
+
+function weekLabel(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+async function load() {
+  isLoading.value = true;
+  errorMessage.value = null;
+  try {
+    stats.value = await requests.get("/admin/stats");
+  } catch (error) {
+    errorMessage.value = (error as Error).message;
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+onMounted(load);
+
+const tiles = computed(() => {
+  const s = stats.value;
+  if (!s) return [];
+  return [
+    { label: "Games all time", value: compact(s.games.total) },
+    { label: "Games last 30 days", value: compact(s.games.createdLast30Days) },
+    { label: "Registered users", value: compact(s.users.registered) },
+    { label: "Guest users", value: compact(s.users.guest) },
+    { label: "Active sessions", value: compact(s.users.activeSessions) },
+  ];
+});
+
+/** Rounds the axis maximum up to a clean number so gridline ticks read well. */
+const weeklyMax = computed(() => {
+  const peak = Math.max(0, ...(stats.value?.weeklyGames ?? []).map((w) => w.games));
+  if (peak === 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(peak));
+  return Math.ceil(peak / magnitude) * magnitude;
+});
+
+/**
+ * Labelling all twelve buckets crowds the axis on narrow screens, so label the
+ * most recent one and every third bucket back from it; the rest are carried by
+ * the tooltip and the table view.
+ */
+function isLabelledWeek(index: number, length: number): boolean {
+  return (length - 1 - index) % 3 === 0;
+}
+
+const funnel = computed(() => {
+  const s = stats.value;
+  if (!s) return [];
+  const total = s.games.total;
+  return [
+    { stage: "Created", count: total, step: 1 },
+    { stage: "All seats filled", count: s.games.seatsFilled, step: 2 },
+    { stage: "At least one move", count: s.games.withMoves, step: 3 },
+  ].map((row) => ({
+    ...row,
+    share: percentOf(row.count, total),
+    width: total ? (row.count / total) * 100 : 0,
+  }));
+});
+
+const timeControlMax = computed(() =>
+  Math.max(1, ...(stats.value?.timeControls ?? []).map((t) => t.games)),
+);
+
+const generatedAt = computed(() =>
+  stats.value ? new Date(stats.value.generatedAt).toLocaleString() : "",
+);
+</script>
+
+<template>
+  <section class="admin-stats">
+    <div class="section-header">
+      <h2>Site stats</h2>
+      <button :disabled="isLoading" @click="load">
+        {{ isLoading ? "Loading..." : "Refresh" }}
+      </button>
+    </div>
+
+    <p v-if="errorMessage" class="error">Could not load stats: {{ errorMessage }}</p>
+    <p v-else-if="!stats" class="muted">Loading…</p>
+
+    <!-- Held at reduced opacity during a refetch so the layout never jumps. -->
+    <div v-if="stats" class="stats-body" :class="{ refetching: isLoading }">
+      <p class="muted generated-at">Computed {{ generatedAt }}</p>
+
+      <ul class="tile-row">
+        <li v-for="tile in tiles" :key="tile.label" class="tile">
+          <span class="tile-label">{{ tile.label }}</span>
+          <span class="tile-value">{{ tile.value }}</span>
+        </li>
+      </ul>
+
+      <div class="chart-card">
+        <div class="section-header">
+          <div>
+            <h3>Games created per week</h3>
+            <p class="muted">Last 12 weeks by ISO week (UTC); the final week is still in progress.</p>
+          </div>
+          <button class="link-button" @click="showWeeklyTable = !showWeeklyTable">
+            {{ showWeeklyTable ? "Show chart" : "Show table" }}
+          </button>
+        </div>
+
+        <div v-if="showWeeklyTable" class="table-scroll">
+        <table class="stats-table">
+          <thead>
+            <tr>
+              <th scope="col">Week starting</th>
+              <th scope="col" class="numeric">Games</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="week in stats.weeklyGames" :key="week.weekStart">
+              <td>{{ weekLabel(week.weekStart) }}</td>
+              <td class="numeric">{{ plainFormatter.format(week.games) }}</td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+
+        <div v-else class="column-chart">
+          <div class="y-axis">
+            <span>{{ plainFormatter.format(weeklyMax) }}</span>
+            <span>{{ plainFormatter.format(Math.round(weeklyMax / 2)) }}</span>
+            <span>0</span>
+          </div>
+          <div class="plot">
+            <div class="gridline" style="bottom: 100%"></div>
+            <div class="gridline" style="bottom: 50%"></div>
+            <div class="gridline baseline" style="bottom: 0"></div>
+            <div
+              v-for="(week, index) in stats.weeklyGames"
+              :key="week.weekStart"
+              class="column-slot"
+              tabindex="0"
+              :aria-label="`Week starting ${weekLabel(week.weekStart)}: ${week.games} games`"
+              @mouseenter="hoveredWeek = index"
+              @mouseleave="hoveredWeek = null"
+              @focus="hoveredWeek = index"
+              @blur="hoveredWeek = null"
+            >
+              <div
+                class="column"
+                :style="{ height: `${(week.games / weeklyMax) * 100}%` }"
+              ></div>
+              <div v-if="hoveredWeek === index" class="tooltip" role="tooltip">
+                <strong>{{ plainFormatter.format(week.games) }}</strong>
+                games<br />
+                <span class="muted">week of {{ weekLabel(week.weekStart) }}</span>
+              </div>
+            </div>
+          </div>
+          <div class="x-axis">
+            <span
+              v-for="(week, index) in stats.weeklyGames"
+              :key="week.weekStart"
+              class="x-tick"
+            >
+              {{ isLabelledWeek(index, stats.weeklyGames.length) ? weekLabel(week.weekStart) : "" }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="chart-card">
+        <h3>How far games get</h3>
+        <p class="muted">
+          Whether a game finished is not stored, so “at least one move” stands in for
+          “actually played”.
+        </p>
+        <ul class="funnel">
+          <li v-for="row in funnel" :key="row.stage">
+            <div class="funnel-label">
+              <span>{{ row.stage }}</span>
+              <span class="muted">{{ row.share }}</span>
+            </div>
+            <div class="funnel-plot">
+              <div
+                class="funnel-bar"
+                :class="`funnel-step-${row.step}`"
+                :style="{ width: `${row.width}%` }"
+              >
+                <span class="funnel-value">{{ plainFormatter.format(row.count) }}</span>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="chart-card">
+        <h3>Variants</h3>
+        <div class="table-scroll">
+        <table class="stats-table">
+          <thead>
+            <tr>
+              <th scope="col">Variant</th>
+              <th scope="col" class="numeric">Games</th>
+              <th scope="col" class="numeric">Last 30d</th>
+              <th scope="col" class="numeric">Seats filled</th>
+              <th scope="col" class="numeric">Played</th>
+              <th scope="col" class="numeric">Avg moves</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="variant in stats.variants" :key="variant.variant">
+              <td>{{ variant.variant }}</td>
+              <td class="numeric">{{ plainFormatter.format(variant.games) }}</td>
+              <td class="numeric">{{ plainFormatter.format(variant.gamesLast30Days) }}</td>
+              <td class="numeric">{{ plainFormatter.format(variant.seatsFilled) }}</td>
+              <td class="numeric">{{ plainFormatter.format(variant.withMoves) }}</td>
+              <td class="numeric">{{ average(variant.totalMoves, variant.withMoves) }}</td>
+            </tr>
+            <tr v-if="!stats.variants.length">
+              <td colspan="6" class="muted">No games yet.</td>
+            </tr>
+          </tbody>
+        </table>
+        </div>
+      </div>
+
+      <div class="chart-card">
+        <h3>Time controls</h3>
+        <ul class="bar-list">
+          <li v-for="entry in stats.timeControls" :key="entry.label">
+            <span class="bar-list-label">{{ entry.label }}</span>
+            <span class="bar-list-plot">
+              <span
+                class="bar-list-bar"
+                :style="{ width: `${(entry.games / timeControlMax) * 100}%` }"
+              >
+                <span class="bar-list-value">{{ plainFormatter.format(entry.games) }}</span>
+              </span>
+            </span>
+          </li>
+          <li v-if="!stats.timeControls.length" class="muted">No games yet.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+/*
+ * Chart hues are steps of the site's brand green, picked per mode against that
+ * mode's surface rather than flipped automatically, so marks keep a >= 3:1
+ * contrast against the background in both themes.
+ */
+.admin-stats {
+  margin-bottom: 2rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+
+  --chart-accent: #00a86f;
+  --funnel-step-1: #45c096;
+  --funnel-step-2: #22a176;
+  --funnel-step-3: #007d52;
+}
+
+@media (prefers-color-scheme: dark) {
+  .admin-stats {
+    --chart-accent: #1faf7a;
+    --funnel-step-1: #0e6b4d;
+    --funnel-step-2: #158a63;
+    --funnel-step-3: #1faf7a;
+  }
+}
+
+.admin-stats h2 {
+  margin-top: 0;
+}
+
+.section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.stats-body {
+  transition: opacity 0.2s;
+}
+
+.stats-body.refetching {
+  opacity: 0.6;
+}
+
+.generated-at {
+  margin-bottom: 1rem;
+}
+
+.muted {
+  color: var(--color-text);
+  opacity: 0.7;
+  font-size: 0.85em;
+}
+
+.error {
+  color: var(--color-warn);
+}
+
+.tile-row {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-background-soft);
+}
+
+.tile-label {
+  font-size: 0.8rem;
+  opacity: 0.75;
+}
+
+.tile-value {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--color-heading);
+  line-height: 1.2;
+}
+
+.chart-card {
+  margin-top: 1.5rem;
+}
+
+.chart-card h3 {
+  color: var(--color-heading);
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.column-chart {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-areas:
+    "y-axis plot"
+    ".      x-axis";
+  gap: 0 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.y-axis {
+  grid-area: y-axis;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 180px;
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+  text-align: right;
+  /* Nudge the tick text so each label sits on its gridline rather than below it. */
+  margin-block: -0.55em;
+}
+
+.plot {
+  grid-area: plot;
+  position: relative;
+  height: 180px;
+  display: flex;
+  align-items: flex-end;
+  /* The 2px surface gap that separates adjacent columns. */
+  gap: 2px;
+}
+
+.gridline {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.gridline.baseline {
+  border-top-color: var(--color-border-hover);
+}
+
+.column-slot {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  cursor: default;
+}
+
+.column-slot:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.column {
+  width: 100%;
+  max-width: 24px;
+  min-height: 1px;
+  background: var(--chart-accent);
+  /* Rounded at the data end, square where it meets the baseline. */
+  border-radius: 4px 4px 0 0;
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 0.4rem;
+  padding: 0.35rem 0.6rem;
+  white-space: nowrap;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  background: var(--color-background);
+  border: 1px solid var(--color-border-hover);
+  border-radius: 4px;
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.x-axis {
+  grid-area: x-axis;
+  display: flex;
+  gap: 2px;
+  margin-top: 0.35rem;
+}
+
+.x-tick {
+  flex: 1;
+  text-align: center;
+  font-size: 0.7rem;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+.funnel {
+  list-style: none;
+  padding: 0;
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.funnel-label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  margin-bottom: 0.2rem;
+}
+
+/*
+ * Bar widths are percentages of the plot, and the value label is taken out of
+ * flow at the bar's end so it can never shorten the bar it labels. The reserved
+ * padding is what keeps a full-width bar's label on screen.
+ */
+.funnel-plot,
+.bar-list-plot {
+  display: block;
+  padding-right: 3.5rem;
+}
+
+.funnel-bar {
+  position: relative;
+  height: 16px;
+  min-width: 2px;
+  border-radius: 0 4px 4px 0;
+}
+
+.funnel-step-1 {
+  background: var(--funnel-step-1);
+}
+
+.funnel-step-2 {
+  background: var(--funnel-step-2);
+}
+
+.funnel-step-3 {
+  background: var(--funnel-step-3);
+}
+
+.funnel-value,
+.bar-list-value {
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 0.5rem;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* Six columns do not fit a phone; the table scrolls, the page does not. */
+.table-scroll {
+  overflow-x: auto;
+}
+
+.stats-table {
+  width: 100%;
+  min-width: 30rem;
+  border-collapse: collapse;
+  margin-top: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.stats-table th,
+.stats-table td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.stats-table th {
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.stats-table .numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.bar-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.bar-list li {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.bar-list-bar {
+  display: block;
+  position: relative;
+  height: 12px;
+  min-width: 2px;
+  background: var(--chart-accent);
+  border-radius: 0 4px 4px 0;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0;
+  text-decoration: underline;
+}
+
+@media (max-width: 540px) {
+  .bar-list li {
+    grid-template-columns: 5.5rem 1fr;
+  }
+}
+</style>

--- a/packages/vue-client/src/views/AdminView.vue
+++ b/packages/vue-client/src/views/AdminView.vue
@@ -4,6 +4,7 @@ import * as requests from "../requests";
 import { useCurrentUser } from "@/stores/user";
 import Swal from "sweetalert2";
 import router from "@/router";
+import AdminStats from "@/components/AdminStats.vue";
 
 const loggedInUser = useCurrentUser();
 const testEmailAddress = ref<string>("");
@@ -65,11 +66,20 @@ async function sendTestEmail() {
           </button>
         </div>
       </section>
+
+      <div class="stats-panel">
+        <AdminStats />
+      </div>
     </div>
   </main>
 </template>
 
 <style scoped>
+/* The page layout is two columns from 1024px up; the dashboard wants all of it. */
+.stats-panel {
+  grid-column: 1 / -1;
+}
+
 .admin-section {
   margin-bottom: 2rem;
   padding: 1rem;


### PR DESCRIPTION
Adds a **Site stats** panel to the `/admin` page.

## Notes for reviewers
- The aggregations do a **full collection scan** per request — fine at current scale, and the reason this is admin-only and on-demand. We can consider an index or a cached snapshot if the games collection grows large.
- **Guests are counted separately from registered users** throughout

## Screenshots
<img width="1233" height="255" alt="Screenshot 2026-09-05 at 12 50 47 PM" src="https://github.com/user-attachments/assets/1b55fb8a-feca-4f03-9943-328f17113130" />
<img width="1239" height="721" alt="Screenshot 2026-09-05 at 12 50 29 PM" src="https://github.com/user-attachments/assets/efa28834-1bc3-4ff7-b587-a70812ce6627" />
<img width="1237" height="470" alt="Screenshot 2026-09-05 at 12 50 41 PM" src="https://github.com/user-attachments/assets/ad80d622-99b3-4d35-ba5f-44d35853e482" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHKK44AC854sR1JieLVBzr