### PR TITLE
Download the mongod binary once, before test workers start

### DIFF
--- a/packages/server/src/__tests__/helpers/global-setup.ts
+++ b/packages/server/src/__tests__/helpers/global-setup.ts
@@ -1,15 +1,7 @@
 import { MongoBinary } from "mongodb-memory-server";
 
-/**
- * Every test file that touches the database starts its own MongoMemoryServer,
- * and each one downloads the mongod binary if it is not already cached. CI
- * caches yarn's dependencies but not ~/.cache/mongodb-binaries, so on a cold
- * cache those downloads run in parallel, race for the same lock file, and all
- * but one crash with "Cannot unlock file ... it is not locked by this process".
- *
- * Fetching the binary once here, before any worker starts, leaves them nothing
- * to race for. It is a no-op once the binary is cached.
- */
+// On a cold cache, parallel test files each download the mongod binary and race
+// for its lock file. Fetching it once here leaves them nothing to race for.
 export default async function setup(): Promise<void> {
   await MongoBinary.getPath({});
 }

--- a/packages/server/src/__tests__/helpers/global-setup.ts
+++ b/packages/server/src/__tests__/helpers/global-setup.ts
@@ -1,0 +1,15 @@
+import { MongoBinary } from "mongodb-memory-server";
+
+/**
+ * Every test file that touches the database starts its own MongoMemoryServer,
+ * and each one downloads the mongod binary if it is not already cached. CI
+ * caches yarn's dependencies but not ~/.cache/mongodb-binaries, so on a cold
+ * cache those downloads run in parallel, race for the same lock file, and all
+ * but one crash with "Cannot unlock file ... it is not locked by this process".
+ *
+ * Fetching the binary once here, before any worker starts, leaves them nothing
+ * to race for. It is a no-op once the binary is cached.
+ */
+export default async function setup(): Promise<void> {
+  await MongoBinary.getPath({});
+}

--- a/packages/server/src/__tests__/helpers/global-setup.ts
+++ b/packages/server/src/__tests__/helpers/global-setup.ts
@@ -1,7 +1,7 @@
 import { MongoBinary } from "mongodb-memory-server";
 
-// On a cold cache, parallel test files each download the mongod binary and race
-// for its lock file. Fetching it once here leaves them nothing to race for.
+// Fetching once here prevents a mongod download per test suite, which would
+// otherwise race for the same lock file on a cold cache.
 export default async function setup(): Promise<void> {
   await MongoBinary.getPath({});
 }

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**", "src/__tests__/helpers/**"],
+    globalSetup: ["src/__tests__/helpers/global-setup.ts"],
     testTimeout: 10000,
   },
 });


### PR DESCRIPTION
Fixes a CI flake in the server test suite.

## What happens

Occasionally a whole test file dies before running a single test:

```
FAIL src/__tests__/api.test.ts
Error: Cannot unlock file "/home/runner/.cache/mongodb-binaries/8.2.1.lock",
       because it is not locked by this process
  ❯ Function.download        MongoBinary.ts:52:6
  ❯ Module.setupTestDb       src/__tests__/helpers/setup.ts:35:17
```

This isn't a test failure - we are seeing a race that happens when multiple integration test suites attempt to download the MongoMemoryServer binary.

## Fix

A `globalSetup` hook resolves the binary before any suite is run, so they all can use the cached binary.

## Notes

Surfaced on #569, which adds a fourth database test file , adding more contention and amplifying the race.

Not addressed here: the workflow could also cache `~/.cache/mongodb-binaries`, which would cut the download from every run. That is a speed change rather than a correctness one, and a cold cache would still race without this fix, so it seemed worth keeping separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
