### PR TITLE
Store a createdAt date on games and users

### DIFF
--- a/packages/server/migrations/20260912000000-add-created-at.js
+++ b/packages/server/migrations/20260912000000-add-created-at.js
@@ -1,0 +1,38 @@
+module.exports = {
+  /**
+   * Store a `createdAt` date on games and users.
+   *
+   * The backfilled values are exact, not approximations: the leading four bytes
+   * of an ObjectId are a second-resolution creation timestamp, so `$toDate` on
+   * `_id` recovers when each document was really inserted. Documents created
+   * from here on carry a millisecond-resolution `new Date()` instead.
+   *
+   * Filtering on `createdAt: { $exists: false }` keeps this re-runnable if it
+   * fails partway through.
+   *
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async up(db, client) {
+    for (const name of ["games", "users"]) {
+      await db
+        .collection(name)
+        .updateMany(
+          { createdAt: { $exists: false }, _id: { $type: "objectId" } },
+          [{ $set: { createdAt: { $toDate: "$_id" } } }],
+        );
+    }
+  },
+
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async down(db, client) {
+    for (const name of ["games", "users"]) {
+      await db.collection(name).updateMany({}, { $unset: { createdAt: "" } });
+    }
+  },
+};

--- a/packages/server/src/games.ts
+++ b/packages/server/src/games.ts
@@ -44,6 +44,7 @@ export type GameSchema = {
   time_control?: ITimeControlBase;
   creator?: User;
   subscriptions?: GameSubscriptions;
+  createdAt: Date;
 };
 
 export function gamesCollection(): Collection<GameSchema> {
@@ -120,7 +121,7 @@ export async function createGame(
   // Construct a game from the config to ensure the config is valid
   const gameObj = makeGameObject(variant, config);
 
-  const game: GameSchema = {
+  const game: Omit<GameSchema, "createdAt"> = {
     variant: variant,
     moves: [] as MovesType[],
     config: config,
@@ -129,7 +130,10 @@ export async function createGame(
     creator: creator,
   };
 
-  const result = await gamesCollection().insertOne(game);
+  const result = await gamesCollection().insertOne({
+    ...game,
+    createdAt: new Date(),
+  });
 
   if (!result) {
     throw new Error("Failed to create game.");

--- a/packages/server/src/stats.ts
+++ b/packages/server/src/stats.ts
@@ -99,9 +99,15 @@ type UsersFacet = {
  * Aggregate usage numbers for the admin dashboard.
  *
  * Everything here is derived from documents we already store, so no additional
- * tracking is involved and nothing user-identifying is returned. Games and users
- * have no created-at field; `_id` is an ObjectId, whose leading four bytes are a
- * second-resolution creation timestamp, so `$toDate: "$_id"` recovers it.
+ * tracking is involved and nothing user-identifying is returned. Creation time
+ * comes out of `_id`, an ObjectId whose leading four bytes are a second-resolution
+ * insert timestamp, which `$toDate: "$_id"` recovers.
+ *
+ * TODO: games and users now store a `createdAt` date — backfilled from that same
+ * ObjectId timestamp, so the values are identical — and these pipelines should
+ * read the stored field instead. The `$addFields` stages below overwrite it with
+ * the derived value, which would hide any `createdAt` that is deliberately set to
+ * something other than the insert time.
  *
  * Note that "finished" is not among the metrics: whether a game has ended is not
  * stored, and deriving it means replaying every game's moves through its variant.

--- a/packages/server/src/users.ts
+++ b/packages/server/src/users.ts
@@ -9,6 +9,7 @@ export interface GuestUser extends UserResponse {
   token: string;
   login_type: "guest";
   ranking?: UserRankings;
+  createdAt: Date;
 }
 
 // Not currently used, but the plan is to use LocalStrategy from Password.js
@@ -19,6 +20,7 @@ export interface PersistentUser extends UserResponse {
   login_type: "persistent";
   ranking?: UserRankings;
   email?: string;
+  createdAt: Date;
 }
 
 export async function updateUserRanking(
@@ -57,6 +59,7 @@ export async function getUserByName(
     password_hash: db_user.password_hash,
     login_type: db_user.login_type,
     ranking: db_user.ranking,
+    createdAt: db_user.createdAt,
   };
 }
 
@@ -75,6 +78,7 @@ export async function getUserBySessionId(
     id: db_user._id.toString(),
     token: db_user.token,
     login_type: db_user.login_type,
+    createdAt: db_user.createdAt,
   };
 }
 
@@ -144,6 +148,7 @@ export async function createUserWithUsernameAndPassword(
     password_hash,
     login_type: "persistent",
     ranking: {},
+    createdAt: new Date(),
     ...(email && { email }),
   };
 
@@ -169,14 +174,17 @@ export async function authenticateUser(
 export async function createUserWithSessionId(
   session_id: string,
 ): Promise<GuestUser> {
+  const createdAt = new Date();
   const result = await usersCollection().insertOne({
     token: session_id,
     login_type: "guest",
+    createdAt,
   });
   return {
     id: result.insertedId.toString(),
     token: session_id,
     login_type: "guest",
+    createdAt,
   };
 }
 


### PR DESCRIPTION
This should help with certain queries.  We backfill by inferring date from the [ObjectId](https://www.mongodb.com/docs/manual/reference/method/objectid/), hence old games and users have accurate createdAt fields (at least to second resolution).

### Testing

- `yarn build`, `yarn test` (82 server + 11 client), `yarn lint:check` all pass.
- Ran the migration's `up`/`down` against a scratch local database: a game with a backdated ObjectId came back as exactly `2024-03-01T12:34:56.000Z`; a document that already had `createdAt` was left alone; a second `up` was a no-op; `down` removed the field from both collections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNcjv3SNv2FP8h9Gxeyyuq
