### PR TITLE
Show the notifications bell in the mobile top bar

### DIFF
--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -34,6 +34,7 @@ const toggleMenuFn = (event: MouseEvent) => {
     <RouterLink class="navLogo" to="/">
       <img class="navLogoImg" src="/favicon.ico" />
     </RouterLink>
+    <NotificationsNav class="navNotificationsMobile" />
     <button class="navHamburgerContainer navElement" @click="toggleMenuFn">
       <font-awesome-icon icon="fa-solid fa-bars" class="navHamburgerMenu" />
     </button>
@@ -51,7 +52,7 @@ const toggleMenuFn = (event: MouseEvent) => {
           <font-awesome-icon icon="fa-solid fa-book" class="icon" />
           {{ $t("rules") }}
         </RouterLink>
-        <NotificationsNav />
+        <NotificationsNav class="navNotificationsDesktop" />
       </div>
       <div>
         <UserNav />
@@ -90,6 +91,10 @@ nav {
     }
   }
 
+  a.navNotificationsMobile {
+    display: none;
+  }
+
   .navContent {
     display: flex;
     justify-content: space-between;
@@ -104,6 +109,16 @@ nav {
 @media (max-width: 768px) {
   nav {
     justify-content: space-between;
+
+    /* The bell lives in the top bar, not inside the hamburger menu. */
+    a.navNotificationsMobile {
+      display: flex;
+      margin-left: auto;
+    }
+
+    a.navNotificationsDesktop {
+      display: none;
+    }
 
     .navHamburgerContainer {
       display: flex;

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -110,17 +110,12 @@ nav {
   nav {
     justify-content: space-between;
 
-    /* The glyph is 1em, so this one number sizes it and its badge, in scale
-       with the hamburger beside it. */
     a.navNotificationsMobile {
       display: flex;
       margin-left: auto;
       font-size: calc(var(--navbar-height) * 0.56);
     }
 
-    /* A glyph this size has room for the badge on its corner, placed as a
-       fraction of the icon. Flex drops the line-height slack an inline-block
-       leaves under the svg, which those fractions would measure against. */
     a.navNotificationsMobile :deep(.icon-wrapper) {
       display: flex;
     }

--- a/packages/vue-client/src/App.vue
+++ b/packages/vue-client/src/App.vue
@@ -110,10 +110,26 @@ nav {
   nav {
     justify-content: space-between;
 
-    /* The bell lives in the top bar, not inside the hamburger menu. */
+    /* The glyph is 1em, so this one number sizes it and its badge, in scale
+       with the hamburger beside it. */
     a.navNotificationsMobile {
       display: flex;
       margin-left: auto;
+      font-size: calc(var(--navbar-height) * 0.56);
+    }
+
+    /* A glyph this size has room for the badge on its corner, placed as a
+       fraction of the icon. Flex drops the line-height slack an inline-block
+       leaves under the svg, which those fractions would measure against. */
+    a.navNotificationsMobile :deep(.icon-wrapper) {
+      display: flex;
+    }
+
+    a.navNotificationsMobile :deep(.badge) {
+      top: -22%;
+      right: -32%;
+      font-size: 0.45em;
+      padding: 0.2em 0.4em 0.3em 0.4em;
     }
 
     a.navNotificationsDesktop {

--- a/packages/vue-client/src/components/NotificationsNav.vue
+++ b/packages/vue-client/src/components/NotificationsNav.vue
@@ -23,7 +23,6 @@ const notificationCount = useNotificationsCount();
         Math.min(notificationCount, 99)
       }}</span>
     </div>
-    <span class="mobile-only">{{ $t("notifications") }}</span>
   </RouterLink>
 </template>
 
@@ -31,17 +30,6 @@ const notificationCount = useNotificationsCount();
 .icon-wrapper {
   position: relative;
   display: inline-block;
-}
-
-.mobile-only {
-  display: none;
-}
-
-/* Mobile breakpoint - keep in sync with App.vue nav hamburger */
-@media (max-width: 768px) {
-  .mobile-only {
-    display: inline;
-  }
 }
 
 .badge {


### PR DESCRIPTION
On mobile the notifications bell lived inside the hamburger menu, so an unread badge was hidden. This moves it into the top bar. **Desktop is unchanged.**

## Screenshots

| | Before | After |
|---|---|---|
| **Mobile top bar** | <img width="780" height="100" alt="mobile-before" src="https://github.com/user-attachments/assets/d65da437-b944-48a9-8136-8da1991e47a8" /> | <img width="780" height="100" alt="mobile-final" src="https://github.com/user-attachments/assets/e682e851-5ede-4b9d-90dc-3237a8ad97db" /> |
| **Mobile, menu open** | <img width="780" height="660" alt="mobile-menu-open-before" src="https://github.com/user-attachments/assets/1e375165-28bf-432d-b21d-b1e041a8b9db" /> | <img width="780" height="660" alt="mobile-menu-open-final" src="https://github.com/user-attachments/assets/8b95aa5e-387d-433d-973a-9dcab7faed97" /> |

**Desktop** is unchanged

<img width="2560" height="100" alt="desktop-final" src="https://github.com/user-attachments/assets/113ecde1-aa7d-415a-b74a-050d96232b34" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163i9UrU6PvGzQ2d4V9Pzu9
